### PR TITLE
Specialize multiplication of AbstractQ with sparse arrays

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -469,6 +469,11 @@ function _show_with_braille_patterns(io::IO, S::AbstractSparseMatrixCSCInclAdjoi
     foreach(c -> print(io, Char(c)), @view brailleGrid[1:end-1])
 end
 
+(*)(Q::AbstractQ, B::AbstractSparseMatrixCSC) = Q * Matrix(B)
+(*)(Q::AbstractQ, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = Q * copy(B)
+(*)(A::AbstractSparseMatrixCSC, Q::AbstractQ) = Matrix(A) * Q
+(*)(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, Q::AbstractQ) = copy(A) * Q
+
 ## Reshape
 
 function sparse_compute_reshaped_colptr_and_rowval!(colptrS::Vector{Ti}, rowvalS::Vector{Ti},

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1292,6 +1292,9 @@ end
 # zero-preserving functions (z->z, nz->nz)
 -(x::SparseVector) = SparseVector(length(x), copy(nonzeroinds(x)), -nonzeros(x))
 
+(*)(Q::AbstractQ, B::AbstractSparseVector) = Q * Vector(B)
+(*)(A::AbstractSparseVector, Q::AbstractQ) = Vector(A) * Q
+
 # functions f, such that
 #   f(x) can be zero or non-zero when x != 0
 #   f(x) = 0 when x == 0

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -152,6 +152,12 @@ end
     perm = inv(Matrix(I, size(A)...)[q.prow, :])
     f = sum(q.R; dims=2) ./ sum(Dq.R; dims=2)
     @test perm * (transpose(f) .* sQ) ≈ sparse(Dq.Q)
+    v, V = sprandn(100, 0.01), sprandn(100, 100, 0.01)
+    @test Dq.Q * v ≈ Matrix(Dq.Q) * v
+    @test Dq.Q * V ≈ Matrix(Dq.Q) * V
+    @test Dq.Q * V' ≈ Matrix(Dq.Q) * V'
+    @test V * Dq.Q ≈ V * Matrix(Dq.Q)
+    @test V' * Dq.Q ≈ V' * Matrix(Dq.Q)
 end
 
 @testset "no strategies" begin


### PR DESCRIPTION
It turns out that in a few packages (in particular optimization-related ones) there is multiplication of `AbstractQ` instances and `SparseArray`s. Due to a lack of specialization, this falls back to `_generic_matmatmul!`, which is horrible for at least three reasons: (1) it's computing the elements of the matrix representation of `Q` one-by-one; (2) it doesn't use sparsity at all; and (3) it writes the dense result into an empty sparse output array. I have a hard time imagining anything worse than that. This popped up once we drop `AbstractQ <: AbstractMatrix` subtyping, see https://github.com/JuliaLang/julia/pull/46196.