### PR TITLE
Optimize and improve dispatch to sort*

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2,7 +2,7 @@
 
 ### Common definitions
 
-import Base: sort, findall, copy!
+import Base: sort!, findall, copy!
 import LinearAlgebra: promote_to_array_type, promote_to_arrays_
 using LinearAlgebra: _SpecialArrays, _DenseConcatGroup
 
@@ -2123,15 +2123,15 @@ function _densifystarttolastnz!(x::SparseVector)
 end
 
 #sorting
-function sort(x::AbstractCompressedVector{Tv,Ti}; kws...) where {Tv,Ti}
-    allvals = push!(copy(nonzeros(x)),zero(Tv))
-    sinds = sortperm(allvals;kws...)
-    n,k = length(x),length(allvals)
-    z = findfirst(isequal(k),sinds)::Int
-    newnzind = Vector{Ti}(1:k-1)
-    newnzind[z:end] .+= n-k+1
-    newnzvals = allvals[deleteat!(sinds[1:k],z)]
-    typeof(x)(n,newnzind,newnzvals)
+function sort!(x::AbstractCompressedVector; kws...)
+    nz = nonzeros(x)
+    sort!(nz; kws...)
+    i = searchsortedfirst(nz, zero(eltype(x)); kws...)
+    I = nonzeroinds(x)
+    Base.require_one_based_indexing(x, nz, I)
+    I[1:i-1] .= 1:i-1
+    I[i:end] .= i+length(x)-length(nz):length(x)
+    x
 end
 
 function fkeep!(f, x::AbstractCompressedVector{Tv}) where Tv


### PR DESCRIPTION
Before:

```julia
julia> using SparseArrays, StableRNGs, BenchmarkTools

julia> x = sprand(StableRNG(8), 30, .1)
30-element SparseVector{Float64, Int64} with 2 stored entries:
  [6 ]  =  0.14869
  [25]  =  0.0341937

julia> sort!(x)
30-element SparseVector{Float64, Int64} with 25 stored entries:
  [6 ]  =  0.0
  [7 ]  =  0.0
  [8 ]  =  0.0
  [9 ]  =  0.0
        ⋮
  [26]  =  0.0
  [27]  =  0.0
  [28]  =  0.0
  [29]  =  0.0341937
  [30]  =  0.14869

julia> @btime sort(x) setup = (x = sprand(1000, .01));
  782.907 ns (10 allocations: 544 bytes)

julia> @btime sort!(x) setup = (x = sprand(1000, .01));
ERROR: `reinterpret` on sparse arrays is discontinued.
Try reinterpreting the value itself instead.

Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] reinterpret(#unused#::Type, A::SparseVector{Float64, Int64})
    @ SparseArrays ~/.julia/dev/julia_master/usr/share/julia/stdlib/v1.10/SparseArrays/src/abstractsparse.jl:79
  [3] uint_map!(v::SparseVector{Float64, Int64}, lo::Int64, hi::Int64, order::Base.Sort.Float.Right)
    @ Base.Sort ./sort.jl:1425
  [4] sort!(v::SparseVector{Float64, Int64}, lo::Int64, hi::Int64, ::Base.Sort.AdaptiveSortAlg, o::Base.Sort.Float.Right, t::Nothing)
    @ Base.Sort ./sort.jl:844
  [5] fpsort!(v::SparseVector{Float64, Int64}, a::Base.Sort.AdaptiveSortAlg, o::Base.Order.ForwardOrdering, t::Nothing)
    @ Base.Sort.Float ./sort.jl:1588
  [6] sort!
    @ ./sort.jl:1595 [inlined]
  [7] #sort!#11
    @ ./sort.jl:935 [inlined]
  [8] sort!
    @ ./sort.jl:928 [inlined]
  [9] var"##core#305"(x::SparseVector{Float64, Int64})
    @ Main ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:489
 [10] var"##sample#306"(::Tuple{}, __params::BenchmarkTools.Parameters)
    @ Main ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:495
 [11] _run(b::BenchmarkTools.Benchmark, p::BenchmarkTools.Parameters; verbose::Bool, pad::String, kwargs::Base.Pairs{Symbol, Integer, NTuple{4, Symbol}, NamedTuple{(:samples, :evals, :gctrial, :gcsample), Tuple{Int64, Int64, Bool, Bool}}})
    @ BenchmarkTools ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:99
 [12] #invokelatest#2
    @ ./essentials.jl:818 [inlined]
 [13] invokelatest
    @ ./essentials.jl:813 [inlined]
 [14] #run_result#45
    @ ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:34 [inlined]
 [15] run_result
    @ ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:34 [inlined]
 [16] run(b::BenchmarkTools.Benchmark, p::BenchmarkTools.Parameters; progressid::Nothing, nleaves::Float64, ndone::Float64, kwargs::Base.Pairs{Symbol, Integer, NTuple{5, Symbol}, NamedTuple{(:verbose, :samples, :evals, :gctrial, :gcsample), Tuple{Bool, Int64, Int64, Bool, Bool}}})
    @ BenchmarkTools ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:117
 [17] run (repeats 2 times)
    @ ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:117 [inlined]
 [18] #warmup#54
    @ ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:169 [inlined]
 [19] warmup(item::BenchmarkTools.Benchmark)
    @ BenchmarkTools ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:168
 [20] top-level scope
    @ ~/.julia/packages/BenchmarkTools/0owsb/src/execution.jl:575
```

After
```julia
julia> using SparseArrays, StableRNGs, BenchmarkTools

julia> x = sprand(StableRNG(8), 30, .1)
30-element SparseVector{Float64, Int64} with 2 stored entries:
  [6 ]  =  0.14869
  [25]  =  0.0341937

julia> sort!(x)
30-element SparseVector{Float64, Int64} with 2 stored entries:
  [29]  =  0.0341937
  [30]  =  0.14869

julia> @btime sort(x) setup = (x = sprand(1000, .01));
  161.197 ns (2 allocations: 128 bytes)

julia> @btime sort!(x) setup = (x = sprand(1000, .01));
  26.352 ns (0 allocations: 0 bytes)
```
Tests are on Julia master.