### PR TITLE
use more type stable `cat_t` implementation

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1078,10 +1078,11 @@ const _SparseConcatGroup = Union{_DenseConcatGroup, _SparseConcatArrays, _Annota
 _makesparse(x::Number) = x
 _makesparse(x::AbstractArray) = SparseMatrixCSC(issparse(x) ? x : sparse(x))
 
-function Base._cat(dims, Xin::_SparseConcatGroup...)
+# `@constprop :aggressive` allows `dims` to be propagated as constant improving return type inference
+Base.@constprop :aggressive function Base._cat(dims, Xin::_SparseConcatGroup...)
     X = map(_makesparse, Xin)
     T = promote_eltype(Xin...)
-    Base.cat_t(T, X...; dims=dims)
+    return Base._cat_t(dims, T, X...)
 end
 function hcat(Xin::_SparseConcatGroup...)
     X = map(_makesparse, Xin)

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -561,6 +561,11 @@ end
                 @test issparse(hvcat((2,), othervecormat, spvec))
                 @test issparse(cat(spvec, othervecormat; dims=(1,2)))
                 @test issparse(cat(othervecormat, spvec; dims=(1,2)))
+
+                # inferrability (https://github.com/JuliaSparse/SparseArrays.jl/pull/92)
+                cat_with_constdims(args...) = cat(args...; dims=(1,2))
+                @test issparse(@inferred cat_with_constdims(spvec, othervecormat))
+                @test issparse(@inferred cat_with_constdims(othervecormat, spvec))
             end
             # The preceding tests should cover multi-way combinations of those types, but for good
             # measure test a few multi-way combinations involving those types
@@ -572,6 +577,11 @@ end
             @test issparse(hvcat((5,), spvec, densemat, diagmat, densevec, spmat))
             @test issparse(cat(densemat, diagmat, spmat, densevec, spvec; dims=(1,2)))
             @test issparse(cat(spvec, diagmat, densevec, spmat, densemat; dims=(1,2)))
+
+            # inferrability (https://github.com/JuliaSparse/SparseArrays.jl/pull/92)
+            cat_with_constdims(args...) = cat(args...; dims=(1,2))
+            @test issparse(@inferred cat_with_constdims(densemat, diagmat, spmat, densevec, spvec))
+            @test issparse(@inferred cat_with_constdims(spvec, diagmat, densevec, spmat, densemat))
         end
         @testset "vertical concatenation of SparseVectors with different el- and ind-type (#22225)" begin
             spv6464 = SparseVector(0, Int64[], Int64[])


### PR DESCRIPTION
After JuliaLang/julia#45028, it will be more recommended to use this
more type stable version of `cat_t`.