### PR TITLE
Add support for qsymbolic to umfpack

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,9 +5,9 @@ DocTestSetup = :(using SparseArrays, LinearAlgebra)
 ```
 
 Julia has support for sparse vectors and [sparse matrices](https://en.wikipedia.org/wiki/Sparse_matrix)
-in the `SparseArrays` stdlib module. Sparse arrays are arrays that contain enough zeros
-that storing them in a special data structure leads to savings in space and execution time,
-compared to dense arrays.
+in the `SparseArrays` stdlib module. Sparse arrays are arrays that contain enough zeros that storing them in a special data structure leads to savings in space and execution time, compared to dense arrays.
+
+External packages which implement different sparse storage types, multidimensional sparse arrays, and more can be found in [Noteworthy external packages](@ref man-csc)
 
 ## [Compressed Sparse Column (CSC) Sparse Matrix Storage](@id man-csc)
 
@@ -247,3 +247,9 @@ Several other Julia packages provide sparse matrix implementations that should b
 3. [SparseMatricesCSR.jl](https://github.com/gridap/SparseMatricesCSR.jl) provides a Julia native implementation of the Compressed Sparse Rows (CSR) format.
 
 4. [MKLSparse.jl](https://github.com/JuliaSparse/MKLSparse.jl) accelerates SparseArrays sparse-dense matrix operations using Intel's MKL library.
+
+5. [SparseArrayKit.jl](https://github.com/Jutho/SparseArrayKit.jl) available for multidimensional sparse arrays.
+
+6. [LuxurySparse.jl](https://github.com/QuantumBFS/LuxurySparse.jl) provides static sparse array formats, as well as a coordinate format.
+
+7. [ExtendableSparse.jl](https://github.com/j-fu/ExtendableSparse.jl) enables fast insertion into sparse matrices using a lazy approach to new stored indices.

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -375,14 +375,14 @@ function lu!(F::UmfpackLU, S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes};
     if zerobased
         F.colptr .= getcolptr(S)
     else
-        F.colptr .= getcolptr(S) .- one(Ti)
+        F.colptr .= getcolptr(S) .- one(eltype(S))
     end
 
     resize!(F.rowval, length(rowvals(S)))
     if zerobased
         F.rowval .= rowvals(S)
     else
-        F.rowval .= rowvals(S) .- one(Ti)
+        F.rowval .= rowvals(S) .- one(eltype(S))
     end
 
     resize!(F.nzval, length(nonzeros(S)))
@@ -393,7 +393,7 @@ function lu!(F::UmfpackLU, S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes};
         F.symbolic = C_NULL
     end
 
-    umfpack_numeric!(F, reuse_numeric=false, q)
+    umfpack_numeric!(F; reuse_numeric=false, q)
 
     check && (issuccess(F) || throw(LinearAlgebra.SingularException(0)))
     return F
@@ -934,9 +934,9 @@ for Tv in (:Float64, :ComplexF64), Ti in UmfpackIndexTypes
     end
 end
 
-function umfpack_report_symbolic(lu::UmfpackLU, level::Real=4.0)
+function umfpack_report_symbolic(lu::UmfpackLU, level::Real=4.0, q=nothing)
     lock(lu) do
-        umfpack_symbolic!(lu)
+        umfpack_symbolic!(lu, q)
         old_prl::Float64 = lu.control[UMFPACK_PRL]
         lu.ctrol[UMFPACK_PRL] = Float64(level)
         @isok umfpack_dl_report_symbolic(lu.symbolic, lu.control)

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -361,7 +361,7 @@ julia> F \\ ones(2)
  1.0
 ```
 """
-function lu!(F::UmfpackLU, S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes}; 
+function lu!(F::UmfpackLU, S::SparseMatrixCSC; 
   check::Bool=true, reuse_symbolic::Bool=true, q=nothing)
     zerobased = getcolptr(S)[1] == 0
 

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -9,7 +9,6 @@ using Serialization
 using LinearAlgebra:
     I, det, issuccess, ldiv!, lu, lu!, Adjoint, Transpose, SingularException, Diagonal, logabsdet
 using SparseArrays: nnz, sparse, sprand, sprandn, SparseMatrixCSC, UMFPACK, increment!
-
 if Base.USE_GPL_LIBS
 
 for itype in UMFPACK.UmfpackIndexTypes
@@ -382,6 +381,30 @@ end
     F = lu(B; check=false)
     facstring = sprint((t, s) -> show(t, "text/plain", s), F)
     @test facstring == "Failed factorization of type $(summary(F))"
+end
+
+
+@testset "UMFPACK's lu with custom permutation" begin
+    A = sparse([1.0 0.0 0.9778920565882165 0.0 0.0 0.0 0.0 0.0 0.0 0.0;
+    0.0 1.0 0.0 0.0 0.0 1.847311282254734 0.0 0.0 0.0 0.0;
+    0.0 0.0 1.0 0.0 0.0 0.04863647201402087 0.0 0.0 0.0 -1.1593207405039443;
+    0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.0 0.0 0.5145863988424498;
+    0.0421803353935357 0.0 -1.2818900361848549 0.0 1.0 0.0 0.1116124255865398 0.0 0.0 0.0;
+    0.0 0.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 0.5457237331767308;
+    -0.4983003278517826 -0.9974658316950679 1.0734689365455168 -1.0511956770913033 0.0 -0.37409855916460416 1.999357231970987 0.0 0.0 -0.9620788056415616;
+    -1.5784683379261246 0.0 0.0 0.0 -0.4147349268116999 0.0 0.8539293641597945 1.0 0.0 0.0;
+    0.0 0.0 0.0 0.0 -0.039051958043171624 0.0 0.0 -0.3814599389272203 1.0 0.0;
+    0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0])
+    q1 = [9, 8, 5, 1, 7, 2, 3, 4, 6, 10]
+    q0 = q1 .- 1
+    for i in 1:10
+        b = randn(10)
+        x = lu(A) \ b
+        x0 = lu(A; q=q0) \ b
+        x1 = lu(A; q=q1) \ b
+        @test x ≈ x0
+        @test x ≈ x1
+    end
 end
 
 end # Base.USE_GPL_LIBS


### PR DESCRIPTION
i had two questions, 
frist do we have style? if so
```julia
function umfpack_numeric!(U::UmfpackLU{ComplexF64,$itype}; reuse_numeric = true, q = nothing)
```
or
```julia
function umfpack_numeric!(U::UmfpackLU{ComplexF64,$itype}; reuse_numeric=true, q=nothing)
```

another question is how i can test this? i don't seem to be able to call AMD.jl when i run julia with `--project`.

i get
```
ERROR: MethodError: no method matching colamd(::SparseMatrixCSC{Float64, Int64}, ::Colamd{Int64})
Closest candidates are:
  colamd(::SparseArrays.SparseMatrixCSC{F, Int64}, ::Colamd{Int64}) where F at ~/.julia/packages/AMD/aB8em/src/COLAMD.jl:81
  colamd(::Symmetric{F, SparseArrays.SparseMatrixCSC{F, Int64}}, ::Colamd{Int64}) where F at ~/.julia/packages/AMD/aB8em/src/COLAMD.jl:106
  colamd(::Hermitian{F, SparseArrays.SparseMatrixCSC{F, Int64}}, ::Colamd{Int64}) where F at ~/.julia/packages/AMD/aB8em/src/COLAMD.jl:108
Stacktrace:
 [1] top-level scope
```
when running 
```julia
using BenchmarkTools, Revise, SparseArrays, LinearAlgebra, AMD
meta = Colamd{Int}()
A = sprand(10, 10, .5)
p_amd = colamd(A, meta)
```
should close https://github.com/JuliaSparse/SparseArrays.jl/issues/116