### PR TITLE
Improved memory usage when creating the sparsity pattern

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1000,7 +1000,7 @@ julia> sparse(Is, Js, Vs)
 sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::AbstractVector{Tv}, m::Integer, n::Integer, combine) where {Tv,Ti<:Integer} =
     _sparse(I, J, V, m, n, combine)
 sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, v::Tv, m::Integer, n::Integer, combine) where {Tv<:Number,Ti<:Integer} = 
-    _sparse(I, J, iszero(v) ? 0.0 : fill(v,length(I)), Int(m), Int(n), combine)
+    _sparse(I, J, iszero(v) ? v : fill(v,length(I)), Int(m), Int(n), combine)
 
 function _sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Tv,AbstractVector{Tv}}, m::Integer, n::Integer, combine) where {Tv,Ti<:Integer}
     require_one_based_indexing(I, J, V)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1093,7 +1093,7 @@ F. Gustavson, "Two fast algorithms for sparse matrices: multiplication and permu
 transposition," ACM TOMS 4(3), 250-269 (1978) inspired this method's use of a pair of
 counting sorts.
 """
-function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Type{Tv},AbstractVector{Tv}}, 
+function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Tv,AbstractVector{Tv}}, 
         m::Integer, n::Integer, combine, klasttouch::Vector{Tj},
         csrrowptr::Vector{Tj}, csrcolval::Vector{Ti}, csrnzval::Vector{Tv},
         csccolptr::Vector{Ti}, cscrowval::Vector{Ti}, cscnzval::Vector{Tv}) where {Tv,Ti<:Integer,Tj<:Integer}
@@ -1227,7 +1227,7 @@ end
 
 dimlub(I) = isempty(I) ? 0 : Int(maximum(I)) #least upper bound on required sparse matrix dimension
 
-sparse(I,J,v::Number) = sparse(I, J, fill(v,length(I)))
+sparse(I,J,v::Number) = sparse(I, J, v, dimlub(I), dimlub(J))
 
 sparse(I,J,V::AbstractVector) = sparse(I, J, V, dimlub(I), dimlub(J))
 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1098,7 +1098,7 @@ function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Tv,Abstr
         csrrowptr::Vector{Tj}, csrcolval::Vector{Ti}, csrnzval::Vector{Tv},
         csccolptr::Vector{Ti}, cscrowval::Vector{Ti}, cscnzval::Vector{Tv}) where {Tv,Ti<:Integer,Tj<:Integer}
 
-    require_one_based_indexing(I, J, (V isa Type) ? 0 : V)
+    require_one_based_indexing(I, J, V)
     sparse_check_Ti(m, n, Ti)
     sparse_check_length("I", I, 0, Tj)
     only_sparsity_pattern = (V isa Number && iszero(V)) # We can use a optimsed version if only care about the sparsity pattern (and not the values)
@@ -1996,6 +1996,9 @@ julia> spzeros(Float32, 4)
 ```
 """
 spzeros(m::Integer, n::Integer) = spzeros(Float64, m, n)
+spzeros(I::AbstractVector, J::AbstractVector) = spzeros(Float64, I, J, dimlub(I), dimlub(J))
+spzeros(::Type{Tv}, I::AbstractVector, J::AbstractVector) where {Tv} = spzeros(Tv, Int, dimlub(I), dimlub(J))
+spzeros(::Type{Tv}, I::AbstractVector, J::AbstractVector, m, n) where {Tv} = sparse(I, J, zero(Tv), Int(m), Int(n), +)
 spzeros(::Type{Tv}, m::Integer, n::Integer) where {Tv} = spzeros(Tv, Int, m, n)
 function spzeros(::Type{Tv}, ::Type{Ti}, m::Integer, n::Integer) where {Tv, Ti}
     ((m < 0) || (n < 0)) && throw(ArgumentError("invalid Array dimensions"))

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1036,7 +1036,7 @@ function sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Tv,Abstra
     end
 end
 
