### PR TITLE
Fix syntax in basetests.jl

### DIFF
--- a/test/basetests.jl
+++ b/test/basetests.jl
@@ -2,6 +2,7 @@
 # these tests have been moved from other files in julia tests to
 # the SparseArrays.jl repo
 
+using Test
 using Random, LinearAlgebra, SparseArrays
 
 # From arrayops.jl

--- a/test/basetests.jl
+++ b/test/basetests.jl
@@ -12,6 +12,7 @@ using Random, LinearAlgebra, SparseArrays
         for a = ([1], UInt[1], [3, 4, 5], UInt[3, 4, 5])
             @test s === copy!(s, SparseVector(a)) == Vector(a)
         end
+    end
 end
 
 @testset "CartesianIndex" begin
@@ -46,12 +47,12 @@ end
     M = rand(n, n)
     @testset "vector of vectors" begin
         v = [[M]; [M]] # using vcat
-	@test size(v) == (2,)
+        @test size(v) == (2,)
         @test !issparse(v)
     end
     @testset "matrix of vectors" begin
         m1 = [[M] [M]] # using hcat
-	m2 = [[M] [M];] # using hvcat
+        m2 = [[M] [M];] # using hvcat
         @test m1 == m2
         @test size(m1) == (1,2)
         @test !issparse(m1)

--- a/test/testgroups
+++ b/test/testgroups
@@ -1,3 +1,4 @@
 higherorderfns
 sparse
 sparsevector
+basetests


### PR DESCRIPTION
Here's a tiny fix for some broken syntax I noticed in test/basetests.jl

By the way, do people realize that the tests in `test/basetests.jl` are not currently being included?