### PR TITLE
Remove temporary circshift direction workaround

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -11,10 +11,6 @@ using Base.Sort: Forward
 using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, matprod
 
-# Temporary workaround for simplifying SparseArrays.jl upgrade in JuliaLang/julia
-# to workaround circshift! bug, see https://github.com/JuliaLang/julia/pull/46759
-const CIRCSHIFT_WRONG_DIRECTION = circshift!([1, 2, 3], 1) != circshift([1, 2, 3], 1)
-
 
 import Base: +, -, *, \, /, &, |, xor, ==, zero
 import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -4216,16 +4216,16 @@ function Base.swaprows!(A::AbstractSparseMatrixCSC, i, j)
             rows[rr[iidx]] = j
             jidx == 0 && continue
             rotate_range = rr[iidx]:jrange[jidx]
-            circshift!(@view(vals[rotate_range]), CIRCSHIFT_WRONG_DIRECTION ? -1 : 1)
-            circshift!(@view(rows[rotate_range]), CIRCSHIFT_WRONG_DIRECTION ? -1 : 1)
+            circshift!(@view(vals[rotate_range]), 1)
+            circshift!(@view(rows[rotate_range]), 1)
         else
             # Same as i, but in the opposite direction
             @assert has_j
             rows[jrange[jidx]] = i
             iidx > length(rr) && continue
             rotate_range = rr[iidx]:jrange[jidx]
-            circshift!(@view(vals[rotate_range]), CIRCSHIFT_WRONG_DIRECTION ? 1 : -1)
-            circshift!(@view(rows[rotate_range]), CIRCSHIFT_WRONG_DIRECTION ? 1 : -1)
+            circshift!(@view(vals[rotate_range]), -1)
+            circshift!(@view(rows[rotate_range]), -1)
         end
     end
     return nothing

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2272,8 +2272,8 @@ function subvector_shifter!(R::AbstractVector, V::AbstractVector, start::Integer
         end
     end
     # ...but rowval should be sorted within columns
-    circshift!(@view(R[start:fin]), (CIRCSHIFT_WRONG_DIRECTION ? (+) : (-))(split-start+1))
-    circshift!(@view(V[start:fin]), (CIRCSHIFT_WRONG_DIRECTION ? (+) : (-))(split-start+1))
+    circshift!(@view(R[start:fin]), -split+start-1)
+    circshift!(@view(V[start:fin]), -split+start-1)
 end
 
 function circshift!(O::SparseVector, X::SparseVector, (r,)::Base.DimsInteger{1})


### PR DESCRIPTION
Will the Base PR be backported to v1.8.2, or not? I.e., can this be included in our backport PR, which hopefully still makes it for v1.8.2?