### PR TITLE
remove `eltype` interface-piracy

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -980,10 +980,6 @@ free!(A::Dense)  = free!(pointer(A))
 free!(A::Sparse) = free!(pointer(A))
 free!(F::Factor) = free!(pointer(F))
 
-eltype(::Type{Dense{T}}) where {T<:VTypes} = T
-eltype(::Type{Factor{T}}) where {T<:VTypes} = T
-eltype(::Type{Sparse{T}}) where {T<:VTypes} = T
-
 nnz(F::Factor) = nnz(Sparse(F))
 
 function show(io::IO, F::Factor)


### PR DESCRIPTION
These specializations are unnecessary since the `eltype(Type{AbstractArray{T}}) where T` fallback already ensures this behavior; i.e., the interface of the supertype already provides this.

Removing this was motivated by a discussion in the ttfx Slack channel where vtjnash indicated that these types of superfluous interface-extensions could be considered a form of piracy. 

<details>

This addresses the following entry from a `@snoopr` report:
```jl
inserting eltype(::Type{SparseArrays.CHOLMOD.Dense{T}}) where T<:Union{Float64, ComplexF64} @ SparseArrays.CHOLMOD ~/dev/julia-master/share/julia/stdlib/v1.10/SparseArrays/src/solvers/cholmod.jl:983 invalidated:
   backedges: 1: superseding eltype(::Type{<:AbstractArray{E}}) where E @ Base abstractarray.jl:239 with MethodInstance for eltype(::Type{<:AbstractArray{T, N}} where {T, N}) (4 children)
```

</details>