-#sparse(I::AbstractVector, J::AbstractVector, V::AbstractVector, m::Integer, n::Integer, combine) = sparse(AbstractVector{Int}(I), AbstractVector{Int}(J), V, m, n, combine)
+sparse(I::AbstractVector, J::AbstractVector, V::Union{Number,AbstractVector}, m::Integer, n::Integer, combine) = sparse(AbstractVector{Int}(I), AbstractVector{Int}(J), V, m, n, combine)
 
 """
     sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::AbstractVector{Tv},
@@ -1202,7 +1202,7 @@ function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
     SparseMatrixCSC(m, n, csccolptr, cscrowval, cscnzval)
 end
 function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
-        V::AbstractVector{Tv}, m::Integer, n::Integer, combine, klasttouch::Vector{Tj},
+        V::Union{Tv,AbstractVector{Tv}}, m::Integer, n::Integer, combine, klasttouch::Vector{Tj},
         csrrowptr::Vector{Tj}, csrcolval::Vector{Ti}, csrnzval::Vector{Tv},
         csccolptr::Vector{Ti}) where {Tv,Ti<:Integer,Tj<:Integer}
     sparse!(I, J, V, m, n, combine, klasttouch,
@@ -1210,7 +1210,7 @@ function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
             csccolptr, Vector{Ti}(), Vector{Tv}())
 end
 function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
-        V::AbstractVector{Tv}, m::Integer, n::Integer, combine, klasttouch::Vector{Tj},
+        V::Union{Tv,AbstractVector{Tv}}, m::Integer, n::Integer, combine, klasttouch::Vector{Tj},
         csrrowptr::Vector{Tj}, csrcolval::Vector{Ti}, csrnzval::Vector{Tv}) where {Tv,Ti<:Integer,Tj<:Integer}
     sparse!(I, J, V, m, n, combine, klasttouch,
             csrrowptr, csrcolval, csrnzval,

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1003,7 +1003,7 @@ sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, v::Tv, m::Integer, n::Integ
     _sparse(I, J, iszero(v) ? 0.0 : fill(v,length(I)), Int(m), Int(n), combine)
 
 function _sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Tv,AbstractVector{Tv}}, m::Integer, n::Integer, combine) where {Tv,Ti<:Integer}
-    require_one_based_indexing(I, J, (V isa Type) ? 0 : V)
+    require_one_based_indexing(I, J, V)
     coolen = length(I)
     length(J) == coolen || throw(ArgumentError("J (= $(length(J))) need length == length(I) = $coolen"))
     only_sparsity_pattern = (V isa Number && iszero(V)) # We can use a optimsed version if only care about the sparsity pattern (and not the values)
@@ -1026,7 +1026,7 @@ function _sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Tv,Abstr
         csrrowptr = Vector{Ti}(undef, m+1)
         csrcolval = Vector{Ti}(undef, coolen)
         csrnzval = Vector{Tv}(undef, only_sparsity_pattern ? 0 : coolen)
-        
+
         # Allocate storage for the CSC form's column pointers and a necessary workspace
         csccolptr = Vector{Ti}(undef, n+1)
         klasttouch = Vector{Ti}(undef, n)
@@ -1124,7 +1124,6 @@ function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::Union{Type{Tv}
         csrrowptr[i] = countsum
         countsum += overwritten
     end
-
     # Counting-sort the column and nonzero values from J and V into csrcolval and csrnzval
     # Tracking write positions in csrrowptr corrects the row pointers
     @inbounds for k in 1:coolen

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -56,9 +56,33 @@ end
     @test size(m) == (3, 4)
     @test eltype(m) === Float32
     @test m == spzeros(3, 4)
-    @test spzeros([1, 2, 3], [1, 2, 3]) == sparse([1, 2, 3], [1, 2, 3], 0.0, 3, 3, +)
-    @test spzeros(Float32, [1, 2, 3], [1, 2, 3]) == sparse([1, 2, 3], [1, 2, 3], Float32(0.0), 3, 3, +)
-    @test spzeros(Float64, [1, 2, 3], [1, 2, 3], 3, 3) == sparse([1, 2, 3], [1, 2, 3], 0.0, 3, 3, +)
+end
+
+@testset "spzeros for pattern creation (structural zeros)" begin
+    function same_structure(A, B)
+        A.m == B.m && A.n == B.n && A.colptr == B.colptr && A.rowval == B.rowval
+    end
+    I = [1, 2, 3]
+    J = [1, 3, 4]
+    V = zeros(length(I))
+    S = spzeros(I, J)
+    S′ = sparse(I, J, V)
+    @test S == S′
+    @test same_structure(S, S′)
+    @test eltype(S) == Float64
+    S = spzeros(Float32, I, J)
+    @test S == S′
+    @test same_structure(S, S′)
+    @test eltype(S) == Float32
+    S = spzeros(I, J, 4, 5)
+    S′ = sparse(I, J, V, 4, 5)
+    @test S == S′
+    @test same_structure(S, S′)
+    @test eltype(S) == Float64
+    S = spzeros(Float32, I, J, 4, 5)
+    @test S == S′
+    @test same_structure(S, S′)
+    @test eltype(S) == Float32
 end
 
 @testset "concatenation tests" begin

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -60,7 +60,7 @@ end
 
 @testset "spzeros for pattern creation (structural zeros)" begin
     function same_structure(A, B)
-        A.m == B.m && A.n == B.n && A.colptr == B.colptr && A.rowval == B.rowval
+        return all(getfield(A, f) == getfield(B, f) for f in (:m, :n, :colptr, :rowval))
     end
     I = [1, 2, 3]
     J = [1, 3, 4]

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -56,6 +56,9 @@ end
     @test size(m) == (3, 4)
     @test eltype(m) === Float32
     @test m == spzeros(3, 4)
+    @test spzeros([1, 2, 3], [1, 2, 3]) == sparse([1, 2, 3], [1, 2, 3], 0.0, 3, 3, +)
+    @test spzeros(Float32, [1, 2, 3], [1, 2, 3]) == sparse([1, 2, 3], [1, 2, 3], Float32(0.0), 3, 3, +)
+    @test spzeros(Float64, [1, 2, 3], [1, 2, 3], 3, 3) == sparse([1, 2, 3], [1, 2, 3], 0.0, 3, 3, +)
 end
 
 @testset "concatenation tests" begin


### PR DESCRIPTION
This PR makes it more memory efficient to create the sparsity pattern,  i.e. when you dont care about the values of `V`.

For a cube mesh with 70x70x70 elements (and linear interpolation with 1 dof per node), i get these benchmarks:
```
@show 2*Base.summarysize(I)/(1024^2)        #Memory of I and J
@btime sparse($I, $J, 1.0)                  # This PR
@btime sparse($I, $J, fill(1.0, length(J))) # Previously
```

```
(2 * Base.summarysize(I)) / 1024 ^ 2 = 340.42230224609375 #MB
200.528 ms (17 allocations: 321.74 MiB)
318.534 ms (21 allocations: 662.17 MiB)

357911×357911 SparseMatrixCSC{Float64, Int64} with 9393931 stored entries:
⎡⠻⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⎤
⎢⠀⠈⠻⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⎥
⎢⠀⠀⠀⠈⠻⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⎥
⎢⠀⠀⠀⠀⠀⠈⠻⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⎥
⎢⠀⠀⠀⠀⠀⠀⠀⠈⠻⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⎥
⎢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣦⡀⠀⠀⠀⠀⠀⠀⠀⎥
⎢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣦⡀⠀⠀⠀⠀⠀⎥
⎢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣦⡀⠀⠀⠀⎥
⎢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣦⡀⠀⎥
⎣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⣦⎦
```

I can't get the tests to pass (I get a bunch of ambiguity errors that I dont understand how to fix), but if you like this PR I will fix them.
