### PR TITLE
Obviate future ambiguities in adjoint cholmod solves

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1580,15 +1580,17 @@ end
 \(adjL::AdjType{<:Any,<:Factor}, B::Sparse) = (L = adjL.parent; spsolve(CHOLMOD_A, L, B))
 \(adjL::AdjType{<:Any,<:Factor}, B::SparseVecOrMat) = (L = adjL.parent; \(adjoint(L), Sparse(B)))
 
-(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Vector{Complex{Float64}}) = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Matrix{Complex{Float64}}) = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Adjoint{<:Any,Matrix{Complex{Float64}}}) = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjType{Float64,Factor{Float64}}, B::Transpose{<:Any,Matrix{Complex{Float64}}}) = complex.(adjL\real(B), adjL\imag(B))
-function \(adjL::AdjType{<:Any,<:Factor}, b::StridedVector)
+# Explicit typevars are necessary to avoid ambiguities with defs in LinearAlgebra/factorizations.jl
+# Likewise the two following explicit Vector and Matrix defs (rather than a single VecOrMat)
+(\)(adjL::AdjType{T,<:Factor}, B::Vector{Complex{T}}) where {T<:Float64} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjType{T,<:Factor}, B::Matrix{Complex{T}}) where {T<:Float64} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjType{T,<:Factor}, B::Adjoint{<:Any,Matrix{Complex{T}}}) where {T<:Float64} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjType{T,<:Factor}, B::Transpose{<:Any,Matrix{Complex{T}}}) where {T<:Float64} = complex.(adjL\real(B), adjL\imag(B))
+function \(adjL::AdjType{<:VTypes,<:Factor}, b::StridedVector)
     L = adjL.parent
     return Vector(solve(CHOLMOD_A, L, Dense(b)))
 end
-function \(adjL::AdjType{<:Any,<:Factor}, B::StridedMatrix)
+function \(adjL::AdjType{<:VTypes,<:Factor}, B::StridedMatrix)
     L = adjL.parent
     return Matrix(solve(CHOLMOD_A, L, Dense(B)))
 end


### PR DESCRIPTION
This adds explicit typevars to the adjoint cholmod solves as we have them for plain cholmod solves. This )(hopefully) prevents method ambiguities in https://github.com/JuliaLang/julia/pull/46874.