### PR TITLE
Add a sparse `ev_view` for `SymTridiagonal` backed by sparse arrays

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -80,4 +80,12 @@ zero(a::AbstractSparseArray) = spzeros(eltype(a), size(a)...)
 LinearAlgebra.diagzero(D::Diagonal{<:AbstractSparseMatrix{T}},i,j) where {T} =
     spzeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
 
+# A fix for #46355
+# Adding two views of sparse arrays results in a dense array. `_eview is used
+# by LinearAlgebra to make sure that only the real off-diagonal entries of a
+# SymTridiagonal matrix are accessed operating on such matrices. We usually use
+# a view to avoid copying the off-diagonal when slicing it, but for sparse arrays
+# we will just do the normal slice for now.
+# See also: #42472
+LinearAlgebra._evview(S::SymTridiagonal{T, V}) where {T, V <: AbstractSparseArray{T}} = S.ev[begin:length(S.dv) - 1]
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -693,6 +693,19 @@ end
     end
 end
 
+@testset "Adding sparse-backed SymTridiagonal (#46355)" begin
+    a = SymTridiagonal(sparsevec(Int[1]), sparsevec(Int[]))
+    @test a + a == Matrix(a) + Matrix(a)
+
+    # symtridiagonal with non-empty off-diagonal
+    b = SymTridiagonal(sparsevec(Int[1, 2, 3]), sparsevec(Int[1, 2]))
+    @test b + b == Matrix(b) + Matrix(b)
+
+    # a symtridiagonal with an additional off-diagonal element
+    c = SymTridiagonal(sparsevec(Int[1, 2, 3]), sparsevec(Int[1, 2, 3]))
+    @test c + c == Matrix(c) + Matrix(c)
+end
+
 @testset "kronecker product" begin
     for (m,n) in ((5,10), (13,8), (14,10))
         a = sprand(m, 5, 0.4); a_d = Matrix(a)


### PR DESCRIPTION
This is a fix for https://github.com/JuliaLang/julia/issues/46355, where `SymTridiagonal` matrices backed by sparse arrays couldn't be summed/subtracted/etc. The root cause is that adding `@view`s of SparseArrays produces a dense array.

https://github.com/JuliaLang/julia/blob/ec98087cbf19bac26f6be05df9282746b0cffe78/stdlib/LinearAlgebra/src/tridiag.jl#L207

https://github.com/JuliaLang/julia/blob/ec98087cbf19bac26f6be05df9282746b0cffe78/stdlib/LinearAlgebra/src/LinearAlgebra.jl#L449-L453

```julia
julia> z = @view sparse([1, 2, 3])[1:3]
3-element view(::SparseVector{Int64, Int64}, 1:3) with eltype Int64:
 1
 2
 3

julia> z + z
3-element Vector{Int64}:
 2
 4
 6
```

This `view` usage was added in https://github.com/JuliaLang/julia/pull/42472 to deal with an implementation detail of  `SymTridiagonal`s where the off-diagonal has an additional element that should usually be ignored. A view was used to access only the actual elements of the off-diagonal without copying. This PR makes it so that sparse arrays just use a regular (copying) slice, until a better fix is found (I am not sure if there has been any discussion about the sparse `@view` sum thing).