### PR TITLE
Fix "no method matching" test

### DIFF
--- a/test/higherorderfns.jl
+++ b/test/higherorderfns.jl
@@ -670,7 +670,7 @@ using SparseArrays.HigherOrderFns: SparseVecStyle, SparseMatStyle
     end
     @test err isa MethodError
     @test !occursin("is ambiguous", sprint(showerror, err))
-    @test occursin("no method matching for call to _copy(::typeof(rand))", sprint(showerror, err))
+    @test err.f === SparseArrays.HigherOrderFns._copy
 end
 
 @testset "Sparse outer product, for type $T and vector $op" for

--- a/test/higherorderfns.jl
+++ b/test/higherorderfns.jl
@@ -670,7 +670,7 @@ using SparseArrays.HigherOrderFns: SparseVecStyle, SparseMatStyle
     end
     @test err isa MethodError
     @test !occursin("is ambiguous", sprint(showerror, err))
-    @test occursin("no method matching _copy(::typeof(rand))", sprint(showerror, err))
+    @test occursin("no method matching for call to _copy(::typeof(rand))", sprint(showerror, err))
 end
 
 @testset "Sparse outer product, for type $T and vector $op" for


### PR DESCRIPTION
Right now we're thinking about changing the `MethodError` message. Unfortunately, this breaks a lot of tests, including this one. Discussion at https://github.com/JuliaLang/julia/pull/47369.

~~If the change below does happen, merge this PR afterwards.
https://github.com/JuliaLang/julia/pull/47369/commits/44367ce8fed017c1aee6a01fb273b12653e7f5c9~~