### PR TITLE
Run Julia v1.8 on the `release-1.8` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          # - '1.6'
-          - 'nightly'
+          - '1.8'
+          # - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -63,8 +63,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          # version: '1.6'
-          version: 'nightly'
+          version: '1.8'
+          # version: 'nightly'
       - name: Generate docs
         run: |
           julia --color=yes -e 'write("Project.toml", replace(read("Project.toml", String), r"uuid = .*?\n" =>"uuid = \"3f01184e-e22b-5df5-ae63-d93ebab69eaf\"\n"));'


### PR DESCRIPTION
I think this is only consistent with what this branch is good for: make sure Julia v1.8 is working.