### PR TITLE
Test code quality, resolve ambiguities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,15 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-SuiteSparse_jll = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+
+[compat]
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Dates", "InteractiveUtils", "Printf", "Test"]
+test = ["Aqua", "Dates", "InteractiveUtils", "Printf", "Test"]

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -76,6 +76,7 @@ issparse(A::DenseArray) = false
 issparse(S::AbstractSparseArray) = true
 
 indtype(S::AbstractSparseArray{<:Any,Ti}) where {Ti} = Ti
+indtype(T::UpperOrLowerTriangular{<:Any,<:AbstractSparseArray}) = indtype(parent(T))
 
 # The following two methods should be overloaded by concrete types to avoid
 # allocating the I = findall(...)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -170,13 +170,8 @@ const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti},SparseTriangular{Tv
 # The last is faster, if more than ≈ 1/32 of the result column is nonzero.
 # TODO: extend to SparseMatrixCSCUnion to allow for SubArrays (view(X, :, r)).
 function spmatmul(A::SparseOrTri, B::Union{SparseOrTri,SparseVectorUnion,SubArray{<:Any,<:Any,<:AbstractSparseArray}})
-    TvA = eltype(A)
-    TiA = indtype(A)
-    TvB = eltype(B)
-    TiB = indtype(B)
-
-    Tv = promote_op(matprod, TvA, TvB)
-    Ti = promote_type(TiA, TiB)
+    Tv = promote_op(matprod, eltype(A), eltype(B))
+    Ti = promote_type(indtype(A), indtype(B))
     mA, nA = size(A)
     nB = size(B, 2)
     nA == size(B, 1) || throw(DimensionMismatch())
@@ -1331,7 +1326,7 @@ const _SparseKronGroup = Union{_SparseKronArrays, _Annotated_SparseKronArrays}
 @inline function kron!(C::SparseMatrixCSC, A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)
     mA, nA = size(A); mB, nB = size(B)
     mC, nC = mA*mB, nA*nB
