### PR TITLE
document rfn argument of sprand

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1888,14 +1888,24 @@ function sparse_sortedlinearindices!(I::Vector{Ti}, V::Vector, m::Int, n::Int) w
 end
 
 """
-    sprand([rng],[type],m,[n],p::AbstractFloat,[rfn])
+    sprand([rng],[T::Type],m,[n],p::AbstractFloat)
+    sprand([rng],m,[n],p::AbstractFloat,[rfn=rand])
 
 Create a random length `m` sparse vector or `m` by `n` sparse matrix, in
 which the probability of any element being nonzero is independently given by
-`p` (and hence the mean density of nonzeros is also exactly `p`). Nonzero
-values are sampled from the distribution specified by `rfn` and have the type `type`. The uniform
-distribution is used in case `rfn` is not specified. The optional `rng`
-argument specifies a random number generator, see [Random Numbers](@ref).
+`p` (and hence the mean density of nonzeros is also exactly `p`).
+The optional `rng` argument specifies a random number generator, see [Random Numbers](@ref).
+The optional `T` argument specifies the element type, which defaults to `Float64`.
+
+By default, nonzero values are sampled from a uniform distribution using
+the [`rand`](@ref) function, i.e. by `rand(T)`, or `rand(rng, T)` if `rng`
+is supplied; for the default `T=Float64`, this corresponds to nonzero values
+sampled uniformly in `[0,1)`.
+
+You can sample nonzero values from a different distribution by passing a
+custom `rfn` function instead of `rand`.   This should be a function `rfn(n)`
+that returns an array of `n` random numbers sampled from the desired distribution;
+alternatively, if `rng` is supplied, it should be a function `rfn(rng, n)`.
 
 # Examples
 ```jldoctest; setup = :(using Random; Random.seed!(1234))

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1903,9 +1903,9 @@ is supplied; for the default `T=Float64`, this corresponds to nonzero values
 sampled uniformly in `[0,1)`.
 
 You can sample nonzero values from a different distribution by passing a
-custom `rfn` function instead of `rand`.   This should be a function `rfn(n)`
-that returns an array of `n` random numbers sampled from the desired distribution;
-alternatively, if `rng` is supplied, it should be a function `rfn(rng, n)`.
+custom `rfn` function instead of `rand`.   This should be a function `rfn(k)`
+that returns an array of `k` random numbers sampled from the desired distribution;
+alternatively, if `rng` is supplied, it should instead be a function `rfn(rng, k)`.
 
 # Examples
 ```jldoctest; setup = :(using Random; Random.seed!(1234))


### PR DESCRIPTION
I noticed that the `rfn` argument of `sprand` was poorly documented:

1. We didn't say what its arguments should be.
2. We didn't say clearly that it defaults to `rand`
3. The type `T` argument goes in a different place if `rfn` is passed.   Moreover, although in this case you can pass `T` as the *last* argument, it seems that it doesn't really work — if it doesn't match the return type of `rfn`, it is ignored!  So, it seems better to leave that undocumented for now until we decide what to do with it.