### PR TITLE
Fix method ambiguities and activate tests

### DIFF
--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -10,7 +10,7 @@ struct ReadOnly{T,N,V<:AbstractArray{T,N}} <: AbstractArray{T,N}
 end
 # ReadOnly of ReadOnly is meaningless
 ReadOnly(x::ReadOnly) = x
-Base.getproperty(x::ReadOnly, s) = Base.getproperty(parent(x), s)
+Base.getproperty(x::ReadOnly, s::Symbol) = Base.getproperty(parent(x), s)
 @inline Base.parent(x::ReadOnly) = getfield(x, :parent)
 
 for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :eltype]

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -825,7 +825,7 @@ function findall(p::F, x::SparseVectorUnion{<:Any,Ti}) where {Ti,F<:Function}
 
     return I
 end
-findall(p::Base.Fix2{typeof(in)}, x::AbstractCompressedVector{<:Any,Ti}) where {Ti} =
+findall(p::Base.Fix2{typeof(in)}, x::SparseVectorUnion{<:Any,Ti}) where {Ti} =
     invoke(findall, Tuple{Base.Fix2{typeof(in)}, AbstractArray}, p, x)
 
 """

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -1,26 +1,32 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
-using Test, LinearAlgebra, SparseArrays
-@testset "detect_ambiguities" begin
-    @test_nowarn detect_ambiguities(SparseArrays; recursive=true, ambiguous_bottom=false)
+
+using Test, SparseArrays
+
+if "exec" in ARGS
+    let ambig = detect_ambiguities(SparseArrays; recursive=true)
+        @test isempty(ambig)
+        ambig = Set{Any}(((m1.sig, m2.sig) for (m1, m2) in ambig))
+        expect = []
+        good = true
+        while !isempty(ambig)
+            sigs = pop!(ambig)
+            i = findfirst(==(sigs), expect)
+            if i === nothing
+                println(stderr, "push!(expect, (", sigs[1], ", ", sigs[2], "))")
+                good = false
+                continue
+            end
+            deleteat!(expect, i)
+        end
+        @test isempty(expect)
+        @test good
+    end
+else
+    @testset "method ambiguity" begin
+        # Ambiguity test is run inside a clean process.
+        # https://github.com/JuliaLang/julia/issues/28804
+        script = @__FILE__
+        cmd = `$(Base.julia_cmd()) --startup-file=no $script exec`
+        @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
+    end
 end
-
-## This was the older version that was disabled
-
-# let ambig = detect_ambiguities(SparseArrays; recursive=true)
-#     @test isempty(ambig)
-#     ambig = Set{Any}(((m1.sig, m2.sig) for (m1, m2) in ambig))
-#     expect = []
-#     good = true
-#     while !isempty(ambig)
-#         sigs = pop!(ambig)
-#         i = findfirst(==(sigs), expect)
-#         if i === nothing
-#             println(stderr, "push!(expect, (", sigs[1], ", ", sigs[2], "))")
-#             good = false
-#             continue
-#         end
-#         deleteat!(expect, i)
-#     end
-#     @test isempty(expect)
-#     @test good
-# end

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -1361,16 +1361,6 @@ end
     @test_throws MethodError sprandn(T, 5, 5, 0.5)
 end
 
-# TODO: Re-enable after completing the SparseArrays.jl migration
-#
-# @testset "method ambiguity" begin
-#     # Ambiguity test is run inside a clean process.
-#     # https://github.com/JuliaLang/julia/issues/28804
-#     script = joinpath(@__DIR__, "ambiguous_exec.jl")
-#     cmd = `$(Base.julia_cmd()) --startup-file=no $script`
-#     @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
-# end
-
 @testset "count specializations" begin
     # count should throw for sparse arrays for which zero(eltype) does not exist
     @test_throws MethodError count(SparseMatrixCSC(2, 2, Int[1, 2, 3], Int[1, 2], Any[true, true]))


### PR DESCRIPTION
This patch fixes some method ambiguities that have accumulated in the SparseArrays.jl repo while tests have been deactivated, closes #266.