### PR TITLE
Replace AbstractTriangular by UpperOrLowerTriangular

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -10,7 +10,7 @@ using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
 using Base.Order: Forward
 using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, matprod, AbstractQ, HessenbergQ, QRCompactWYQ, QRPackedQ,
-    LQPackedQ
+    LQPackedQ, UpperOrLowerTriangular
 
 
 import Base: +, -, *, \, /, &, |, xor, ==, zero, @propagate_inbounds

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -369,7 +369,7 @@ const WrapperMatrixTypes{T,MT} = Union{
     SubArray{T,2,MT},
     Adjoint{T,MT},
     Transpose{T,MT},
-    AbstractTriangular{T,MT},
+    UpperOrLowerTriangular{T,MT},
     UpperHessenberg{T,MT},
     Symmetric{T,MT},
     Hermitian{T,MT},

--- a/src/sparseconvert.jl
+++ b/src/sparseconvert.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import LinearAlgebra: AbstractTriangular
-
 """
     SparseMatrixCSCSymmHerm
 
@@ -10,10 +8,10 @@ import LinearAlgebra: AbstractTriangular
 const SparseMatrixCSCSymmHerm{Tv,Ti} = Union{Symmetric{Tv,<:SparseMatrixCSCUnion{Tv,Ti}},
                                             Hermitian{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}}
 
-const AbstractTriangularSparse{Tv,Ti} = AbstractTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
+const AbstractTriangularSparse{Tv,Ti} = UpperOrLowerTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
 
-# converting Symmetric/Hermitian/AbstractTriangular/SubArray of SparseMatrixCSC
-# and Transpose/Adjoint of AbstractTriangular of SparseMatrixCSC to SparseMatrixCSC
+# converting Symmetric/Hermitian/Triangular/SubArray of SparseMatrixCSC
+# and Transpose/Adjoint of Triangular of SparseMatrixCSC to SparseMatrixCSC
 for wr in (Symmetric, Hermitian, Transpose, Adjoint,
            UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular,
            SubArray)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1192,7 +1192,7 @@ const _SparseConcatArrays = Union{_SpecialArrays, _SparseArrays}
 
 const _Symmetric_SparseConcatArrays{T,A<:_SparseConcatArrays} = Symmetric{T,A}
 const _Hermitian_SparseConcatArrays{T,A<:_SparseConcatArrays} = Hermitian{T,A}
-const _Triangular_SparseConcatArrays{T,A<:_SparseConcatArrays} = LinearAlgebra.AbstractTriangular{T,A}
+const _Triangular_SparseConcatArrays{T,A<:_SparseConcatArrays} = UpperOrLowerTriangular{T,A}
 const _Annotated_SparseConcatArrays = Union{_Triangular_SparseConcatArrays, _Symmetric_SparseConcatArrays, _Hermitian_SparseConcatArrays}
 # It's important that _SparseConcatGroup is a larger union than _DenseConcatGroup to make
 # sparse cat-methods less specific and to kick in only if there is some sparse array present


### PR DESCRIPTION
This will allow to push https://github.com/JuliaLang/julia/pull/26307 across the finish line. I don't think the intention here was really `AbstractTriangular`, but that the intention was to refer to the LinAlg types, which is exactly what `UpperOrLowerTriangular` is referring to.