### PR TITLE
decrement should always return a vector

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -49,7 +49,12 @@ function decrement!(A::AbstractArray{T}) where T<:Integer
     for i in eachindex(A); A[i] -= oneunit(T) end
     A
 end
-decrement(A::AbstractArray{<:Integer}) = decrement!(copy(A))
+decrement(A::AbstractVector{T}) where T<:Integer = let x = Vector{T}(undef, length(A))
+    for (i, j) in zip(eachindex(A), eachindex(x))
+        x[j] = A[i] - oneunit(T)
+    end
+    x
+end
 
 
 include("readonly.jl")

--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -49,8 +49,9 @@ function decrement!(A::AbstractArray{T}) where T<:Integer
     for i in eachindex(A); A[i] -= oneunit(T) end
     A
 end
-decrement(A::AbstractVector) = decrement!(Vector(A))
-
+decrement(A::AbstractArray) = let y = Array(A)
+    y .= y .- oneunit(eltype(A))
+end
 
 include("readonly.jl")
 include("abstractsparse.jl")

--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -49,12 +49,7 @@ function decrement!(A::AbstractArray{T}) where T<:Integer
     for i in eachindex(A); A[i] -= oneunit(T) end
     A
 end
-decrement(A::AbstractVector{T}) where T<:Integer = let x = Vector{T}(undef, length(A))
-    for (i, j) in zip(eachindex(A), eachindex(x))
-        x[j] = A[i] - oneunit(T)
-    end
-    x
-end
+decrement(A::AbstractVector) = decrement!(Vector(A))
 
 
 include("readonly.jl")

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -37,5 +37,3 @@ Base.copy(x::ReadOnly) = ReadOnly(copy(parent(x)))
 (==)(x::ReadOnly, y::ReadOnly) = parent(x) == parent(y)
 
 Base.dataids(::ReadOnly) = tuple()
-# Convert from 1-based to 0-based indices
-decrement(A::ReadOnly) = decrement!(copy(parent(A)))


### PR DESCRIPTION
we only use it when it returns a vector, so  i think it's good idea for AbstractMatrixCSCs that don't use Vectors (like Fixed)