### PR TITLE
Restrict AbstractQ multiplication to LinearAlgebra types

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -9,7 +9,8 @@ using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
     require_one_based_indexing, promote_eltype
 using Base.Order: Forward
 using LinearAlgebra
-using LinearAlgebra: AdjOrTrans, matprod, AbstractQ
+using LinearAlgebra: AdjOrTrans, matprod, AbstractQ, HessenbergQ, QRCompactWYQ, QRPackedQ,
+    LQPackedQ
 
 
 import Base: +, -, *, \, /, &, |, xor, ==, zero, @propagate_inbounds
@@ -30,6 +31,10 @@ export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm,
     sprand, sprandn, spzeros, nnz, permute, findnz,  fkeep!, ftranspose!,
     sparse_hcat, sparse_vcat, sparse_hvcat
+
+const AdjQType = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ : Adjoint
+
+const LinAlgLeftQs = Union{HessenbergQ,QRCompactWYQ,QRPackedQ}
 
 # helper function needed in sparsematrix, sparsevector and higherorderfns
 # `iszero` and `!iszero` don't guarantee to return a boolean but we need one that does

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -8,7 +8,6 @@ using LinearAlgebra
 using LinearAlgebra: AbstractQ, copy_similar
 using ..LibSuiteSparse: SuiteSparseQR_C
 
-const AdjQType = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ : Adjoint
 const AbstractQType = isdefined(LinearAlgebra, :AdjointQ) ? AbstractQ : AbstractMatrix
 
 # ordering options */
@@ -32,7 +31,7 @@ const ORDERINGS = [ORDERING_FIXED, ORDERING_NATURAL, ORDERING_COLAMD, ORDERING_C
 # the best of AMD and METIS. METIS is not tried if it isn't installed.
 
 using ..SparseArrays
-using ..SparseArrays: getcolptr, FixedSparseCSC, AbstractSparseMatrixCSC, _unsafe_unfix
+using ..SparseArrays: getcolptr, FixedSparseCSC, AbstractSparseMatrixCSC, _unsafe_unfix, AdjQType
 using ..CHOLMOD
 using ..CHOLMOD: change_stype!, free!
 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -469,10 +469,17 @@ function _show_with_braille_patterns(io::IO, S::AbstractSparseMatrixCSCInclAdjoi
     foreach(c -> print(io, Char(c)), @view brailleGrid[1:end-1])
 end
 
-(*)(Q::AbstractQ, B::AbstractSparseMatrixCSC) = Q * Matrix(B)
-(*)(Q::AbstractQ, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = Q * copy(B)
-(*)(A::AbstractSparseMatrixCSC, Q::AbstractQ) = Matrix(A) * Q
-(*)(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, Q::AbstractQ) = copy(A) * Q
+for QT in (:LinAlgLeftQs, :LQPackedQ)
+    @eval (*)(Q::$QT, B::AbstractSparseMatrixCSC) = Q * Matrix(B)
+    @eval (*)(Q::$QT, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = Q * copy(B)
+    @eval (*)(A::AbstractSparseMatrixCSC, Q::$QT) = Matrix(A) * Q
+    @eval (*)(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, Q::$QT) = copy(A) * Q
+
+    @eval (*)(Q::AdjQType{<:Any,<:$QT}, B::AbstractSparseMatrixCSC) = Q * Matrix(B)
+    @eval (*)(Q::AdjQType{<:Any,<:$QT}, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = Q * copy(B)
+    @eval (*)(A::AbstractSparseMatrixCSC, Q::AdjQType{<:Any,<:$QT}) = Matrix(A) * Q
+    @eval (*)(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, Q::AdjQType{<:Any,<:$QT}) = copy(A) * Q
+end
 
 ## Reshape
 

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1292,8 +1292,13 @@ end
 # zero-preserving functions (z->z, nz->nz)
 -(x::SparseVector) = SparseVector(length(x), copy(nonzeroinds(x)), -nonzeros(x))
 
-(*)(Q::AbstractQ, B::AbstractSparseVector) = Q * Vector(B)
-(*)(A::AbstractSparseVector, Q::AbstractQ) = Vector(A) * Q
+for QT in (:LinAlgLeftQs, :LQPackedQ)
+    @eval (*)(Q::$QT, B::AbstractSparseVector) = Q * Vector(B)
+    @eval (*)(Q::AdjQType{<:Any,<:$QT}, B::AbstractSparseVector) = Q * Vector(B)
+
+    @eval (*)(A::AbstractSparseVector, Q::$QT) = Vector(A) * Q
+    @eval (*)(A::AbstractSparseVector, Q::AdjQType{<:Any,<:$QT}) = Vector(A) * Q
+end
 
 # functions f, such that
 #   f(x) can be zero or non-zero when x != 0


### PR DESCRIPTION
The recent change in #317 is giving heavy ambiguity pain when tested on https://github.com/JuliaLang/julia/pull/46196, so I think it is much better to restrict to the `AbstractQ` subtypes owned by `LinearAlgebra`. Other packages providing `AbstractQ`s will need to define what to do when multiplying their Q with a sparse array.