### PR TITLE
Let `length(::SparseVector{Tv,Ti})` return `Ti`

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -53,6 +53,7 @@ const AdjOrTransSparseVectorUnion{Tv,Ti} = LinearAlgebra.AdjOrTrans{Tv, <:Sparse
 
 ### Basic properties
 
+length(x::SparseVector)   = getfield(x, :n)
 size(x::SparseVector)     = (getfield(x, :n),)
 count(f, x::SparseVector) = count(f, nonzeros(x)) + f(zero(eltype(x)))*(length(x) - nnz(x))
 

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -33,9 +33,12 @@ x1_full[SparseArrays.nonzeroinds(spv_x1)] = nonzeros(spv_x1)
     @test SparseArrays.nonzeroinds(x) == [2, 5, 6]
     @test nonzeros(x) == [1.25, -0.75, 3.5]
     @test count(SparseVector(8, [2, 5, 6], [true,false,true])) == 2
-    y = SparseVector(typemax(Int128), Int128[4], [5])
+    y = SparseVector(8, Int128[4], [5])
     @test y isa SparseVector{Int,Int128}
-    @test @inferred size(y) == (@inferred(length(y)),)
+    @test @inferred size(y) == (@inferred(length(y))::Int128,)
+    y = SparseVector(8, Int8[4], [5.0])
+    @test y isa SparseVector{Float64,Int8}
+    @test @inferred size(y) == (@inferred(length(y))::Int8,)
 end
 
 @testset "isstored" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/45937.

Should be backported to v1.8.