### PR TITLE
Bugfix in getindex for Matrices with one dimension 0

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -733,25 +733,27 @@ function getindex(A::AbstractSparseMatrixCSC{Tv}, I::AbstractUnitRange) where Tv
     rowvalB = Vector{Int}(undef, nnzB)
     nzvalB = Vector{Tv}(undef, nnzB)
 
-    rowstart,colstart = Base._ind2sub(szA, first(I))
-    rowend,colend = Base._ind2sub(szA, last(I))
+    if nnzB > 0
+        rowstart,colstart = Base._ind2sub(szA, first(I))
+        rowend,colend = Base._ind2sub(szA, last(I))
 
-    idxB = 1
-    @inbounds for col in colstart:colend
-        minrow = (col == colstart ? rowstart : 1)
-        maxrow = (col == colend ? rowend : szA[1])
-        for r in colptrA[col]:(colptrA[col+1]-1)
-            rowA = rowvalA[r]
-            if minrow <= rowA <= maxrow
-                rowvalB[idxB] = Base._sub2ind(szA, rowA, col) - first(I) + 1
-                nzvalB[idxB] = nzvalA[r]
-                idxB += 1
+        idxB = 1
+        @inbounds for col in colstart:colend
+            minrow = (col == colstart ? rowstart : 1)
+            maxrow = (col == colend ? rowend : szA[1])
+            for r in colptrA[col]:(colptrA[col+1]-1)
+                rowA = rowvalA[r]
+                if minrow <= rowA <= maxrow
+                    rowvalB[idxB] = Base._sub2ind(szA, rowA, col) - first(I) + 1
+                    nzvalB[idxB] = nzvalA[r]
+                    idxB += 1
+                end
             end
         end
-    end
-    if nnzB > (idxB-1)
-        deleteat!(nzvalB, idxB:nnzB)
-        deleteat!(rowvalB, idxB:nnzB)
+        if nnzB > (idxB-1)
+            deleteat!(nzvalB, idxB:nnzB)
+            deleteat!(rowvalB, idxB:nnzB)
+        end
     end
     @if_move_fixed A SparseVector(n, rowvalB, nzvalB)
 end

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -446,6 +446,15 @@ end
         @test isa(r1, SparseVector{Int64,UInt8})
         @test isa(r2, SparseMatrixCSC{Int64,UInt8})
     # end
+
+    @testset "empty sparse matrix indexing" begin
+        for k = 0:3
+            @test issparse(spzeros(k,0)[:])
+            @test isempty(spzeros(k,0)[:])
+            @test issparse(spzeros(0,k)[:])
+            @test isempty(spzeros(0,k)[:])
+        end
+    end
 end
 
 @testset "setindex" begin

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -290,6 +290,10 @@ end
             @test Array(r) == Array(x)[bIv]
         end
     end
+    @testset "index with colon" begin
+        @test issparse(spzeros(0)[:])
+        @test isempty(spzeros(0)[:])
+    end
 end
 @testset "setindex" begin
     let xc = spzeros(Float64, 8)


### PR DESCRIPTION
Co-authored-by: David Hien <david.hien@web.de>

Fixes ```spzeros(k,0)[:]``` and ```spzeros(0,k)[:]``` throwing errors or segmentation faults. 