### PR TITLE
Remove fkeep! from the documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -234,7 +234,6 @@ SparseArrays.permute
 permute!{Tv, Ti, Tp <: Integer, Tq <: Integer}(::SparseMatrixCSC{Tv,Ti}, ::SparseMatrixCSC{Tv,Ti}, ::AbstractArray{Tp,1}, ::AbstractArray{Tq,1})
 SparseArrays.halfperm!
 SparseArrays.ftranspose!
-SparseArrays.fkeep!
 ```
 
 ```@meta


### PR DESCRIPTION
fkeep! doesn't have a docstring, and including it in the documentation errors when building julia.