### PR TITLE
Change type signature of _checkbuffers and _goodbuffers

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -79,8 +79,8 @@ end
 
 size(S::SparseMatrixCSC) = (getfield(S, :m), getfield(S, :n))
 
-_goodbuffers(S::SparseMatrixCSC) = _goodbuffers(size(S)..., getcolptr(S), getrowval(S), nonzeros(S))
-_checkbuffers(S::SparseMatrixCSC) = (@assert _goodbuffers(S); S)
+_goodbuffers(S::AbstractSparseMatrixCSC) = _goodbuffers(size(S)..., getcolptr(S), getrowval(S), nonzeros(S))
+_checkbuffers(S::AbstractSparseMatrixCSC) = (@assert _goodbuffers(S); S)
 _checkbuffers(S::Union{Adjoint, Transpose}) = (_checkbuffers(parent(S)); S)
 
 function _goodbuffers(m, n, colptr, rowval, nzval)


### PR DESCRIPTION
This PR only changes 2 lines - the signatures of `_checkbuffers` and `_goodbuffers` as mentioned in the linked issue.

These methods check the assumptions on colptr, rowval and nonzeros and thus should work for all AbstractSparseMatrixCSC. Changing the signature also removes the need for every subtype to implement it, which will fix the packages broken by [JuliaLang/julia/pull/40523](https://github.com/JuliaLang/julia/pull/40523) such as [ThreadedSparseArrays.jl/issues/9](https://github.com/jagot/ThreadedSparseArrays.jl/issues/9)

Fixes #9