### PR TITLE
add undef initializers

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -47,6 +47,8 @@ end
 SparseMatrixCSC(m, n, colptr::ReadOnly, rowval::ReadOnly, nzval::Vector) =
     SparseMatrixCSC(m, n, copy(parent(colptr)), copy(parent(rowval)), nzval)
 
+SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer) = spzeros(Tv, Ti, m, n)
+
 """
     `FixedSparseCSC{Tv,Ti<:Integer} <: AbstractSparseMatrixCSC{Tv,Ti}`
 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -47,6 +47,11 @@ end
 SparseMatrixCSC(m, n, colptr::ReadOnly, rowval::ReadOnly, nzval::Vector) =
     SparseMatrixCSC(m, n, copy(parent(colptr)), copy(parent(rowval)), nzval)
 
+"""
+    SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer)
+
+Creates an empty sparse matrix with element type `Tv` and integer type `Ti` of size `m × n`.
+"""
 SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer) where {Tv, Ti} = spzeros(Tv, Ti, m, n)
 
 """

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -47,7 +47,7 @@ end
 SparseMatrixCSC(m, n, colptr::ReadOnly, rowval::ReadOnly, nzval::Vector) =
     SparseMatrixCSC(m, n, copy(parent(colptr)), copy(parent(rowval)), nzval)
 
-SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer) = spzeros(Tv, Ti, m, n)
+SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer) where {Tv, Ti} = spzeros(Tv, Ti, m, n)
 
 """
     `FixedSparseCSC{Tv,Ti<:Integer} <: AbstractSparseMatrixCSC{Tv,Ti}`

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -49,7 +49,7 @@ end
 SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
     SparseVector{Tv,Ti}(n, nzind, nzval)
 
-SparseVector{Tv, Ti}(::UndefInitializer, n::Integer) = SparseVector{Tv, Ti}(n, Ti[], Tv[])
+SparseVector{Tv, Ti}(::UndefInitializer, n::Integer) where {Tv, Ti}  = SparseVector{Tv, Ti}(n, Ti[], Tv[])
 
 """
     `FixedSparseVector{Tv,Ti<:Integer} <: AbstractCompressedVector{Tv,Ti}`

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -49,6 +49,8 @@ end
 SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
     SparseVector{Tv,Ti}(n, nzind, nzval)
 
+SparseVector{Tv, Ti}(::UndefInitializer, n::Integer) = SparseVector{Tv, Ti}(n, Ti[], Tv[])
+
 """
     `FixedSparseVector{Tv,Ti<:Integer} <: AbstractCompressedVector{Tv,Ti}`
 

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -51,6 +51,11 @@ end
     @test sparse([1, 1, 2, 2, 2], [1, 2, 1, 2, 2], 1.0, 2, 2, +) == sparse([1, 1, 2, 2], [1, 2, 1, 2], [1.0, 1.0, 1.0, 2.0], 2, 2)
     @test sparse([1, 1, 2, 2, 2], [1, 2, 1, 2, 2], -1.0, 2, 2, *) == sparse([1, 1, 2, 2], [1, 2, 1, 2], [-1.0, -1.0, -1.0, 1.0], 2, 2)
     @test sparse(sparse(Int32.(1:5), Int32.(1:5), trues(5))') isa SparseMatrixCSC{Bool,Int32}
+    # undef initializer
+    m = SparseMatrixCSC{Float32, Int16}(undef, 3, 4)
+    @test size(m) == (3, 4)
+    @test eltype(m) === Float32
+    @test m == spzeros(3, 4)
 end
 
 @testset "concatenation tests" begin

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -216,6 +216,13 @@ end
             end
         end
     end
+
+    @testset "Undef initializer" begin
+        v = SparseVector{Float32, Int16}(undef, 4)
+        @test size(v) == (4, )
+        @test eltype(v) === Float32
+        @test v == spzeros(Float32, 4)
+    end
 end
 ### Element access
 


### PR DESCRIPTION
This is useful to have a unified way to create sparse and dense vectors.

Will add tests if the feature is considered useful / needed