### PR TITLE
Re-enable the METIS ordering tests

### DIFF
--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -109,9 +109,7 @@ end
      A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], randn(nn), m, n)
      b = randn(m)
      xref = Array(A) \ b
-     # Filter out METIS ordering. https://github.com/JuliaSparse/SparseArrays.jl/issues/369
-     spqr_orderings = filter(x->x!=6, SPQR.ORDERINGS)
-     for ordering ∈ spqr_orderings
+     for ordering ∈ SPQR.ORDERINGS
          QR = qr(A, ordering=ordering)
          x = QR \ b
          @test x ≈ xref
@@ -122,9 +120,7 @@ end
 @testset "select ordering underdetermined" begin
      A = sparse([1:n; rand(1:n, nn - n)], [1:n; rand(1:m, nn - n)], randn(nn), n, m)
      b = A * ones(m)
-     # Filter out METIS ordering. https://github.com/JuliaSparse/SparseArrays.jl/issues/369
-     spqr_orderings = filter(x->x!=6, SPQR.ORDERINGS)
-     for ordering ∈ spqr_orderings
+     for ordering ∈ SPQR.ORDERINGS
          QR = qr(A, ordering=ordering)
          x = QR \ b
          # x ≂̸ Array(A) \ b; LAPACK returns a min-norm x while SPQR returns a basic x


### PR DESCRIPTION
Turns out our latest SuiteSparse7 build worked out fine, and it fixes #369.