### PR TITLE
Add documentation for similar of sparse matrices

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -212,6 +212,7 @@ SparseArrays.SparseVector
 SparseArrays.SparseMatrixCSC
 SparseArrays.sparse
 SparseArrays.sparsevec
+SparseArrays.similar
 SparseArrays.issparse
 SparseArrays.nnz
 SparseArrays.findnz

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -212,7 +212,7 @@ SparseArrays.SparseVector
 SparseArrays.SparseMatrixCSC
 SparseArrays.sparse
 SparseArrays.sparsevec
-SparseArrays.similar
+Base.similar
 SparseArrays.issparse
 SparseArrays.nnz
 SparseArrays.findnz

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -202,7 +202,7 @@ section of the standard library reference.
 | [`sprandn(m,n,d)`](@ref)   | [`randn(m,n)`](@ref)   | Creates a *m*-by-*n* random matrix (of density *d*) with iid non-zero elements distributed according to the standard normal (Gaussian) distribution.                  |
 | [`sprandn(rng,m,n,d)`](@ref) | [`randn(rng,m,n)`](@ref) | Creates a *m*-by-*n* random matrix (of density *d*) with iid non-zero elements generated with the `rng` random number generator                                   |
 
-# [Sparse Arrays](@id stdlib-sparse-arrays)
+# [SparseArrays API](@id stdlib-sparse-arrays)
 
 ```@docs
 SparseArrays.AbstractSparseArray

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -579,8 +579,6 @@ output matrix are different from the output.
 
 The output matrix has zeros in the same locations as the input, but
 unititialized values for the nonzero locations.
-
-# Examples
 """
 similar(S::AbstractSparseMatrixCSC, ::Type{TvNew}, ::Type{TiNew}) where{TvNew,TiNew} =
     _sparsesimilar(S, TvNew, TiNew)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -561,13 +561,7 @@ _sparsesimilar(S::AbstractSparseMatrixCSC, ::Type{TvNew}, ::Type{TiNew}, dims::D
 # covers similar(A[, Tv]) calls, which preserve stored-entry structure, and the latter
 # methods cover similar(A[, Tv], shape...) calls, which partially preserve
 # storage space when the shape calls for a two-dimensional result.
-similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}) where {Ti,TvNew} = _sparsesimilar(S, TvNew, Ti)
-similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}, dims::Union{Dims{1},Dims{2}}) where {Ti,TvNew} =
-    _sparsesimilar(S, TvNew, Ti, dims)
-# The following methods cover similar(A, Tv, Ti[, shape...]) calls, which specify the
-# result's index type in addition to its entry type, and aren't covered by the hooks above.
-# The calls without shape again preserve stored-entry structure, whereas those with shape
-# preserve storage space when the shape calls for a two-dimensional result.
+
 """
     similar(A::AbstractSparseMatrixCSC{Tv,Ti}, [::Type{TvNew}, ::Type{TiNew}, m::Integer, n::Integer]) where {Tv,Ti}
 
@@ -580,6 +574,13 @@ output matrix are different from the output.
 The output matrix has zeros in the same locations as the input, but
 unititialized values for the nonzero locations.
 """
+similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}) where {Ti,TvNew} = _sparsesimilar(S, TvNew, Ti)
+similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}, dims::Union{Dims{1},Dims{2}}) where {Ti,TvNew} =
+    _sparsesimilar(S, TvNew, Ti, dims)
+# The following methods cover similar(A, Tv, Ti[, shape...]) calls, which specify the
+# result's index type in addition to its entry type, and aren't covered by the hooks above.
+# The calls without shape again preserve stored-entry structure, whereas those with shape
+# preserve storage space when the shape calls for a two-dimensional result.
 similar(S::AbstractSparseMatrixCSC, ::Type{TvNew}, ::Type{TiNew}) where{TvNew,TiNew} =
     _sparsesimilar(S, TvNew, TiNew)
 similar(S::AbstractSparseMatrixCSC, ::Type{TvNew}, ::Type{TiNew}, dims::Union{Dims{1},Dims{2}}) where {TvNew,TiNew} =

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -568,6 +568,20 @@ similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}, dims::Union{Dims{1}
 # result's index type in addition to its entry type, and aren't covered by the hooks above.
 # The calls without shape again preserve stored-entry structure, whereas those with shape
 # preserve storage space when the shape calls for a two-dimensional result.
+"""
+    similar(A::AbstractSparseMatrixCSC{Tv,Ti}, [::Type{TvNew}, ::Type{TiNew}, m::Integer, n::Integer]) where {Tv,Ti}
+
+Create an uninitialized mutable array with the given element type,
+index type, and size, based upon the given source
+`SparseMatrixCSC`. The new sparse matrix maintains the structure of
+the original sparse matrix, except in the case where dimensions of the
+output matrix are different from the output.
+
+The output matrix has zeros in the same locations as the input, but
+unititialized values for the nonzero locations.
+
+# Examples
+"""
 similar(S::AbstractSparseMatrixCSC, ::Type{TvNew}, ::Type{TiNew}) where{TvNew,TiNew} =
     _sparsesimilar(S, TvNew, TiNew)
 similar(S::AbstractSparseMatrixCSC, ::Type{TvNew}, ::Type{TiNew}, dims::Union{Dims{1},Dims{2}}) where {TvNew,TiNew} =

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -365,7 +365,7 @@ end
             x = getfield(F1.workspace, nm)
             x .= rand(eltype(x), length(x))
         end
-        
+
         umfpack_report(F1)
         b  = IOBuffer()
         serialize(b, F1)


### PR DESCRIPTION
`similar` does slightly different things for sparse matrices. Document that. Fix #14 

I'm not sure if this is the right way to add these docs. Would appreciate a review from someone more knowledgable.