### PR TITLE
Restrict SparseQ mul to avoid ambiguity with LinAlg

### DIFF
--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -288,7 +288,7 @@ function LinearAlgebra.rmul!(A::StridedMatrix, adjQ::AdjQType{<:Any,<:QRSparseQ}
     return A
 end
 
-function (*)(Q::QRSparseQ, b::AbstractVector)
+function (*)(Q::QRSparseQ, b::StridedVector) # TODO: relax to AbstractVector
     TQb = promote_type(eltype(Q), eltype(b))
     QQ = convert(AbstractQType{TQb}, Q)
     if size(Q.factors, 1) == length(b)


### PR DESCRIPTION
Follow-up to #203. Without the restriction, multiplication is ambiguous with a method from `LinearAlgebra`. This can be relaxes once https://github.com/JuliaLang/julia/pull/46196 is merged.