-    @boundscheck size(C) == (mC, nC) || throw(DimensionMismatch("target matrix needs to have size ($mC, $nC)," * 
+    @boundscheck size(C) == (mC, nC) || throw(DimensionMismatch("target matrix needs to have size ($mC, $nC)," *
         " but has size $(size(C))"))
     rowvalC = rowvals(C)
     nzvalC = nonzeros(C)

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -35,5 +35,8 @@ Base.copy(x::ReadOnly) = ReadOnly(copy(parent(x)))
 (==)(x::ReadOnly, y::AbstractVector) = parent(x) == y
 (==)(x::AbstractVector, y::ReadOnly) = x == parent(y)
 (==)(x::ReadOnly, y::ReadOnly) = parent(x) == parent(y)
+# disambiguation
+(==)(x::ReadOnly{T,1,<:AbstractVector{T}}, y::ReadOnly{S,1,<:AbstractVector{S}}) where {T,S} =
+    parent(x) == parent(y)
 
 Base.dataids(::ReadOnly) = tuple()

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -35,8 +35,5 @@ Base.copy(x::ReadOnly) = ReadOnly(copy(parent(x)))
 (==)(x::ReadOnly, y::AbstractVector) = parent(x) == y
 (==)(x::AbstractVector, y::ReadOnly) = x == parent(y)
 (==)(x::ReadOnly, y::ReadOnly) = parent(x) == parent(y)
-# disambiguation
-(==)(x::ReadOnly{T,1,<:AbstractVector{T}}, y::ReadOnly{S,1,<:AbstractVector{S}}) where {T,S} =
-    parent(x) == parent(y)
 
 Base.dataids(::ReadOnly) = tuple()

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -5,7 +5,7 @@ module SPQR
 import Base: \, *
 using Base: require_one_based_indexing
 using LinearAlgebra
-using LinearAlgebra: AbstractQ, AdjointQ, copy_similar
+using LinearAlgebra: AbstractQ, AdjointQ, AdjointAbsVec, copy_similar
 using ..LibSuiteSparse: SuiteSparseQR_C
 
 # ordering options */
@@ -322,6 +322,7 @@ function (*)(A::AbstractMatrix, adjQ::AdjointQ{<:Any,<:QRSparseQ})
         throw(DimensionMismatch("matrix A has dimensions $(size(A)) but Q-matrix has dimensions $(size(adjQ))"))
     end
 end
+(*)(u::AdjointAbsVec, Q::AdjointQ{<:Any,<:QRSparseQ}) = (Q'u')'
 
 (*)(Q::QRSparseQ, B::SparseMatrixCSC) = sparse(Q) * B
 (*)(A::SparseMatrixCSC, Q::QRSparseQ) = A * sparse(Q)

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -1,5 +1,33 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
-using Test, LinearAlgebra, SparseArrays
+using Test, LinearAlgebra, SparseArrays, Aqua
+
+@testset "code quality" begin
+    @testset "Method ambiguity" begin
+        # Aqua.test_ambiguities([SparseArrays, Base, Core])
+    end
+    @testset "Unbound type parameters" begin
+        @test_broken Aqua.detect_unbound_args_recursively(SparseArrays) == []
+    end
+    @testset "Undefined exports" begin
+        Aqua.test_undefined_exports(SparseArrays) == []
+    end
+    @testset "Compare Project.toml and test/Project.toml" begin
+        Aqua.test_project_extras(SparseArrays)
+    end
+    @testset "Stale dependencies" begin
+        Aqua.test_stale_deps(SparseArrays)
+    end
+    @testset "Compat bounds" begin
+        Aqua.test_deps_compat(SparseArrays)
+    end
+    @testset "Project.toml formatting" begin
+        Aqua.test_project_toml_formatting(SparseArrays)
+    end
+    @testset "Piracy" begin
+        @test_broken Aqua.Piracy.hunt(SparseArrays) == Method[]
+    end
+end
+
 @testset "detect_ambiguities" begin
     @test_nowarn detect_ambiguities(SparseArrays; recursive=true, ambiguous_bottom=false)
 end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -9,6 +9,9 @@ using SparseArrays: AbstractSparseVector, AbstractSparseMatrixCSC, FixedSparseCS
     @test r == v
     @test v == r
     @test r == r
+    @test ReadOnly([v v]) == ReadOnly([v r])
+    @test copy(r)::ReadOnly == r
+    @test ReadOnly(r) === r
     @test (resize!(r, length(r)); true)
     @test_throws ErrorException resize!(r, length(r) - 1)
     @test_throws ErrorException resize!(r, length(r) + 1)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -6,6 +6,9 @@ using SparseArrays: AbstractSparseVector, AbstractSparseMatrixCSC, FixedSparseCS
     v = randn(100)
     r = ReadOnly(v)
     @test length(r) == length(v)
+    @test r == v
+    @test v == r
+    @test r == r
     @test (resize!(r, length(r)); true)
     @test_throws ErrorException resize!(r, length(r) - 1)
     @test_throws ErrorException resize!(r, length(r) + 1)
@@ -19,7 +22,6 @@ struct_eq(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC) =
     getcolptr(A) == getcolptr(B) && rowvals(A) == rowvals(B)
 struct_eq(A::AbstractSparseVector, B::AbstractSparseVector) =
     nonzeroinds(A) == nonzeroinds(B)
-struct_eq(x, y, z...) = struct_eq(x, y) && (length(z) == 0 || struct_eq(y, z...))
 
 @testset "FixedSparseCSC" begin
     A = sprandn(10, 10, 0.3)

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -623,6 +623,12 @@ end
             @test isa(vcat(spv6464, SparseVector(0, Int32[], Int64[])), SparseVector{Int64,Int64})
             @test isa(vcat(spv6464, SparseVector(0, Int32[], Int32[])), SparseVector{Int64,Int64})
         end
+        @testset "horizontal concatenation of SparseVectors with different el- and ind-type (#22225)" begin
+            spv6464 = SparseVector(0, Int64[], Int64[])
+            @test isa(hcat(spv6464, SparseVector(0, Int64[], Int32[])), SparseMatrixCSC{Int64,Int64})
+            @test isa(hcat(spv6464, SparseVector(0, Int32[], Int64[])), SparseMatrixCSC{Int64,Int64})
+            @test isa(hcat(spv6464, SparseVector(0, Int32[], Int32[])), SparseMatrixCSC{Int64,Int64})
+        end
     end
 end
 @testset "sparsemat: combinations with sparse matrix" begin

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -44,6 +44,7 @@ nn = 100
         Imm = Matrix{Float64}(I, m, m)
         @test Q' * (Q*Imm) ≈ Imm
         @test (Imm*Q) * Q' ≈ Imm
+        @test ((Imm[:,1])' * Q')::Adjoint ≈ Q[:,1]'
 
         # test that Q'Pl*A*Pr = R
         R0 = Q'*Array(A[F.prow, F.pcol])


### PR DESCRIPTION
This resolves two ambiguities: comparison of `ReadOnly`s and adjoint vectors times AdjointQ's. This also adds code quality tests via `Aqua.jl`. The new ambiguity test is currently turned off, because it reports the `ReadOnly` ambiguity already existing in the sysimg. After this PR is merged and the stdlib bumped in Julia, the ambiguity test can be turned on. Some other, smaller changes were necessary to help the other code quality checks, like unbound type arguments.