### PR TITLE
Allow real adjoint cholmod solve with complex rhs

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1538,10 +1538,10 @@ end
 (\)(L::Factor{T}, B::Dense{T}) where {T<:VTypes} = solve(CHOLMOD_A, L, B)
 # Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl
 # Likewise the two following explicit Vector and Matrix defs (rather than a single VecOrMat)
-(\)(L::Factor{T}, B::Vector{Complex{T}}) where {T<:Float64} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Matrix{Complex{T}}) where {T<:Float64} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Adjoint{<:Any, <:Matrix{Complex{T}}}) where {T<:Float64} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Transpose{<:Any, <:Matrix{Complex{T}}}) where {T<:Float64} = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{Float64}, B::Vector{Complex{Float64}}) = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{Float64}, B::Matrix{Complex{Float64}}) = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{Float64}, B::Adjoint{<:Any,Matrix{Complex{Float64}}}) = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{Float64}, B::Transpose{<:Any,Matrix{Complex{Float64}}}) = complex.(L\real(B), L\imag(B))
 
 (\)(L::Factor{T}, b::StridedVector) where {T<:VTypes} = Vector(L\Dense{T}(b))
 (\)(L::Factor{T}, B::StridedMatrix) where {T<:VTypes} = Matrix(L\Dense{T}(B))
@@ -1559,6 +1559,10 @@ end
 \(adjL::AdjType{<:Any,<:Factor}, B::Sparse) = (L = adjL.parent; spsolve(CHOLMOD_A, L, B))
 \(adjL::AdjType{<:Any,<:Factor}, B::SparseVecOrMat) = (L = adjL.parent; \(adjoint(L), Sparse(B)))
 
+(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Vector{Complex{Float64}}) = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Matrix{Complex{Float64}}) = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Adjoint{<:Any,Matrix{Complex{Float64}}}) = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Transpose{<:Any,Matrix{Complex{Float64}}}) = complex.(adjL\real(B), adjL\imag(B))
 function \(adjL::AdjType{<:Any,<:Factor}, b::StridedVector)
     L = adjL.parent
     return Vector(solve(CHOLMOD_A, L, Dense(b)))

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -719,8 +719,16 @@ end
 
 @testset "Real factorization and complex rhs" begin
     A = sprandn(5, 5, 0.4) |> t -> t't + I
-    B = complex.(randn(5, 2), randn(5, 2))
+    B = complex.(randn(5, 5), randn(5, 5))
+    b = B[:,1]
+    @test cholesky(A)\b ≈ A\b
     @test cholesky(A)\B ≈ A\B
+    @test cholesky(A)\B' ≈ A\B'
+    @test cholesky(A)\transpose(B) ≈ A\transpose(B)
+    @test cholesky(A)'\b ≈ copy(A')\b
+    @test cholesky(A)'\B ≈ copy(A')\B
+    @test cholesky(A)'\B' ≈ copy(A')\B'
+    @test cholesky(A)'\transpose(B) ≈ copy(A')\transpose(B)
 end
 
 @testset "Make sure that ldlt performs an LDLt (Issue #19032)" begin


### PR DESCRIPTION
This extends the same behavior of `Factor` to adjoints of `Factor`s, and helps to prevent a potential method ambiguity in https://github.com/JuliaLang/julia/pull/46874.