### PR TITLE
Fix ambiguities with Base.

### DIFF
--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -10,7 +10,7 @@ struct ReadOnly{T,N,V<:AbstractArray{T,N}} <: AbstractArray{T,N}
 end
 # ReadOnly of ReadOnly is meaningless
 ReadOnly(x::ReadOnly) = x
-Base.getproperty(x::ReadOnly, s) = Base.getproperty(parent(x), s)
+Base.getproperty(x::ReadOnly, s::Symbol) = Base.getproperty(parent(x), s)
 @inline Base.parent(x::ReadOnly) = getfield(x, :parent)
 
 for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :eltype]

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -825,7 +825,7 @@ function findall(p::F, x::SparseVectorUnion{<:Any,Ti}) where {Ti,F<:Function}
 
     return I
 end
-findall(p::Base.Fix2{typeof(in)}, x::AbstractCompressedVector{<:Any,Ti}) where {Ti} =
+findall(p::Base.Fix2{typeof(in)}, x::SparseVectorUnion{<:Any,Ti}) where {Ti} =
     invoke(findall, Tuple{Base.Fix2{typeof(in)}, AbstractArray}, p, x)
 
 """


### PR DESCRIPTION
This patch fixes the tests run in Base, i.e.
```
@test isempty(detect_ambiguities(Core, Base; recursive=true))
```
passes. Enabling the tests seemed much more complicated (#267) so let's do this for now to unblock the update in JuliaLang/julia.