### PR TITLE
remove solvers/lib form codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,5 @@ coverage:
     project:
       default:
         only_pulls: true # Only show the `codecov/project` commit status on pull requests.
+ignore:
+  - "src/solvers/lib/*.jl"


### PR DESCRIPTION
the code coverage has dropped drastically since suitesparse was merged. i don't think it's meaningful to calculate the code coverage on these files.