### PR TITLE
Remove deepcopy from UMFPACK, add kwarg to copy

### DIFF
--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -265,7 +265,7 @@ This must be done if multiple threads may call factorization or refactorization 
 on the copy and original simultaneously.
 """
 # Not using simlar helps if the actual needed size has changed as it would need to be resized again
-Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F); copynumeric = false, copysymbolic) where {Tv, Ti} =
+Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F); copynumeric = false, copysymbolic = false) where {Tv, Ti} =
     UmfpackLU(
         copysymbolic ? Symbolic{Tv, Ti}(C_NULL) : F.symbolic,
         copynumeric ? Numeric{Tv, Ti}(C_NULL) : F.numeric,

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -265,7 +265,7 @@ This must be done if multiple threads may call factorization or refactorization 
 on the copy and original simultaneously.
 """
 # Not using simlar helps if the actual needed size has changed as it would need to be resized again
-Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F); copynumeric = false, copysymbolic = false) where {Tv, Ti} =
+Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F); copynumeric = true, copysymbolic = true) where {Tv, Ti} =
     UmfpackLU(
         copysymbolic ? Symbolic{Tv, Ti}(C_NULL) : F.symbolic,
         copynumeric ? Numeric{Tv, Ti}(C_NULL) : F.numeric,

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -268,7 +268,7 @@ on the copy and original simultaneously.
 Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F); safecopy = false) where {Tv, Ti} =
     UmfpackLU(
         safecopy ? Symbolic{Tv, Ti}(C_NULL) : F.symbolic,
-        safecopy ? Numeric{Tv, TI}(C_NULL) : F.numeric,
+        safecopy ? Numeric{Tv, Ti}(C_NULL) : F.numeric,
         F.m, F.n,
         F.colptr,
         F.rowval,

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -255,20 +255,20 @@ UmfpackWS(F::UmfpackLU{Tv, Ti}, refinement::Bool=has_refinement(F)) where {Tv, T
 UmfpackWS(F::ATLU, refinement::Bool=has_refinement(F)) = UmfpackWS(F.parent, refinement)
 
 """
-    copy(F::UmfpackLU, [ws::UmfpackWS]; safecopy = false) -> UmfpackLU
+    copy(F::UmfpackLU, [ws::UmfpackWS]; copynumeric = false, copysymbolic)::UmfpackLU
 A shallow copy of UmfpackLU to use in multithreaded solve applications.
 This function duplicates the working space, control, info and lock fields.
 
-If `safecopy = true` is passed, then the internal Symbolic and Numeric
-factorization objects will be duplicated as well. This must be done if
-multiple threads may call factorization or refactorization functions
+If `copynumeric = true` or `copysymbolic` are passed, 
+then the internal Symbolic and Numeric factorization objects will be duplicated as well. 
+This must be done if multiple threads may call factorization or refactorization functions
 on the copy and original simultaneously.
 """
 # Not using simlar helps if the actual needed size has changed as it would need to be resized again
-Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F); safecopy = false) where {Tv, Ti} =
+Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F); copynumeric = false, copysymbolic) where {Tv, Ti} =
     UmfpackLU(
-        safecopy ? Symbolic{Tv, Ti}(C_NULL) : F.symbolic,
-        safecopy ? Numeric{Tv, Ti}(C_NULL) : F.numeric,
+        copysymbolic ? Symbolic{Tv, Ti}(C_NULL) : F.symbolic,
+        copynumeric ? Numeric{Tv, Ti}(C_NULL) : F.numeric,
         F.m, F.n,
         F.colptr,
         F.rowval,

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -150,7 +150,7 @@ end
         test_ws_dup(Af, copy(parent(adjoint(Af))))
         umfpack_report(Af)
 
-        Afcopy = copy(Af)
+        Afcopy = copy(Af; copynumeric = false, copysymbolic = false)
         @test Afcopy.numeric === Af.numeric
         @test Afcopy.symbolic === Af.symbolic
 

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -154,7 +154,7 @@ end
         @test Afcopy.numeric === Af.numeric
         @test Afcopy.symbolic === Af.symbolic
 
-        Afcopy = deepcopy(Af)
+        Afcopy = copy(Af; safecopy = true)
         @test Afcopy.numeric !== Af.numeric
         @test Afcopy.symbolic !== Af.symbolic
     end

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -154,7 +154,7 @@ end
         @test Afcopy.numeric === Af.numeric
         @test Afcopy.symbolic === Af.symbolic
 
-        Afcopy = copy(Af; safecopy = true)
+        Afcopy = copy(Af; copynumeric = true, copysymbolic = true)
         @test Afcopy.numeric !== Af.numeric
         @test Afcopy.symbolic !== Af.symbolic
     end


### PR DESCRIPTION
@JeffBezanson is this more acceptable? The semantics of the previous version didn't really match `deepcopy` anyway (only certain fields were copied). 

Can `copy` signature be modified without affecting Base specialization changes? 