### PR TITLE
Remove Thread-local storage from CHOLMOD and SPQR

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -152,7 +152,7 @@ macro cholmod_param(kwarg, code)
 end
 
 function getcommon()
-    if :cholmod_common ∉ keys(task_local_storage()) # havent yet started cholmod on this task
+    if !haskey(task_local_storage(), :cholmod_common) # havent yet started cholmod on this task
         common = finalizer(cholmod_l_finish, Ref(cholmod_common()))
         result = cholmod_l_start(common)
         @assert result == TRUE "failed to run `cholmod_l_start`!"

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -66,7 +66,7 @@ function _qr!(ordering::Integer, tol::Real, econ::Integer, getCTX::Integer,
         H,              # m-by-nh Householder vectors
         HPinv,          # size m row permutation
         HTau,           # 1-by-nh Householder coefficients
-        CHOLMOD.COMMONS[Threads.threadid()]) # /* workspace and parameters */
+        CHOLMOD.getcommon()) # /* workspace and parameters */
 
     if rnk < 0
         error("Sparse QR factorization failed")
@@ -83,7 +83,7 @@ function _qr!(ordering::Integer, tol::Real, econ::Integer, getCTX::Integer,
         # Free memory allocated by SPQR. This call will make sure that the
         # correct deallocator function is called and that the memory count in
         # the common struct is updated
-        cholmod_l_free(n, sizeof(CHOLMOD.SuiteSparse_long), e, CHOLMOD.COMMONS[Threads.threadid()])
+        cholmod_l_free(n, sizeof(CHOLMOD.SuiteSparse_long), e, CHOLMOD.getcommon())
     end
     hpinv = HPinv[]
     if hpinv == C_NULL
@@ -96,7 +96,7 @@ function _qr!(ordering::Integer, tol::Real, econ::Integer, getCTX::Integer,
         # Free memory allocated by SPQR. This call will make sure that the
         # correct deallocator function is called and that the memory count in
         # the common struct is updated
-        cholmod_l_free(m, sizeof(CHOLMOD.SuiteSparse_long), hpinv, CHOLMOD.COMMONS[Threads.threadid()])
+        cholmod_l_free(m, sizeof(CHOLMOD.SuiteSparse_long), hpinv, CHOLMOD.getcommon())
     end
 
     return rnk, _E, _HPinv

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -245,35 +245,35 @@ end
 
 ## The struct pointer must be constructed by the library constructor and then modified afterwards to checks that the method throws
 @testset "illegal dtype (for now but should be supported at some point)" begin
-    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.COMMONS[Threads.threadid()])
+    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.getcommon())
     puint = convert(Ptr{UInt32}, p)
     unsafe_store!(puint, CHOLMOD_SINGLE, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Cvoid}), 4) + 4)
     @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
 end
 
 @testset "illegal dtype" begin
-    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.COMMONS[Threads.threadid()])
+    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.getcommon())
     puint = convert(Ptr{UInt32}, p)
     unsafe_store!(puint, 5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Cvoid}), 4) + 4)
     @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
 end
 
 @testset "illegal xtype" begin
-    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.COMMONS[Threads.threadid()])
+    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.getcommon())
     puint = convert(Ptr{UInt32}, p)
     unsafe_store!(puint, 3, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Cvoid}), 4) + 3)
     @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
 end
 
 @testset "illegal itype I" begin
-    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.COMMONS[Threads.threadid()])
+    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.getcommon())
     puint = convert(Ptr{UInt32}, p)
     unsafe_store!(puint, CHOLMOD_INTLONG, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Cvoid}), 4) + 2)
     @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
 end
 
 @testset "illegal itype II" begin
-    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.COMMONS[Threads.threadid()])
+    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.getcommon())
     puint = convert(Ptr{UInt32}, p)
     unsafe_store!(puint,  5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Cvoid}), 4) + 2)
     @test_throws CHOLMOD.CHOLMODException CHOLMOD.Sparse(p)
@@ -322,7 +322,7 @@ end
 
 # Test Sparse and Factor
 @testset "test free!" begin
-    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.COMMONS[Threads.threadid()])
+    p = cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD_REAL, CHOLMOD.getcommon())
     @test CHOLMOD.free!(p)
 end
 
@@ -912,7 +912,7 @@ end
 
 @testset "Check common is still in default state" begin
     # This test intentially depends on all the above tests!
-    current_common = CHOLMOD.COMMONS[Threads.threadid()]
+    current_common = CHOLMOD.getcommon()
     default_common = Ref(cholmod_common())
     result = cholmod_l_start(default_common)
     @test result == CHOLMOD.TRUE

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,14 +7,20 @@ end
 
 if Base.USE_GPL_LIBS
 
+    nt = @static if isdefined(Threads, :maxthreadid)
+        Threads.maxthreadid()
+    else
+        Threads.nthreads()
+    end
+
     # Test multithreaded execution
     @testset "threaded SuiteSparse tests" verbose = true begin
-        @testset "threads = $(Threads.nthreads())" begin
+        @testset "threads = $nt" begin
             include("threads.jl")
         end
         # test both nthreads==1 and nthreads>1. spawn a process to test whichever
         # case we are not running currently.
-        other_nthreads = Threads.nthreads() == 1 ? 4 : 1
+        other_nthreads = nt == 1 ? 4 : 1
         @testset "threads = $other_nthreads" begin
             let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
                 p = run(


### PR DESCRIPTION
See https://github.com/JuliaSparse/SparseArrays.jl/pull/204

This PR takes the path of least resistance and just uses `task_local_storage`. The part that most needs review is the addition of a call to `cholmod_l_finish`. This is attached to the `cholmod_common` object which is lazily created in each task (which uses CHOLMOD). 

I *think* this is correct, but I'm not 100% certain on the lifetime of `task_local_storage`. 