### PR TITLE
Elide bounds checks in `getindex`

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -16,7 +16,7 @@ using LinearAlgebra: AdjOrTrans, matprod
 const CIRCSHIFT_WRONG_DIRECTION = circshift!([1, 2, 3], 1) != circshift([1, 2, 3], 1)
 
 
-import Base: +, -, *, \, /, &, |, xor, ==, zero
+import Base: +, -, *, \, /, &, |, xor, ==, zero, @propagate_inbounds
 import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!, isbanded,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -149,8 +149,10 @@ is stored in `_restore_scalar_indexing` and a function that has the same definit
 returns an error is stored in `_destroy_scalar_indexing`.
 """
 macro RCI(exp)
-    # evaluate to not push any broken code in the arrays when developping this package.
-    # also ensures that restore has the exact same effect.
+    # Evaluate to not push any broken code in the arrays when developping this package.
+    # Ensures that restore has the exact same effect.
+    # Expand macro so we can chain macros. Save the expanded version for speed
+    exp = macroexpand(@__MODULE__, exp)
     @eval $exp
     if length(exp.args) == 2 && exp.head ∈ (:function, :(=))
         push!(_restore_scalar_indexing, exp)

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -152,8 +152,8 @@ macro RCI(exp)
     # Evaluate to not push any broken code in the arrays when developping this package.
     # Ensures that restore has the exact same effect.
     # Expand macro so we can chain macros. Save the expanded version for speed
-    exp = macroexpand(@__MODULE__, exp)
-    @eval $exp
+    exp = macroexpand(__module__, exp)
+    @eval __module__ $exp
     if length(exp.args) == 2 && exp.head ∈ (:function, :(=))
         push!(_restore_scalar_indexing, exp)
         push!(_destroy_scalar_indexing,

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2491,11 +2491,11 @@ end
 
 @RCI function getindex(A::AbstractSparseMatrixCSC{T}, i0::Integer, i1::Integer) where T
     @boundscheck checkbounds(A, i0, i1)
-    r1 = Int(getcolptr(A)[i1])
-    r2 = Int(getcolptr(A)[i1+1]-1)
+    r1 = Int(@inbounds getcolptr(A)[i1])
+    r2 = Int(@inbounds getcolptr(A)[i1+1]-1)
     (r1 > r2) && return zero(T)
     r1 = searchsortedfirst(rowvals(A), i0, r1, r2, Forward)
-    ((r1 > r2) || (rowvals(A)[r1] != i0)) ? zero(T) : nonzeros(A)[r1]
+    ((r1 > r2) || (rowvals(A)[r1] != i0)) ? zero(T) : @inbounds nonzeros(A)[r1]
 end
 
 # Colon translation

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2495,7 +2495,7 @@ end
     r2 = Int(@inbounds getcolptr(A)[i1+1]-1)
     (r1 > r2) && return zero(T)
     r1 = searchsortedfirst(rowvals(A), i0, r1, r2, Forward)
-    ((r1 > r2) || (@inbounds rowvals(A)[r1] != i0)) ? zero(T) : @inbounds nonzeros(A)[r1]
+    ((r1 > r2) || (rowvals(A)[r1] != i0)) ? zero(T) : nonzeros(A)[r1]
 end
 
 # Colon translation

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2487,9 +2487,9 @@ function rangesearch(haystack::AbstractRange, needle)
     (rem==0 && 1<=i+1<=length(haystack)) ? i+1 : 0
 end
 
-@RCI getindex(A::AbstractSparseMatrixCSC, I::Tuple{Integer,Integer}) = getindex(A, I[1], I[2])
+@RCI @propagate_inbounds getindex(A::AbstractSparseMatrixCSC, I::Tuple{Integer,Integer}) = getindex(A, I[1], I[2])
 
-@RCI Base.@propagate_inbounds function getindex(A::AbstractSparseMatrixCSC{T}, i0::Integer, i1::Integer) where T
+@RCI @propagate_inbounds function getindex(A::AbstractSparseMatrixCSC{T}, i0::Integer, i1::Integer) where T
     @boundscheck checkbounds(A, i0, i1)
     r1 = Int(@inbounds getcolptr(A)[i1])
     r2 = Int(@inbounds getcolptr(A)[i1+1]-1)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2495,7 +2495,7 @@ end
     r2 = Int(@inbounds getcolptr(A)[i1+1]-1)
     (r1 > r2) && return zero(T)
     r1 = searchsortedfirst(rowvals(A), i0, r1, r2, Forward)
-    ((r1 > r2) || (rowvals(A)[r1] != i0)) ? zero(T) : @inbounds nonzeros(A)[r1]
+    ((r1 > r2) || (@inbounds rowvals(A)[r1] != i0)) ? zero(T) : @inbounds nonzeros(A)[r1]
 end
 
 # Colon translation

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2489,7 +2489,7 @@ end
 
 @RCI getindex(A::AbstractSparseMatrixCSC, I::Tuple{Integer,Integer}) = getindex(A, I[1], I[2])
 
-@RCI function getindex(A::AbstractSparseMatrixCSC{T}, i0::Integer, i1::Integer) where T
+@RCI Base.@propagate_inbounds function getindex(A::AbstractSparseMatrixCSC{T}, i0::Integer, i1::Integer) where T
     @boundscheck checkbounds(A, i0, i1)
     r1 = Int(@inbounds getcolptr(A)[i1])
     r2 = Int(@inbounds getcolptr(A)[i1+1]-1)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -380,8 +380,8 @@ end
 
 ### Element access
 
-@RCI function setindex!(x::AbstractCompressedVector{Tv,Ti}, v::Tv, i::Ti) where {Tv,Ti<:Integer}
-    checkbounds(x, i)
+@RCI @propagate_inbounds function setindex!(x::AbstractCompressedVector{Tv,Ti}, v::Tv, i::Ti) where {Tv,Ti<:Integer}
+    @boundscheck checkbounds(x, i)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
 
@@ -398,7 +398,7 @@ end
     return x
 end
 
-@RCI setindex!(x::AbstractCompressedVector{Tv,Ti}, v, i::Integer) where {Tv,Ti<:Integer} =
+@RCI @propagate_inbounds setindex!(x::AbstractCompressedVector{Tv,Ti}, v, i::Integer) where {Tv,Ti<:Integer} =
     setindex!(x, convert(Tv, v), convert(Ti, i))
 
 
@@ -930,8 +930,8 @@ function _spgetindex(m::Int, nzind::AbstractVector{Ti}, nzval::AbstractVector{Tv
     (ii <= m && nzind[ii] == i) ? nzval[ii] : zero(Tv)
 end
 
-@RCI function getindex(x::AbstractSparseVector, i::Integer)
-    checkbounds(x, i)
+@RCI @propagate_inbounds function getindex(x::AbstractSparseVector, i::Integer)
+    @boundscheck checkbounds(x, i)
     _spgetindex(nnz(x), nonzeroinds(x), nonzeros(x), i)
 end
 


### PR DESCRIPTION
I'm presuming that the first bounds check is sufficient to cover the later ones being omitted. Then the user can control the first bounds checks for this method at the call site.

In my code which is highly dominated by sparse array lookups, this increased overall speed by 5%.