### PR TITLE
Don't serialize pointers and workspace, add `lu!(F::UmfpackLU)`

### DIFF
--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -241,19 +241,19 @@ doing so may lead to race-conditions.
 """
 # Not using simlar helps if the actual needed size has changed as it would need to be resized again
 Base.copy(F::UmfpackLU, ws=UmfpackWS(F)) = 
-    finalizer(umfpack_free_symbolic_nl,
     UmfpackLU(
-    F.symbolic,
-    F.numeric,
-    F.m, F.n,
-    F.colptr,
-    F.rowval,
-    F.nzval,
-    F.status,
-    ws,
-    copy(F.control),
-    copy(F.info),
-    ReentrantLock()))
+        F.symbolic,
+        F.numeric,
+        F.m, F.n,
+        F.colptr,
+        F.rowval,
+        F.nzval,
+        F.status,
+        ws,
+        copy(F.control),
+        copy(F.info),
+        ReentrantLock()
+    )
 Base.copy(F::T, ws=UmfpackWS(F)) where {T <: ATLU} = 
     T(copy(parent(F), ws))
 

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -167,7 +167,30 @@ function show_umf_info(control::Vector{Float64}, info::Vector{Float64}, level::R
 end
 
 
+mutable struct Numeric{Tv,Ti}
+    p::Ptr{Cvoid}
+    function Numeric{Tv, Ti}(p) where {Tv<:UMFVTypes, Ti<:UMFITypes}
+        return finalizer(new{Tv, Ti}(p)) do num
+            umfpack_free_numeric(num, Tv, Ti)
+            num.p = C_NULL
+        end
+    end
+end
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, num::Numeric) = num.p
 
+mutable struct Symbolic{Tv, Ti}
+    p::Ptr{Cvoid}
+    function Symbolic{Tv, Ti}(p) where {Tv<:UMFVTypes, Ti<:UMFITypes}
+        return finalizer(new{Tv, Ti}(p)) do sym
+            umfpack_free_symbolic(sym, Tv, Ti)
+            sym.p = C_NULL
+        end
+    end
+end
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, num::Symbolic) = num.p
+
+_isnull(x::Union{Symbolic, Numeric}) = x.p == C_NULL
+_isnotnull(x::Union{Symbolic, Numeric}) = x.p != C_NULL
 """
 Working space for Umfpack so `ldiv!` doesn't allocate.
 
@@ -198,8 +221,8 @@ Base.similar(w::UmfpackWS) = UmfpackWS(similar(w.Wi), similar(w.W))
 
 ## Should this type be immutable?
 mutable struct UmfpackLU{Tv<:UMFVTypes,Ti<:UMFITypes} <: Factorization{Tv}
-    symbolic::Ptr{Cvoid}
-    numeric::Ptr{Cvoid}
+    symbolic::Symbolic{Tv, Ti}
+    numeric::Numeric{Tv, Ti}
     m::Int
     n::Int
     colptr::Vector{Ti}                  # 0-based column pointers
@@ -257,11 +280,10 @@ Base.copy(F::UmfpackLU, ws=UmfpackWS(F)) =
 Base.copy(F::T, ws=UmfpackWS(F)) where {T <: ATLU} = 
     T(copy(parent(F), ws))
 
-Base.deepcopy(F::UmfpackLU, ws=UmfpackWS(F)) = 
-    finalizer(umfpack_free_symbolic_nl,
+Base.deepcopy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F)) where {Tv, Ti} = 
     UmfpackLU(
-    C_NULL, # TODO: switch to a copy when upstream is available
-    C_NULL, # TODO: switch to a copy when upstream is available
+    Symbolic{Tv, Ti}(C_NULL), # TODO: switch to a copy when upstream is available
+    Numeric{Tv, Ti}(C_NULL), # TODO: switch to a copy when upstream is available
     F.m, F.n,
     F.colptr,
     F.rowval,
@@ -270,9 +292,9 @@ Base.deepcopy(F::UmfpackLU, ws=UmfpackWS(F)) =
     ws,
     copy(F.control),
     copy(F.info),
-    ReentrantLock()))
+    ReentrantLock())
 Base.deepcopy(F::T, ws=UmfpackWS(F)) where {T <: ATLU} = 
-    T(deepcopy(F.parent, ws; copypointers))
+    T(deepcopy(parent(F), ws; copypointers))
 
 Base.adjoint(F::UmfpackLU) = Adjoint(F)
 Base.transpose(F::UmfpackLU) = Transpose(F)
