### PR TITLE
Fix bug where non-order keyword arguments are passed from `sort!` to `searchsortedfirst`

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1064,7 +1064,7 @@ function Vector(x::AbstractSparseVector{Tv}) where Tv
     return r
 end
 Array(x::AbstractSparseVector) = Vector(x)
-    
+
 function Base.collect(x::Union{AbstractSparseVector,AbstractSparseMatrix})
    if Base.has_offset_axes(x)
        return Base._collect_indices(axes(x), x)
@@ -2138,11 +2138,14 @@ function _densifystarttolastnz!(x::SparseVector)
     x
 end
 
-#sorting
+#sorting TODO: integrate with `Base.Sort.IEEEFloatOptimization`'s partitioning by zero
+searchsortedfirst_discard_keywords(v::AbstractVector, x; lt=isless, by=identity,
+    rev::Union{Bool,Nothing}=nothing, order::Base.Order.Ordering=Forward, kws...) =
+        searchsortedfirst(v,x,Base.Order.ord(lt,by,rev,order))
 function sort!(x::AbstractCompressedVector; kws...)
     nz = nonzeros(x)
     sort!(nz; kws...)
-    i = searchsortedfirst(nz, zero(eltype(x)); kws...)
+    i = searchsortedfirst_discard_keywords(nz, zero(eltype(x)); kws...)
     I = nonzeroinds(x)
     Base.require_one_based_indexing(x, nz, I)
     I[1:i-1] .= 1:i-1

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -783,6 +783,11 @@ g12063() = f12063(0, 0, 0, 0, 0, 0, 0.0, spzeros(0,0), Int[])
     @test String(take!(io)) == "transpose(sparse([1, 2, 1, 2], [1, 1, 2, 2], [1, 3, 2, 4], 2, 2))"
 end
 
+@testset "Issue #334" begin
+    x = sprand(10, .3);
+    @test issorted(sort!(x; alg=Base.DEFAULT_STABLE));
+end
+
 end # SparseTestsBase
 
 end # module

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -786,6 +786,7 @@ end
 @testset "Issue #334" begin
     x = sprand(10, .3);
     @test issorted(sort!(x; alg=Base.DEFAULT_STABLE));
+    @test_throws MethodError sort!(x; banana=:blue); # From discussion at #335
 end
 
 end # SparseTestsBase


### PR DESCRIPTION
Silently ignore unrecognized keywords when finding the first index of zero. If stray keywords are passed, they will still cause the inner `sort!` to throw.

Fixes #334

Backport because I introduced this bug in 1.9 in #303.