### PR TITLE
remove invalid test for failing sprand(BigFloat)

### DIFF
--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -2997,7 +2997,7 @@ end
 @testset "sprandn with type $T" for T in (Float64, Float32, Float16, ComplexF64, ComplexF32, ComplexF16)
     @test sprandn(T, 5, 5, 0.5) isa AbstractSparseMatrix{T}
 end
-@testset "sprandn with invalid type $T" for T in (AbstractFloat, BigFloat, Complex)
+@testset "sprandn with invalid type $T" for T in (AbstractFloat, Complex)
     @test_throws MethodError sprandn(T, 5, 5, 0.5)
 end
 


### PR DESCRIPTION
It doesn't make sense to test that `sprand(BigFloat, ...)` throws a `MethodError`, as this function will work as soon as https://github.com/JuliaLang/julia/issues/17629 is fixed.

In particular, this test is blocking https://github.com/JuliaLang/julia/pull/44714