### PR TITLE
Fix order of triangular and adjortrans wrappers

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -543,9 +543,9 @@ end
 
 # forward multiplication for adjoint and transpose of LowerTriangular CSC matrices
 function _lmul!(U::UpperTriangularWrapped, B::StridedVecOrMat)
-    A = U.parent.data
+    A = parent(parent(U))
     unit = U.parent isa UnitDiagonalTriangular
-    adj = U isa Adjoint
+    adj = parent(U) isa Adjoint
 
     nrowB, ncolB  = size(B, 1), size(B, 2)
     aa = getnzval(A)
@@ -583,9 +583,9 @@ end
 
 # backward multiplication with adjoint and transpose of LowerTriangular CSC matrices
 function _lmul!(L::LowerTriangularWrapped, B::StridedVecOrMat)
-    A = L.parent.data
-    unit = L.parent isa UnitDiagonalTriangular
-    adj = L isa Adjoint
+    A = parent(parent(L))
+    unit = L isa UnitDiagonalTriangular
+    adj = parent(L) isa Adjoint
 
     nrowB, ncolB  = size(B, 1), size(B, 2)
     aa = getnzval(A)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -718,9 +718,9 @@ end
 
 # forward substitution for adjoint and transpose of UpperTriangular CSC matrices
 function _ldiv!(L::LowerTriangularWrapped, B::StridedVecOrMat)
-    A = L.parent.data
-    unit = L.parent isa UnitDiagonalTriangular
-    adj = L isa Adjoint
+    A = parent(parent(L))
+    unit = L isa UnitDiagonalTriangular
+    adj = parent(L) isa Adjoint
 
     nrowB, ncolB  = size(B, 1), size(B, 2)
     aa = getnzval(A)
@@ -764,9 +764,9 @@ end
 
 # backward substitution for adjoint and transpose of LowerTriangular CSC matrices
 function _ldiv!(U::UpperTriangularWrapped, B::StridedVecOrMat)
-    A = U.parent.data
-    unit = U.parent isa UnitDiagonalTriangular
-    adj = U isa Adjoint
+    A = parent(parent(U))
+    unit = U isa UnitDiagonalTriangular
+    adj = parent(U) isa Adjoint
 
     nrowB, ncolB = size(B, 1), size(B, 2)
     aa = getnzval(A)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -544,7 +544,7 @@ end
 # forward multiplication for adjoint and transpose of LowerTriangular CSC matrices
 function _lmul!(U::UpperTriangularWrapped, B::StridedVecOrMat)
     A = parent(parent(U))
-    unit = U.parent isa UnitDiagonalTriangular
+    unit = U isa UnitDiagonalTriangular
     adj = parent(U) isa Adjoint
 
     nrowB, ncolB  = size(B, 1), size(B, 2)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -424,20 +424,20 @@ const LowerTriangularPlain{T} = Union{
             UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}}
 
 const LowerTriangularWrapped{T} = Union{
-            Adjoint{T,<:UpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Adjoint{T,<:UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:UpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}}} where T
+            LowerTriangular{T,<:Adjoint{T,<:SparseMatrixCSCUnion{T}}},
+            UnitLowerTriangular{T,<:Adjoint{T,<:SparseMatrixCSCUnion{T}}},
+            LowerTriangular{T,<:Transpose{T,<:SparseMatrixCSCUnion{T}}},
+            UnitLowerTriangular{T,<:Transpose{T,<:SparseMatrixCSCUnion{T}}}} where T
 
 const UpperTriangularPlain{T} = Union{
             UpperTriangular{T,<:SparseMatrixCSCUnion{T}},
             UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}}
 
 const UpperTriangularWrapped{T} = Union{
-            Adjoint{T,<:LowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Adjoint{T,<:UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:LowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}}} where T
+            UpperTriangular{T,<:Adjoint{T,<:SparseMatrixCSCUnion{T}}},
+            UnitUpperTriangular{T,<:Adjoint{T,<:SparseMatrixCSCUnion{T}}},
+            UpperTriangular{T,<:Transpose{T,<:SparseMatrixCSCUnion{T}}},
+            UnitUpperTriangular{T,<:Transpose{T,<:SparseMatrixCSCUnion{T}}}} where T
 
 const UpperTriangularSparse{T} = Union{
             UpperTriangularWrapped{T}, UpperTriangularPlain{T}} where T
@@ -1582,10 +1582,10 @@ for (xformtype, xformop) in ((:Adjoint, :adjoint), (:Transpose, :transpose))
                     if istriu(A)
                         return \(Diagonal(($xformop.(diag(A)))), B)
                     else
-                        return \($xformop(LowerTriangular(A)), B)
+                        return \(UpperTriangular($xformop(A)), B)
                     end
                 elseif istriu(A)
-                    return \($xformop(UpperTriangular(A)), B)
+                    return \(LowerTriangular($xformop(A)), B)
                 end
                 if ishermitian(A)
                     return \($xformop(Hermitian(A)), B)


### PR DESCRIPTION
I'm not sure why this hasn't come up anywhere, but it may be that it simply lead to performance penalties. In any case, for a while adjoints of triangular matrices are passed to the wrapped matrix while the triangular wrapper is flipped. This should be backported to v1.8.