### PR TITLE
Faster conversion to dense matrix

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -954,7 +954,7 @@ function Base.copyto!(M::Matrix{<:Number}, S::SparseMatrixCSC{T}) where T<:Numbe
     elseif length(M) >= length(S)
         m_view = view(M, 1:length(S))
         copyto!(m_view, S)
-        return m_view
+        return M
     else
         throw(BoundsError())
     end

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -949,12 +949,12 @@ end
 
 function Base.copyto!(M::Matrix, S::SparseMatrixCSC{T}) where T
     if size(M) == size(S)
-        fill!(M, 0)
+        fill!(M, zero(T))
     elseif size(M,1) >= size(S,1) && size(M,2) >= size(S,2)
         m_view = view(M, 1:size(S,1), 1:size(S,2))
         fill!(m_view, zero(T))
     else
-        throw(BoundsError)
+        throw(BoundsError())
     end
     return _copy_nonzeros_to!(M, S)
 end

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -950,7 +950,7 @@ function _copy_nonzeros_to!(A::Array, S::SparseMatrixCSC)
 end
 
 function Base.copyto!(A::Array{T}, S::SparseMatrixCSC{<:Number}) where {T<:Number}
-    isempty(S) && return M
+    isempty(S) && return A
     length(A) < length(S) && throw(BoundsError())
     
     # Zero elements that are also in S, don't change rest of A 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -950,7 +950,7 @@ function Base.copyto!(M::Matrix{<:Number}, S::SparseMatrixCSC{T}) where T<:Numbe
     isempty(S) && return M
     if size(M) == size(S)
         fill!(M, zero(T))
-        _copy_nonzeros_to!(M, S)
+        return _copy_nonzeros_to!(M, S)
     elseif length(M) >= length(S)
         m_view = view(M, 1:length(S))
         copyto!(m_view, S)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -945,8 +945,8 @@ function Base.copyto!(A::Array{T}, S::SparseMatrixCSC{<:Number}) where {T<:Numbe
     colptr = getcolptr(S)
     rowval = getrowval(S)
     nzval = getnzval(S)
-    for col in 1:length(colptr)-1
-        for i in colptr[col]:(colptr[col+1]-1)
+    for col in 1:size(S, 2)
+        for i in nzrange(S, col)
             row = rowval[i]
             val = nzval[i]
             linear_index = num_rows*(col-1)+row

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -36,7 +36,7 @@ end
     @test SparseMatrixCSC{eltype(a), Int}(a) == a
     @test SparseMatrixCSC{eltype(a)}(Array(a)) == a
     @test Array(SparseMatrixCSC{eltype(a), Int8}(a)) == Array(a)
-    @test convert(a) == a
+    @test collect(a) == a
 end
 
 @testset "sparse matrix construction" begin

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -36,6 +36,7 @@ end
     @test SparseMatrixCSC{eltype(a), Int}(a) == a
     @test SparseMatrixCSC{eltype(a)}(Array(a)) == a
     @test Array(SparseMatrixCSC{eltype(a), Int8}(a)) == Array(a)
+    @test convert(a) == a
 end
 
 @testset "sparse matrix construction" begin

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -302,7 +302,8 @@ end
 @testset "copyto!" begin
     A = sprand(5, 5, 0.2)
     B = sprand(5, 5, 0.2)
-    copyto!(A, B)
+    Ar = copyto!(A, B)
+    @test Ar === A
     @test A == B
     @test pointer(nonzeros(A)) != pointer(nonzeros(B))
     @test pointer(rowvals(A)) != pointer(rowvals(B))
@@ -340,7 +341,9 @@ end
     B = sprand(5, 5, 1.0)
     A = rand(5,5)
     A´ = similar(A)
-    @test copyto!(A, B) == copyto!(A´, Matrix(B))
+    Ac = copyto!(A, B)
+    @test Ac === A 
+    @test A == copyto!(A´, Matrix(B))
     # Test copyto!(dense, Rdest, sparse, Rsrc)
     A = rand(5,5)
     A´ = similar(A)
@@ -355,11 +358,15 @@ end
     @test Matrix(B´)[Rdest] == Matrix(B)[Rsrc]
     # Test that only elements at overlapping linear indices are overwritten
     A = sprand(3, 3, 1.0); B = ones(4, 4)
-    copyto!(B, A)
+    Bc = copyto!(B, A)
     @test B[4, :] != B[:, 4] == ones(4)
+    @test Bc === B
     # Allow no-op copyto! with empty source even for incompatible eltypes
     A = sparse(fill("", 0, 0))
     @test copyto!(B, A) == B
+
+    # Test correct error for too small destination array
+    @test_throws BoundsError copyto!(rand(2,2), sprand(3,3,0.2))
 end
 
 @testset "getindex" begin

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -59,7 +59,7 @@ end
         @test isa(Array(x), Vector{Float64})
         @test Array(x) == xf
         @test Vector(x) == xf
-        @test convert(x) == xf
+        @test collect(x) == xf
     end
 end
 @testset "show" begin

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -59,6 +59,7 @@ end
         @test isa(Array(x), Vector{Float64})
         @test Array(x) == xf
         @test Vector(x) == xf
+        @test convert(x) == xf
     end
 end
 @testset "show" begin


### PR DESCRIPTION
Ref #312 @ViralBShah 
(I also added a test to cover the `collect` - calls)

```julia
using SparseArrays, BenchmarkTools
for n in [16^i for i in 1:3]
    print("n = $n: ")
    sm = sprand(n, n, 0.2)
    @btime collect($sm)
end
# main
n = 16:   367.136 ns (1 allocation: 2.12 KiB)
n = 256:   64.300 μs (2 allocations: 512.05 KiB)
n = 4096:   45.581 ms (2 allocations: 128.00 MiB)
# PR
n = 16:   261.872 ns (1 allocation: 2.12 KiB)
n = 256:   23.200 μs (2 allocations: 512.05 KiB)
n = 4096:   27.871 ms (2 allocations: 128.00 MiB)
```
Edit: Benchmark updated for changing `copyto!` instead

<details>
<summary>versioninfo</summary>

```julia
Julia Version 1.8.5
Commit 17cfb8e65e (2023-01-08 06:45 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: 8 × 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, tigerlake)
  Threads: 1 on 8 virtual cores
Environment:
  JULIA_PKG_OFFLINE = false
  JULIA_PKG_USE_CLI_GIT = true
```
</details>