### PR TITLE
Fix `all`/`any` on empty sparse arrays

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2190,9 +2190,9 @@ _mapreducezeros(f::Base.ExtremaMap, op::typeof(Base._extrema_rf), ::Type{T}, nze
 
 # Specialized mapreduce for any and all
 Base._any(f, A::AbstractSparseMatrixCSC, ::Colon) =
-    Base._mapreduce(f, |, IndexCartesian(), A)
+    iszero(widelength(A)) ? false : Base._mapreduce(f, |, IndexCartesian(), A)
 Base._all(f, A::AbstractSparseMatrixCSC, ::Colon) =
-    Base._mapreduce(f, &, IndexCartesian(), A)
+    iszero(widelength(A)) ? true  : Base._mapreduce(f, &, IndexCartesian(), A)
 
 function Base._mapreduce(f, op::Union{typeof(Base.mul_prod),typeof(*)}, ::Base.IndexCartesian, A::AbstractSparseMatrixCSC{T}) where T
     nnzA = nnz(A)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1540,8 +1540,10 @@ function Base._mapreduce(f, op, ::IndexCartesian, A::SparseVectorUnion{T}) where
     _mapreducezeros(f, op, T, rest, ini)
 end
 
-Base._any(f, A::SparseVectorUnion, ::Colon) = Base._mapreduce(f, |, IndexCartesian(), A)
-Base._all(f, A::SparseVectorUnion, ::Colon) = Base._mapreduce(f, &, IndexCartesian(), A)
+Base._any(f, A::SparseVectorUnion, ::Colon) =
+    iszero(length(A)) ? false : Base._mapreduce(f, |, IndexCartesian(), A)
+Base._all(f, A::SparseVectorUnion, ::Colon) =
+    iszero(length(A)) ? true  : Base._mapreduce(f, &, IndexCartesian(), A)
 
 function Base.mapreducedim!(f, op, R::AbstractVector, A::SparseVectorUnion)
     # dim1 reduction could be safely replaced with a mapreduce

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -230,6 +230,8 @@ dA = Array(sA)
         @test all(v)
         @test !iszero(v)
         @test count(v) == length(v)
+        @test all(!iszero, spzeros(0, 0))
+        @test !any(iszero, spzeros(0, 0))
     end
 
     @testset "empty cases" begin

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -976,6 +976,11 @@ end
         @test all(v)
         @test count(v) == length(v)
     end
+
+    let v = spzeros(0)
+        @test all(!iszero, v)
+        @test !any(iszero, v)
+    end
 end
 
 ### linalg


### PR DESCRIPTION
Fixes #270.