### PR TITLE
Use libsuitesparseconfig for some symbols

### DIFF
--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,5 +1,5 @@
 [general]
-library_names = {"SuiteSparseQR_C.h" = "libspqr", "umfpack.h" = "libumfpack", "cholmod.h" = "libcholmod"}
+library_names = {"SuiteSparse_config.h" = "libsuitesparseconfig", "SuiteSparseQR_C.h" = "libspqr", "umfpack.h" = "libumfpack", "cholmod.h" = "libcholmod"}
 
 use_julia_native_enum_type = true
 use_deterministic_symbol = true


### PR DESCRIPTION
Use `SuiteSparse_jll.libsuitesparseconfig` for some symbols (see #379) 