### PR TITLE
Clean up temporary fixes

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -9,8 +9,8 @@ using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
     require_one_based_indexing, promote_eltype
 using Base.Order: Forward
 using LinearAlgebra
-using LinearAlgebra: AdjOrTrans, matprod, AbstractQ, HessenbergQ, QRCompactWYQ, QRPackedQ,
-    LQPackedQ, UpperOrLowerTriangular
+using LinearAlgebra: AdjOrTrans, AdjointFactorization, TransposeFactorization, matprod,
+    AbstractQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ, UpperOrLowerTriangular
 
 
 import Base: +, -, *, \, /, &, |, xor, ==, zero, @propagate_inbounds
@@ -56,13 +56,6 @@ end
 decrement(A::AbstractArray) = let y = Array(A)
     y .= y .- oneunit(eltype(A))
 end
-
-AdjointFact = isdefined(LinearAlgebra, :AdjointFactorization) ?
-    LinearAlgebra.AdjointFactorization :
-    Adjoint
-TransposeFact = isdefined(LinearAlgebra, :TransposeFactorization) ?
-    LinearAlgebra.TransposeFactorization :
-    Transpose
 
 include("readonly.jl")
 include("abstractsparse.jl")

--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -10,7 +10,8 @@ using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
 using Base.Order: Forward
 using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, AdjointFactorization, TransposeFactorization, matprod,
-    AbstractQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ, UpperOrLowerTriangular
+    AbstractQ, AdjointQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ,
+    UpperOrLowerTriangular
 
 
 import Base: +, -, *, \, /, &, |, xor, ==, zero, @propagate_inbounds
@@ -31,8 +32,6 @@ export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm,
     sprand, sprandn, spzeros, nnz, permute, findnz,  fkeep!, ftranspose!,
     sparse_hcat, sparse_vcat, sparse_hvcat
-
-const AdjQType = isdefined(LinearAlgebra, :AdjointQ) ? LinearAlgebra.AdjointQ : Adjoint
 
 const LinAlgLeftQs = Union{HessenbergQ,QRCompactWYQ,QRPackedQ}
 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -475,10 +475,10 @@ for QT in (:LinAlgLeftQs, :LQPackedQ)
     @eval (*)(A::AbstractSparseMatrixCSC, Q::$QT) = Matrix(A) * Q
     @eval (*)(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, Q::$QT) = copy(A) * Q
 
-    @eval (*)(Q::AdjQType{<:Any,<:$QT}, B::AbstractSparseMatrixCSC) = Q * Matrix(B)
-    @eval (*)(Q::AdjQType{<:Any,<:$QT}, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = Q * copy(B)
-    @eval (*)(A::AbstractSparseMatrixCSC, Q::AdjQType{<:Any,<:$QT}) = Matrix(A) * Q
-    @eval (*)(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, Q::AdjQType{<:Any,<:$QT}) = copy(A) * Q
+    @eval (*)(Q::AdjointQ{<:Any,<:$QT}, B::AbstractSparseMatrixCSC) = Q * Matrix(B)
+    @eval (*)(Q::AdjointQ{<:Any,<:$QT}, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = Q * copy(B)
+    @eval (*)(A::AbstractSparseMatrixCSC, Q::AdjointQ{<:Any,<:$QT}) = Matrix(A) * Q
+    @eval (*)(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, Q::AdjointQ{<:Any,<:$QT}) = copy(A) * Q
 end
 
 ## Reshape

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1302,10 +1302,10 @@ end
 
 for QT in (:LinAlgLeftQs, :LQPackedQ)
     @eval (*)(Q::$QT, B::AbstractSparseVector) = Q * Vector(B)
-    @eval (*)(Q::AdjQType{<:Any,<:$QT}, B::AbstractSparseVector) = Q * Vector(B)
+    @eval (*)(Q::AdjointQ{<:Any,<:$QT}, B::AbstractSparseVector) = Q * Vector(B)
 
     @eval (*)(A::AbstractSparseVector, Q::$QT) = Vector(A) * Q
-    @eval (*)(A::AbstractSparseVector, Q::AdjQType{<:Any,<:$QT}) = Vector(A) * Q
+    @eval (*)(A::AbstractSparseVector, Q::AdjointQ{<:Any,<:$QT}) = Vector(A) * Q
 end
 
 # functions f, such that


### PR DESCRIPTION
This removes some temporary aliases related to `AdjointFactorization` (and prospectively `AdjointQ`).