### PR TITLE
Enable julia stable in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.8-'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          # - '1.6'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8-'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
Let's try to make sure we can keep this package going on Julia stable, and maybe even Julia 1.6.

@dkarrasch I believe the `Base.extremamap` is Julia 1.8 only (I believe it should have been added through your recent PR).  If possible, it would be nice to make the package in its current shape work on Julia 1.7, but if not, we can make 1.8 the minimum required going forward, but be more conservative going forward about using features in new Julia versions.

My purpose here is to just be a bit more deliberate.