### PR TITLE
Resolve `kron` ambiguities

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1380,11 +1380,25 @@ end
     end
     return z
 end
-# due to the sparse result type, there is no risk to override dense ⊗ dense here
-@inline function kron!(C::SparseMatrixCSC, A::Union{_SparseKronGroup,_DenseConcatGroup}, B::Union{_SparseKronGroup,_DenseConcatGroup})
+@inline function kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_DenseConcatGroup)
+    kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
+end
+@inline function kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::Diagonal) # disambiguation
+    kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
+end
+@inline function kron!(C::SparseMatrixCSC, A::_DenseConcatGroup, B::_SparseKronGroup)
+    kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
+end
+@inline function kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_SparseKronGroup)
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
 end
 kron!(C::SparseMatrixCSC, A::SparseVectorUnion, B::AdjOrTransSparseVectorUnion) = broadcast!(*, C, A, B)
+# disambiguation
+@inline function kron!(C::SparseMatrixCSC, A::Diagonal, B::_SparseKronGroup)
+    kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
+end
+kron!(c::SparseMatrixCSC, a::Number, b::_SparseKronGroup) = mul!(c, a, b)
+kron!(c::SparseMatrixCSC, a::_SparseKronGroup, b::Number) = mul!(c, a, b)
 
 function kron(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)
     mA, nA = size(A)
@@ -1410,6 +1424,9 @@ kron(A::_SparseKronGroup, B::_SparseKronGroup) =
 kron(A::_SparseKronGroup, B::_DenseConcatGroup) = kron(A, sparse(B))
 kron(A::_DenseConcatGroup, B::_SparseKronGroup) = kron(sparse(A), B)
 kron(A::SparseVectorUnion, B::AdjOrTransSparseVectorUnion) = A .* B
+# disambiguation
+kron(a::Number, b::_SparseKronGroup) = a * b
+kron(a::_SparseKronGroup, b::Number) = a * b
 
 ## det, inv, cond
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1380,23 +1380,19 @@ end
     end
     return z
 end
-@inline function kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_DenseConcatGroup)
+kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_DenseConcatGroup) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
-end
-@inline function kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::Diagonal) # disambiguation
+kron!(C::SparseMatrixCSC, A::_DenseConcatGroup, B::_SparseKronGroup) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
-end
-@inline function kron!(C::SparseMatrixCSC, A::_DenseConcatGroup, B::_SparseKronGroup)
+kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_SparseKronGroup) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
-end
-@inline function kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_SparseKronGroup)
-    kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
-end
-kron!(C::SparseMatrixCSC, A::SparseVectorUnion, B::AdjOrTransSparseVectorUnion) = broadcast!(*, C, A, B)
+kron!(C::SparseMatrixCSC, A::SparseVectorUnion, B::AdjOrTransSparseVectorUnion) =
+    broadcast!(*, C, A, B)
 # disambiguation
-@inline function kron!(C::SparseMatrixCSC, A::Diagonal, B::_SparseKronGroup)
+kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::Diagonal) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
-end
+kron!(C::SparseMatrixCSC, A::Diagonal, B::_SparseKronGroup) =
+    kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
 kron!(c::SparseMatrixCSC, a::Number, b::_SparseKronGroup) = mul!(c, a, b)
 kron!(c::SparseMatrixCSC, a::_SparseKronGroup, b::Number) = mul!(c, a, b)
 

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1576,7 +1576,8 @@ end
 (\)(L::Factor, B::Transpose{<:Any,<:SparseMatrixCSC}) = L \ copy(B)
 (\)(L::Factor, B::SparseVector) = sparsevec(spsolve(CHOLMOD_A, L, Sparse(B)))
 
-\(adjL::AdjType{<:Any,<:Factor}, B::Dense) = (L = adjL.parent; solve(CHOLMOD_A, L, B))
+# the eltype restriction is necessary for disambiguation with the B::StridedMatrix below
+\(adjL::AdjType{<:VTypes,<:Factor}, B::Dense) = (L = adjL.parent; solve(CHOLMOD_A, L, B))
 \(adjL::AdjType{<:Any,<:Factor}, B::Sparse) = (L = adjL.parent; spsolve(CHOLMOD_A, L, B))
 \(adjL::AdjType{<:Any,<:Factor}, B::SparseVecOrMat) = (L = adjL.parent; \(adjoint(L), Sparse(B)))
 

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -2,6 +2,7 @@
 using Test, LinearAlgebra, SparseArrays
 @testset "detect_ambiguities" begin
     @test_nowarn detect_ambiguities(SparseArrays; recursive=true, ambiguous_bottom=false)
+    @test_nowarn detect_ambiguities(LinearAlgebra; recursive=true, ambiguous_bottom=false)
 end
 
 ## This was the older version that was disabled

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -2,7 +2,6 @@
 using Test, LinearAlgebra, SparseArrays
 @testset "detect_ambiguities" begin
     @test_nowarn detect_ambiguities(SparseArrays; recursive=true, ambiguous_bottom=false)
-    @test_nowarn detect_ambiguities(LinearAlgebra; recursive=true, ambiguous_bottom=false)
 end
 
 ## This was the older version that was disabled


### PR DESCRIPTION
This is required to merge the recent `kron` changes into Julia Base. Includes now ambiguity testing of `LinearAlgebra`, after loading of `SparseArrays`.