### PR TITLE
Fix `show` of `QRSparseQ`

### DIFF
--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -358,8 +358,10 @@ function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, F::QRSparse)
     show(io, mime, F.pcol)
 end
 # TODO: remove once the AdjointQ PR is merged
-function Base.show(io::IO, ::MIME{Symbol("text/plain")}, Q::QRSparseQ)
-    print(io, Base.dims2string(size(Q)), ' ', summary(Q))
+if QRSparseQ <: AbstractMatrix
+    function Base.show(io::IO, ::MIME{Symbol("text/plain")}, Q::QRSparseQ)
+        summary(io, Q)
+    end
 end
 
 """

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -6,7 +6,7 @@ using Test
 using SparseArrays.SPQR
 using SparseArrays.CHOLMOD
 using LinearAlgebra: I, istriu, norm, qr, rank, rmul!, lmul!, Adjoint, Transpose, ColumnNorm, RowMaximum, NoPivot
-using SparseArrays: sparse, sprandn, spzeros, SparseMatrixCSC
+using SparseArrays: SparseArrays, sparse, sprandn, spzeros, SparseMatrixCSC
 
 if Base.USE_GPL_LIBS
 

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -16,6 +16,8 @@ nn = 100
 
 @test size(qr(sprandn(m, n, 0.1)).Q) == (m, m)
 
+@test repr("text/plain", qr(sprandn(4, 4, 0.5)).Q) == "4×4 $(SparseArrays.SPQR.QRSparseQ{Float64, Int})"
+
 @testset "element type of A: $eltyA" for eltyA in (Float64, ComplexF64)
     if eltyA <: Real
         A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], randn(nn), m, n)


### PR DESCRIPTION
I don't know why this didn't come up earlier, but the size of the Q factor was missing. This now popped up in https://github.com/JuliaLang/julia/pull/46196. It can be removed once that one is merged, and then fall back to the generic `show` method defined there.