### PR TITLE
Fix deprecated Threads.nthreads()

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -221,7 +221,11 @@ function __init__()
         ### Initiate CHOLMOD
         ### common controls the type of factorization and keeps pointers
         ### to temporary memory. We need to manage a copy for each thread.
-        nt = Threads.nthreads()
+        nt = @static if isdefined(Threads, :maxthreadid)
+            Threads.maxthreadid()
+        else
+            Threads.nthreads()
+        end
         resize!(COMMONS, nt)
         errorhandler = @cfunction(error_handler, Cvoid, (Cint, Cstring, Cint, Cstring))
         for i in 1:nt

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,14 +7,20 @@ end
 
 if Base.USE_GPL_LIBS
 
+    nt = @static if isdefined(Threads, :maxthreadid)
+        Threads.maxthreadid()
+    else
+        Threads.nthreads()
+    end
+
     # Test multithreaded execution
     @testset "threaded SuiteSparse tests" verbose = true begin
-        @testset "threads = $(Threads.nthreads())" begin
+        @testset "threads = $(nt)" begin
             include("threads.jl")
         end
         # test both nthreads==1 and nthreads>1. spawn a process to test whichever
         # case we are not running currently.
-        other_nthreads = Threads.nthreads() == 1 ? 4 : 1
+        other_nthreads = nt == 1 ? 4 : 1
         @testset "threads = $other_nthreads" begin
             let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
                 p = run(


### PR DESCRIPTION
`Threads.nthreads()` is going to be deprecated in https://github.com/JuliaLang/julia/pull/45447

This needs to be fixed before https://github.com/JuliaLang/julia/pull/45447 merges because Base tests run with `--depwarn=error` https://github.com/JuliaLang/julia/blob/df846436bb91b291be988f5e18e256d514b97347/test/testenv.jl#L19