@@ -360,14 +382,14 @@ function lu(S::AbstractSparseMatrixCSC{Tv, Ti};
     {Tv<:UMFVTypes,Ti<:UMFITypes}
 
     zerobased = getcolptr(S)[1] == 0
-    res = finalizer(umfpack_free_symbolic_nl, 
-            UmfpackLU(C_NULL, C_NULL, size(S, 1), size(S, 2),
+    res = UmfpackLU(Symbolic{Tv, Ti}(C_NULL), Numeric{Tv, Ti}(C_NULL), 
+                    size(S, 1), size(S, 2),
                     zerobased ? copy(getcolptr(S)) : decrement(getcolptr(S)),
                     zerobased ? copy(rowvals(S)) : decrement(rowvals(S)),
                     copy(nonzeros(S)), 0, UmfpackWS(S, has_refinement(control)),
-                    copy(control),
-                    Vector{Float64}(undef, UMFPACK_INFO),
-                    ReentrantLock()))
+                    copy(control), Vector{Float64}(undef, UMFPACK_INFO),
+                    ReentrantLock()
+    )
     umfpack_numeric!(res; q)
     check && (issuccess(res) || throw(LinearAlgebra.SingularException(0)))
     return res
@@ -435,8 +457,8 @@ julia> F \\ ones(2)
  1.0
 ```
 """
-function lu!(F::UmfpackLU, S::AbstractSparseMatrixCSC;
-  check::Bool=true, reuse_symbolic::Bool=true, q=nothing)
+function lu!(F::UmfpackLU{Tv, Ti}, S::AbstractSparseMatrixCSC;
+  check::Bool=true, reuse_symbolic::Bool=true, q=nothing) where {Tv, Ti}
     zerobased = getcolptr(S)[1] == 0
 
     F.m = size(S, 1)
@@ -462,9 +484,8 @@ function lu!(F::UmfpackLU, S::AbstractSparseMatrixCSC;
     resize!(F.nzval, length(nonzeros(S)))
     F.nzval .= nonzeros(S)
 
-    if !reuse_symbolic && F.symbolic != C_NULL
-        umfpack_free_symbolic(F)
-        F.symbolic = C_NULL
+    if !reuse_symbolic && _isnotnull(F.symbolic)
+        F.symbolic = Symbolic{Tv, Ti}(C_NULL)
     end
 
     umfpack_numeric!(F; reuse_numeric=false, q)
@@ -493,7 +514,7 @@ function size(F::UmfpackLU, dim::Integer)
 end
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, F::UmfpackLU)
-    if F.numeric != C_NULL
+    if _isnotnull(F.numeric)
         if issuccess(F)
             summary(io, F); println(io)
             println(io, "L factor:")
@@ -532,11 +553,9 @@ function deserialize(s::AbstractSerializer, ::Type{UmfpackLU{Tv,Ti}}) where {Tv,
     Wsize    = deserialize(s)
     control  = deserialize(s)
     info     = deserialize(s)
-    return finalizer(
-        umfpack_free_symbolic_nl,
-        UmfpackLU{Tv,Ti}(C_NULL, C_NULL, m, n,
-        colptr, rowval, nzval, 0,
-        UmfpackWS{Ti}(Wisize, Wsize), control, info, ReentrantLock()))
+    return UmfpackLU{Tv,Ti}(Symbolic{Tv, Ti}(C_NULL), Numeric{Tv, Ti}(C_NULL), 
+        m, n, colptr, rowval, nzval, 0,
+        UmfpackWS{Ti}(Wisize, Wsize), control, info, ReentrantLock())
 end
 
 # compute the sign/parity of a permutation
@@ -583,8 +602,7 @@ for itype in UmfpackIndexTypes
     get_num_z = Symbol(umf_nm("get_numeric", :ComplexF64, itype))
     @eval begin
         function umfpack_symbolic!(U::UmfpackLU{Float64,$itype}, q::Union{Nothing, StridedVector{$itype}})
-            U.symbolic != C_NULL && return U
-
+            _isnotnull(U.symbolic) && return U
             @lock U begin
                 tmp = Ref{Ptr{Cvoid}}(C_NULL)
                 if q === nothing
@@ -593,12 +611,16 @@ for itype in UmfpackIndexTypes
                     qq = minimum(q) == 1 ? q .- one(eltype(q)) : q
                     @isok $symq_r(U.m, U.n, U.colptr, U.rowval, U.nzval, qq, tmp, U.control, U.info)
                 end
-                U.symbolic = tmp[]
+                if _isnull(U.symbolic)
+                    U.symbolic.p = tmp[]
+                else
+                    U.symbolic = Symbolic{Float64, $itype}(tmp[])
+                end
             end
             return U
         end
         function umfpack_symbolic!(U::UmfpackLU{ComplexF64,$itype}, q::Union{Nothing, StridedVector{$itype}})
-            U.symbolic != C_NULL && return U
+            _isnotnull(U.symbolic) && return U
             @lock U begin
                 tmp = Ref{Ptr{Cvoid}}(C_NULL)
                 if q === nothing
@@ -608,37 +630,38 @@ for itype in UmfpackIndexTypes
                     qq = minimum(q) == 1 ? q .- one(eltype(q)) : q
                     @isok $symq_c(U.m, U.n, U.colptr, U.rowval, real(U.nzval), imag(U.nzval), qq, tmp, U.control, U.info)
                 end
-                U.symbolic = tmp[]
+                if _isnull(U.symbolic)
+                    U.symbolic.p = tmp[]
+                else
+                    U.symbolic = Symbolic{ComplexF64, $itype}(tmp[])
+                end
             end
             return U
         end
         function umfpack_numeric!(U::UmfpackLU{Float64,$itype}; reuse_numeric=true, q=nothing)
             @lock U begin
-                if (reuse_numeric && U.numeric != C_NULL)
-                    return U
-                end
-                if U.symbolic == C_NULL
+                (reuse_numeric && _isnotnull(U.numeric)) && return U
+                if _isnull(U.symbolic)
                     umfpack_symbolic!(U, q)
                 end
-
-
                 tmp = Ref{Ptr{Cvoid}}(C_NULL)
                 status = $num_r(U.colptr, U.rowval, U.nzval, U.symbolic, tmp, U.control, U.info)
                 U.status = status
                 if status != UMFPACK_WARNING_singular_matrix
                     umferror(status)
                 end
-                U.numeric != C_NULL && umfpack_free_numeric(U)
-                U.numeric = tmp[]
+                if _isnull(U.numeric)
+                    U.numeric.p = tmp[]
+                else
+                    U.numeric = Numeric{Float64, $itype}(tmp[])
+                end
             end
             return U
         end
         function umfpack_numeric!(U::UmfpackLU{ComplexF64,$itype}; reuse_numeric=true, q=nothing)
             @lock U begin
-                if (reuse_numeric && U.numeric != C_NULL) return U end
-                if U.symbolic == C_NULL umfpack_symbolic!(U, q) end
-
-
+                (reuse_numeric && _isnotnull(U.numeric)) && return U
+                _isnull(U.symbolic) && umfpack_symbolic!(U, q)
                 tmp = Ref{Ptr{Cvoid}}(C_NULL)
                 status = $num_c(U.colptr, U.rowval, real(U.nzval), imag(U.nzval), U.symbolic, tmp,
                     U.control, U.info)
@@ -646,8 +669,7 @@ for itype in UmfpackIndexTypes
                 if status != UMFPACK_WARNING_singular_matrix
                     umferror(status)
                 end
-                U.numeric != C_NULL && umfpack_free_numeric(U)
-                U.numeric = tmp[]
+                U.numeric.p = tmp[]
             end
             return U
         end
@@ -1010,21 +1032,18 @@ end
 for Tv in (:Float64, :ComplexF64), Ti in UmfpackIndexTypes
     # no lock version for the finalizer
     _free_symbolic = Symbol(umf_nm("free_symbolic", Tv, Ti))
-    @eval function umfpack_free_symbolic_nl(lu::UmfpackLU{$Tv,$Ti})
-        if lu.symbolic != C_NULL
-            umfpack_free_numeric_nl(lu)
-            $_free_symbolic(Ref(lu.symbolic))
-            lu.symbolic = C_NULL
+    @eval function umfpack_free_symbolic(symbolic::Symbolic, ::Type{$Tv}, ::Type{$Ti})
+        if _isnotnull(symbolic)
+            r = Ref(symbolic.p)
+            $_free_symbolic(r)
         end
-        return lu
     end
     _free_numeric = Symbol(umf_nm("free_numeric", Tv, Ti))
-    @eval function umfpack_free_numeric_nl(lu::UmfpackLU{$Tv,$Ti})
-        if lu.numeric != C_NULL
-            $_free_numeric(Ref(lu.numeric))
-            lu.numeric = C_NULL
+    @eval function umfpack_free_numeric(numeric::Numeric, ::Type{$Tv}, ::Type{$Ti})
+        if _isnotnull(numeric)
+            r = Ref(numeric.p)
+            $_free_numeric(r)
         end
-        return lu
     end
 
     _report_symbolic = Symbol(umf_nm("report_symbolic", Tv, Ti))
@@ -1059,15 +1078,4 @@ for Tv in (:Float64, :ComplexF64), Ti in UmfpackIndexTypes
         return control
     end
 end
-
-umfpack_free_numeric(lu::UmfpackLU) =
-@lock lu begin
-    umfpack_free_numeric_nl(lu)
-    lu
-end
-umfpack_free_symbolic(lu::UmfpackLU) =
-@lock lu begin
-    umfpack_free_symblic_nl(lu)
-end
-
 end # UMFPACK module

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -294,7 +294,7 @@ Base.deepcopy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F)) where {Tv, Ti} =
     copy(F.info),
     ReentrantLock())
 Base.deepcopy(F::T, ws=UmfpackWS(F)) where {T <: ATLU} = 
-    T(deepcopy(parent(F), ws; copypointers))
+    T(deepcopy(parent(F), ws))
 
 Base.adjoint(F::UmfpackLU) = Adjoint(F)
 Base.transpose(F::UmfpackLU) = Transpose(F)

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -146,9 +146,17 @@ end
         Af = lu(A0)
         umfpack_report(Af)
         test_ws_dup(Af, copy(Af))
-        test_ws_dup(Af, copy(transpose(Af)).parent)
-        test_ws_dup(Af, copy(adjoint(Af)).parent)
+        test_ws_dup(Af, copy(parent(transpose(Af))))
+        test_ws_dup(Af, copy(parent(adjoint(Af))))
         umfpack_report(Af)
+
+        Afcopy = copy(Af)
+        @test Afcopy.numeric === Af.numeric
+        @test Afcopy.symbolic === Af.symbolic
+
+        Afcopy = deepcopy(Af)
+        @test Afcopy.numeric !== Af.numeric
+        @test Afcopy.symbolic !== Af.symbolic
     end
 end
 
@@ -429,7 +437,6 @@ end
             end
         end
     end
-
 end
 
 @testset "REPL printing of UmfpackLU" begin

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -114,7 +114,7 @@ end
             @test i == x
         end
         umfpack_report(Af)
-        Af1 = copy(Af)
+        Af1 = lu!(copy(Af))
         umfpack_report(Af1)
         @test trylock(Af)
         @test trylock(Af1)
@@ -132,7 +132,7 @@ end
         umfpack_report(Af)
     end
     function test_ws_dup(Af, Af1)
-        for i in [:symbolic, :numeric, :colptr, :rowval, :nzval]
+        for i in [:colptr, :rowval, :nzval]
             @test getproperty(Af, i) === getproperty(Af1, i)
         end
         for i in [:n, :m]
@@ -375,18 +375,20 @@ end
             @test getfield(F1, nm) == getfield(F2, nm)
         end
         for nm in (:W, :Wi)
-            @test getfield(F1.workspace, nm) == getfield(F2.workspace, nm)
+            @test size(getfield(F1.workspace, nm)) == size(getfield(F2.workspace, nm))
         end
         b1 = IOBuffer()
         serialize(b1, (a=F1, b=F2))
         seekstart(b1)
         x = deserialize(b1)
+        lu!(x.a)
+        lu!(x.b)
         for nm in (:colptr, :m, :n, :nzval, :rowval, :status)
             @test getfield(F1, nm) == getfield(x.a, nm) == getfield(x.b, nm)
         end
         for nm in (:W, :Wi)
-            @test getfield(x.a.workspace, nm) == getfield(F1.workspace, nm)
-            @test getfield(x.b.workspace, nm) == getfield(F2.workspace, nm)
+            @test size(getfield(x.a.workspace, nm)) == size(getfield(F1.workspace, nm))
+            @test size(getfield(x.b.workspace, nm)) == size(getfield(F2.workspace, nm))
         end
 
         umfpack_report(F1)


### PR DESCRIPTION
Per @Keno we want to avoid serializing uninitialized memory, and the workspace is not information required to reconstruct a factorization. We came to the decision that this was within the semantics of `serialize`/`deserialize`, and that aliased workspaces after deserialization was a dangerous property.

On master we serialize pointers, which will only work while that pointer remains alive (and could easily segfault). There is no way to serialize the symbolic and numeric factorizations via arbitrary IO.

There are `umfpack_{load | save}_{numeric | symbolic}` functions in UMFPACK, but they take a file path. It would be ideal to add this capability to save the factorization itself, not just the info to reconstruct it, but I recall dealing with FILE handles for SuiteSparseGraphBLAS.jl was very annoying. I will talk to Tim this Friday to see if we can add similar functions that return byte arrays. If not we may do some tempfile reading and writing.

There is a similar pointer issue with the `copy` code. The `numeric` and `symbolic` pointers are both writeable by UMFPACK. We need to find a method to do deepcopies for those (potentially using `save` and `load`, but that may not be performant). In the meantime I tried to split the difference, users may pass `copypointers=true` to `copy` if, for instance, the factorization step is finished and they would like to parallelize the solves.

Finally, in order to support the unfinished objects generated by `copy` and `deserialize` a new `lu!` method was added which will reconstruct the factorization after a copy or deserialization.

Note: this PR needs some additional tests and more comments documenting the decisions made here.