### PR TITLE
float(S) and complex(S) should not copy data unnecessarily

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -970,8 +970,8 @@ convert(T::Type{<:LowerTriangular}, m::AbstractSparseMatrixCSC) = m isa T ? m :
 convert(T::Type{<:UpperTriangular}, m::AbstractSparseMatrixCSC) = m isa T ? m :
     istriu(m) ? T(m) : throw(ArgumentError("matrix cannot be represented as UpperTriangular"))
 
-float(S::SparseMatrixCSC) = SparseMatrixCSC(size(S, 1), size(S, 2), copy(getcolptr(S)), copy(rowvals(S)), float.(nonzeros(S)))
-complex(S::SparseMatrixCSC) = SparseMatrixCSC(size(S, 1), size(S, 2), copy(getcolptr(S)), copy(rowvals(S)), complex(copy(nonzeros(S))))
+float(S::SparseMatrixCSC) = SparseMatrixCSC(size(S, 1), size(S, 2), getcolptr(S), rowvals(S), float(nonzeros(S)))
+complex(S::SparseMatrixCSC) = SparseMatrixCSC(size(S, 1), size(S, 2), getcolptr(S), rowvals(S), complex(nonzeros(S)))
 
 """
     sparse(A)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1086,11 +1086,11 @@ copy(x::AbstractSparseVector) = if _is_fixed(x)
 
 float(x::AbstractSparseVector{<:AbstractFloat}) = x
 float(x::AbstractSparseVector) =
-    SparseVector(length(x), copy(nonzeroinds(x)), float(nonzeros(x)))
+    SparseVector(length(x), nonzeroinds(x), float(nonzeros(x)))
 
 complex(x::AbstractSparseVector{<:Complex}) = x
 complex(x::AbstractSparseVector) =
-    SparseVector(length(x), copy(nonzeroinds(x)), complex(nonzeros(x)))
+    SparseVector(length(x), nonzeroinds(x), complex(nonzeros(x)))
 
 
 ### Concatenation


### PR DESCRIPTION
I noticed that `float(S)` and `complex(S)` always copy the data, including the index arrays.   I don't think this should be the default, since these methods in `Base` share storage if possible:
```jl
julia> x = rand(ComplexF64, 3); float(x) === x
true

julia> x = rand(ComplexF64, 3); complex(x) === x
true
```
If the caller needs to make a copy of the array, they can do `float.(S)` or `copy(float(S))`.

(It was also inconsistent, because `float` of a sparse *vector* did *not* make a copy of the nonzeros if they were already of a floating-point type, e.g. `ComplexF64`, but *did* copy the indices.)