### PR TITLE
CI needs to only run on julia master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
As discussed in https://github.com/JuliaSparse/SparseArrays.jl/pull/340#issuecomment-1419725472 