### PR TITLE
Remove unnecessary padding in coord-form printing of large sparse vectors

### DIFF
--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -40,8 +40,8 @@ Returns `true` if `S` is sparse, and `false` otherwise.
 ```jldoctest
 julia> sv = sparsevec([1, 4], [2.3, 2.2], 10)
 10-element SparseVector{Float64, Int64} with 2 stored entries:
-  [1 ]  =  2.3
-  [4 ]  =  2.2
+  [1]  =  2.3
+  [4]  =  2.2
 
 julia> issparse(sv)
 true

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -897,7 +897,6 @@ end
 show(io::IO, x::AbstractSparseVector) = show(convert(IOContext, io), x)
 function show(io::IOContext, x::AbstractSparseVector)
     # TODO: make this a one-line form
-    n = length(x)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
     if isempty(nzind)
@@ -905,7 +904,7 @@ function show(io::IOContext, x::AbstractSparseVector)
     end
     limit = get(io, :limit, false)::Bool
     half_screen_rows = limit ? div(displaysize(io)[1] - 8, 2) : typemax(Int)
-    pad = ndigits(n)
+    pad = ndigits(nzind[end])
     if !haskey(io, :compact)
         io = IOContext(io, :compact => true)
     end

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -1429,6 +1429,9 @@ mutable struct t20488 end
     @test String(take!(io)) == "2-element SparseArrays.SparseVector{Float64, Int64} with 0 stored entries"
     show(io, similar(sparsevec(rand(3) .+ 0.1), t20488))
     @test String(take!(io)) == "  [1]  =  #undef\n  [2]  =  #undef\n  [3]  =  #undef"
+    # Test that we don't introduce unnecessary padding for long sparse arrays
+    show(io, MIME"text/plain"(), SparseVector(div(typemax(Int32), 2), Int[1], Int[1]))
+    @test String(take!(io)) == "1073741823-element SparseArrays.SparseVector{Int64, Int64} with 1 stored entry:\n  [1]  =  1"
 end
 
 @testset "spzeros with index type" begin


### PR DESCRIPTION
Before:
```
julia> SparseVector(div(typemax(Int32), 2), Int[1], Int[1])
1073741823-element SparseVector{Int64, Int64} with 1 stored entry:
  [1         ]  =  1
```

After:
```
julia> SparseVector(div(typemax(Int32), 2), Int[1], Int[1])
1073741823-element SparseVector{Int64, Int64} with 1 stored entry:
  [1]  =  1
```

The difference here is that we look at the maximum *stored* coordinate
rather than the maximum *possible* coordinate. This will retain the
alignment benefits of printing with padding while avoiding unnecessary
padding when only the first few elements of a large sparse vector are
set.