### PR TITLE
Clean up some multiplication code

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -10,7 +10,7 @@ using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
 using Base.Order: Forward
 using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, AdjointFactorization, TransposeFactorization, matprod,
-    AbstractQ, AdjointQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ,
+    AbstractQ, AdjointQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ, MulAddMul,
     UpperOrLowerTriangular
 
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -623,7 +623,7 @@ end
 # forward substitution for LowerTriangular CSC matrices
 function ldiv!(C::StridedVector, L::LowerTriangularPlain, B::StridedVector)
     A = L.data
-    unit = L isa UnitDiagonalTriangular
+    unit = L isa UnitLowerTriangular
     C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(L)))
 
     nrowB = length(B)
@@ -639,12 +639,12 @@ function ldiv!(C::StridedVector, L::LowerTriangularPlain, B::StridedVector)
         ii = searchsortedfirst(ja, j, i1, i2, Base.Order.Forward)
         jai = ii > i2 ? zero(eltype(ja)) : ja[ii]
 
-        bj = B[j]
+        cj = C[j]
         # check for zero pivot and divide with pivot
         if jai == j
             if !unit
-                bj /= aa[ii]
-                C[j] = bj
+                cj /= LinearAlgebra._ustrip(aa[ii])
+                C[j] = cj
             end
             ii += 1
         elseif !unit
@@ -653,7 +653,7 @@ function ldiv!(C::StridedVector, L::LowerTriangularPlain, B::StridedVector)
 
         # update remaining part
         for i = ii:i2
-            C[ja[i]] -= bj * aa[i]
+            C[ja[i]] -= cj * LinearAlgebra._ustrip(aa[i])
         end
     end
     C
@@ -662,7 +662,7 @@ end
 # backward substitution for UpperTriangular CSC matrices
 function ldiv!(C::StridedVector, U::UpperTriangularPlain, B::StridedVector)
     A = U.data
-    unit = U isa UnitDiagonalTriangular
+    unit = U isa UnitUpperTriangular
     C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(U)))
 
     nrowB = length(B)
@@ -678,12 +678,12 @@ function ldiv!(C::StridedVector, U::UpperTriangularPlain, B::StridedVector)
         ii = searchsortedlast(ja, j, i1, i2, Base.Order.Forward)
         jai = ii < i1 ? zero(eltype(ja)) : ja[ii]
 
-        bj = B[j]
+        cj = C[j]
         # check for zero pivot and divide with pivot
         if jai == j
             if !unit
-                bj /= aa[ii]
-                C[j] = bj
+                cj /= LinearAlgebra._ustrip(aa[ii])
+                C[j] = cj
             end
             ii -= 1
         elseif !unit
@@ -692,7 +692,7 @@ function ldiv!(C::StridedVector, U::UpperTriangularPlain, B::StridedVector)
 
         # update remaining part
         for i = ii:-1:i1
-            C[ja[i]] -= bj * aa[i]
+            C[ja[i]] -= cj * LinearAlgebra._ustrip(aa[i])
         end
     end
     C
@@ -701,8 +701,8 @@ end
 # forward substitution for adjoint and transpose of UpperTriangular CSC matrices
 function ldiv!(C::StridedVector, L::LowerTriangularWrapped, B::StridedVector)
     A = parent(parent(L))
-    unit = L isa UnitDiagonalTriangular
-    adj = parent(L) isa Adjoint
+    unit = L isa UnitLowerTriangular
+    tfun = LinearAlgebra.adj_or_trans(parent(L))
     C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(L)))
 
     nrowB = length(B)
@@ -720,13 +720,9 @@ function ldiv!(C::StridedVector, L::LowerTriangularWrapped, B::StridedVector)
         for ii = i1:i2
             jai = ja[ii]
             if jai < j
-                aai = possible_adjoint(adj, aa[ii])
-                akku -= B[jai] * aai
+                akku -= C[jai] * tfun(aa[ii])
             elseif jai == j
-                if !unit
-                    aai = possible_adjoint(adj, aa[ii])
-                    akku /= aai
-                end
+                akku /= unit ? oneunit(eltype(L)) : tfun(aa[ii])
                 done = true
                 break
             else
@@ -744,7 +740,8 @@ end
 # backward substitution for adjoint and transpose of LowerTriangular CSC matrices
 function ldiv!(C::StridedVector, U::UpperTriangularWrapped, B::StridedVector)
     A = parent(parent(U))
-    unit = U isa UnitDiagonalTriangular
+    unit = U isa UnitUpperTriangular
+    tfun = LinearAlgebra.adj_or_trans(parent(U))
     adj = parent(U) isa Adjoint
     C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(U)))
 
@@ -763,13 +760,9 @@ function ldiv!(C::StridedVector, U::UpperTriangularWrapped, B::StridedVector)
         for ii = i2:-1:i1
             jai = ja[ii]
             if jai > j
-                aai = possible_adjoint(adj, aa[ii])
-                akku -= B[jai] * aai
+                akku -= C[jai] * tfun(aa[ii])
             elseif jai == j
-                if !unit
-                    aai = possible_adjoint(adj, aa[ii])
-                    akku /= aai
-                end
+                akku /= unit ? oneunit(eltype(U)) : tfun(aa[ii])
                 done = true
                 break
             else

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -92,7 +92,7 @@ function LinearAlgebra.generic_matmatmul!(C::StridedVecOrMat, tA, tB, A::AdjOrTr
     elseif tB == 'T'
         _A_mul_Bt_or_Bc!(transpose, C, transA(A), B, _add.alpha, _add.beta)
     else # tB == 'C'
-        _A_mul_Bt_or_Bc!(adjoint, C, transaA(A), B, _add.alpha, _add.beta)
+        _A_mul_Bt_or_Bc!(adjoint, C, transA(A), B, _add.alpha, _add.beta)
     end
     return C
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -624,13 +624,13 @@ end
 function ldiv!(C::StridedVector, L::LowerTriangularPlain, B::StridedVector)
     A = L.data
     unit = L isa UnitDiagonalTriangular
+    C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(L)))
 
     nrowB = length(B)
     aa = getnzval(A)
     ja = getrowval(A)
     ia = getcolptr(A)
 
-    joff = 0
     for j = 1:nrowB
         i1 = ia[j]
         i2 = ia[j + 1] - one(eltype(ia))
@@ -639,12 +639,12 @@ function ldiv!(C::StridedVector, L::LowerTriangularPlain, B::StridedVector)
         ii = searchsortedfirst(ja, j, i1, i2, Base.Order.Forward)
         jai = ii > i2 ? zero(eltype(ja)) : ja[ii]
 
-        bj = B[joff + j]
+        bj = B[j]
         # check for zero pivot and divide with pivot
         if jai == j
             if !unit
                 bj /= aa[ii]
-                C[joff + j] = bj
+                C[j] = bj
             end
             ii += 1
         elseif !unit
@@ -653,7 +653,7 @@ function ldiv!(C::StridedVector, L::LowerTriangularPlain, B::StridedVector)
 
         # update remaining part
         for i = ii:i2
-            C[joff + ja[i]] -= bj * aa[i]
+            C[ja[i]] -= bj * aa[i]
         end
     end
     C
@@ -663,6 +663,7 @@ end
 function ldiv!(C::StridedVector, U::UpperTriangularPlain, B::StridedVector)
     A = U.data
     unit = U isa UnitDiagonalTriangular
+    C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(U)))
 
     nrowB = length(B)
     aa = getnzval(A)
@@ -702,6 +703,7 @@ function ldiv!(C::StridedVector, L::LowerTriangularWrapped, B::StridedVector)
     A = parent(parent(L))
     unit = L isa UnitDiagonalTriangular
     adj = parent(L) isa Adjoint
+    C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(L)))
 
     nrowB = length(B)
     aa = getnzval(A)
@@ -744,6 +746,7 @@ function ldiv!(C::StridedVector, U::UpperTriangularWrapped, B::StridedVector)
     A = parent(parent(U))
     unit = U isa UnitDiagonalTriangular
     adj = parent(U) isa Adjoint
+    C !== B && LinearAlgebra._uconvert_copyto!(C, B, oneunit(eltype(U)))
 
     nrowB = length(B)
     aa = getnzval(A)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -27,7 +27,7 @@ for op ∈ (:+, :-)
     end
 end
 
-function LinearAlgebra.generic_matmatmul!(C::StridedVecOrMat, tA, tB, A::AbstractSparseMatrixCSC, B::DenseInputVecOrMat, _add)
+function LinearAlgebra.generic_matmatmul!(C::StridedVecOrMat, tA, tB, A::AbstractSparseMatrixCSC, B::DenseInputVecOrMat, _add::MulAddMul)
     transB = tB == 'N' ? identity : tB == 'T' ? transpose : adjoint
     if tA == 'N'
         _spmul!(C, A, transB(B), _add.alpha, _add.beta)
@@ -85,7 +85,7 @@ end
 *(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, B::AdjOrTransDenseMatrix) =
     (T = promote_op(matprod, eltype(A), eltype(B)); mul!(similar(B, T, (size(A, 1), size(B, 2))), A, B, true, false))
 
-function LinearAlgebra.generic_matmatmul!(C::StridedVecOrMat, tA, tB, A::AdjOrTransDenseMatrix, B::AbstractSparseMatrixCSC, _add)
+function LinearAlgebra.generic_matmatmul!(C::StridedVecOrMat, tA, tB, A::AdjOrTransDenseMatrix, B::AbstractSparseMatrixCSC, _add::MulAddMul)
     transA = tA == 'N' ? identity : tA == 'T' ? transpose : adjoint
     if tB == 'N'
         _spmul!(C, A, transB(B), _add.alpha, _add.beta)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -68,7 +68,7 @@ function _At_or_Ac_mul_B!(tfun::Function, C::StridedVecOrMat, A::AbstractSparseM
     size(B, 2) == size(C, 2) || throw(DimensionMismatch())
     nzv = nonzeros(A)
     rv = rowvals(A)
-    β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
+    β != one(β) && LinearAlgebra._rmul_or_fill!(C, β)
     for k in 1:size(C, 2)
         @inbounds for col in 1:size(A, 2)
             tmp = zero(eltype(C))
@@ -103,7 +103,7 @@ function _spmul!(C::StridedVecOrMat, X::DenseMatrixUnion, A::AbstractSparseMatri
     size(A, 2) == size(C, 2) || throw(DimensionMismatch())
     rv = rowvals(A)
     nzv = nonzeros(A)
-    β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
+    β != one(β) && LinearAlgebra._rmul_or_fill!(C, β)
     @inbounds for col in 1:size(A, 2), k in nzrange(A, col)
         Aiα = nzv[k] * α
         rvk = rv[k]
@@ -120,7 +120,7 @@ function _spmul!(C::StridedVecOrMat, X::AdjOrTrans{<:Any,<:DenseMatrixUnion}, A:
     size(A, 2) == size(C, 2) || throw(DimensionMismatch())
     rv = rowvals(A)
     nzv = nonzeros(A)
-    β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
+    β != one(β) && LinearAlgebra._rmul_or_fill!(C, β)
     for multivec_row in 1:mX, col in 1:size(A, 2)
         @inbounds for k in nzrange(A, col)
             C[multivec_row, col] += X[multivec_row, rv[k]] * nzv[k] * α
@@ -138,7 +138,7 @@ function _A_mul_Bt_or_Bc!(tfun::Function, C::StridedVecOrMat, A::AdjOrTransDense
     size(B, 1) == size(C, 2) || throw(DimensionMismatch())
     rv = rowvals(B)
     nzv = nonzeros(B)
-    β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
+    β != one(β) && LinearAlgebra._rmul_or_fill!(C, β)
     @inbounds for col in 1:size(B, 2), k in nzrange(B, col)
         Biα = tfun(nzv[k]) * α
         rvk = rv[k]

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -142,7 +142,7 @@ function _A_mul_Bt_or_Bc!(tfun::Function, C::StridedVecOrMat, A::AdjOrTransDense
     @inbounds for col in 1:size(B, 2), k in nzrange(B, col)
         Biα = tfun(nzv[k]) * α
         rvk = rv[k]
-        @simd for multivec_col in 1:mX
+        @simd for multivec_col in 1:mA
             C[multivec_col, rvk] += A[multivec_col, col] * Biα
         end
     end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -45,7 +45,7 @@ function _spmul!(C::StridedVecOrMat, A::AbstractSparseMatrixCSC, B::DenseInputVe
     size(B, 2) == size(C, 2) || throw(DimensionMismatch())
     nzv = nonzeros(A)
     rv = rowvals(A)
-    β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
+    β != one(β) && LinearAlgebra._rmul_or_fill!(C, β)
     for k in 1:size(C, 2)
         @inbounds for col in 1:size(A, 2)
             αxj = B[col,k] * α
@@ -88,7 +88,7 @@ end
 function LinearAlgebra.generic_matmatmul!(C::StridedVecOrMat, tA, tB, A::AdjOrTransDenseMatrix, B::AbstractSparseMatrixCSC, _add::MulAddMul)
     transA = tA == 'N' ? identity : tA == 'T' ? transpose : adjoint
     if tB == 'N'
-        _spmul!(C, A, transB(B), _add.alpha, _add.beta)
+        _spmul!(C, transA(A), B, _add.alpha, _add.beta)
     elseif tB == 'T'
         _A_mul_Bt_or_Bc!(transpose, C, transA(A), B, _add.alpha, _add.beta)
     else # tB == 'C'

--- a/src/sparseconvert.jl
+++ b/src/sparseconvert.jl
@@ -95,7 +95,7 @@ _sparsem(A::AbstractSparseMatrix) = A
 _sparsem(A::AbstractSparseVector) = A
 
 # Transpose/Adjoint of sparse vector (returning sparse matrix)
-function _sparsem(A::Union{Transpose{<:Any,<:AbstractSparseVector},Adjoint{<:Any,<:AbstractSparseVector}})
+function _sparsem(A::AdjOrTrans{<:Any,<:AbstractSparseVector})
     B = parent(A)
     n = length(B)
     Ti = eltype(nonzeroinds(B))
@@ -217,8 +217,7 @@ function _sparsem(A::AbstractTriangularSparse{Tv}) where Tv
 end
 
 # 8 cases: (Transpose|Adjoint){Tv,[Unit](Upper|Lower)Triangular}
-function _sparsem(taA::Union{Transpose{Tv,<:AbstractTriangularSparse},
-                             Adjoint{Tv,<:AbstractTriangularSparse}}) where {Tv}
+function _sparsem(taA::AdjOrTrans{Tv,<:AbstractTriangularSparse}) where {Tv}
 
     sA = taA.parent
     A = sA.data

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -209,8 +209,7 @@ julia> nnz(A)
 """
 nnz(S::AbstractSparseMatrixCSC) = Int(getcolptr(S)[size(S, 2) + 1]) - 1
 nnz(S::ReshapedArray{<:Any,1,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
-nnz(S::Adjoint{<:Any,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
-nnz(S::Transpose{<:Any,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
+nnz(S::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
 nnz(S::UpperTriangular{<:Any,<:AbstractSparseMatrixCSC}) = nnz1(S)
 nnz(S::LowerTriangular{<:Any,<:AbstractSparseMatrixCSC}) = nnz1(S)
 nnz(S::SparseMatrixCSCView) = nnz1(S)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1783,9 +1783,9 @@ function LinearAlgebra.generic_matvecmul!(y::AbstractVector, tA, A::_StridedOrTr
     if tA == 'N'
         _spmul!(y, A, x, _add.alpha, _add.beta)
     elseif tA == 'T'
-        _At_or_Ac_mul_B!((a,b) -> transpose(a) * b, y, parent(A), x, _add.alpha, _add.beta)
+        _At_or_Ac_mul_B!(transpose, y, parent(A), x, _add.alpha, _add.beta)
     else # tA == 'C'
-        _At_or_Ac_mul_B!((a,b) -> adjoint(a) * b, y, parent(tA), x, _add.alpha, _add.beta)
+        _At_or_Ac_mul_B!(adjoint, y, parent(tA), x, _add.alpha, _add.beta)
     end
     return y
 end

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1893,9 +1893,7 @@ function _spmul!(y::AbstractVector, A::AbstractSparseMatrixCSC, x::AbstractSpars
     m, n = size(A)
     length(x) == n && length(y) == m || throw(DimensionMismatch())
     m == 0 && return y
-    if β != one(β)
-        β == zero(β) ? fill!(y, zero(eltype(y))) : rmul!(y, β)
-    end
+    β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
     α == zero(α) && return y
 
     xnzind = nonzeroinds(x)
@@ -1924,9 +1922,7 @@ function _At_or_Ac_mul_B!(tfun::Function,
     m, n = size(A)
     length(x) == m && length(y) == n || throw(DimensionMismatch())
     n == 0 && return y
-    if β != one(β)
-        β == zero(β) ? fill!(y, zero(eltype(y))) : rmul!(y, β)
-    end
+    β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
     α == zero(α) && return y
 
     xnzind = nonzeroinds(x)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -207,7 +207,7 @@ end
     @testset "symmetric/Hermitian sparseview multiply with $S($U)" for S in (Symmetric, Hermitian), U in (:U, :L), (A, B) in ((Areal,Breal), (Acomplex,Bcomplex))
         Asym = S(A, U)
         As = sparse(Asym) # takes most time
-        @test which(mul!, (typeof(B), typeof(Asym), typeof(B))).module == SparseArrays
+        # @test which(mul!, (typeof(B), typeof(Asym), typeof(B))).module == SparseArrays
         @test norm(Asym * B - As * B, Inf) <= eps() * n * p * 10
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -190,7 +190,7 @@ end
     @testset "symmetric/Hermitian sparse multiply with $S($U)" for S in (Symmetric, Hermitian), U in (:U, :L), (A, B) in ((Areal,Breal), (Acomplex,Bcomplex))
         Asym = S(A, U)
         As = sparse(Asym) # takes most time
-        @test which(mul!, (typeof(B), typeof(Asym), typeof(B))).module == SparseArrays
+        # @test which(mul!, (typeof(B), typeof(Asym), typeof(B))).module == SparseArrays
         @test norm(Asym * B - As * B, Inf) <= eps() * n * p * 10
     end
 end

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -175,8 +175,8 @@ dA = Array(sA)
     p28227 = sparse(Real[0 0.5])
 
     for arr in (se33, sA, pA, p28227, spzeros(3, 3))
+        farr = Array(arr)
         for f in (sum, prod, minimum, maximum)
-            farr = Array(arr)
             @test f(arr) ≈ f(farr)
             @test f(arr, dims=1) ≈ f(farr, dims=1)
             @test f(arr, dims=2) ≈ f(farr, dims=2)
@@ -184,7 +184,6 @@ dA = Array(sA)
             @test isequal(f(arr, dims=3), f(farr, dims=3))
         end
         for f in (+, *, min, max)
-            farr = Array(arr)
             @test mapreduce(identity, f, arr) ≈ mapreduce(identity, f, farr)
             @test mapreduce(x -> x + 1, f, arr) ≈ mapreduce(x -> x + 1, f, farr)
         end


### PR DESCRIPTION
This is a continuation of the effort of reducing `mul!` methods and thereby speed-up package loading time. The general approach is to have "a few" generic `mul!`s that catch specific cases, like triangular, banded, or matvec multiplication, and forward them to helper functions. If necessary, disambiguation can happen at this level, which should be easier because it doesn't compete with the entire `mul!` list. For symmetric sparse matrices I've actually added a few `mul!` methods so that hopefully method insertion is faster (it mirrors the LinearAlgebra methods and differs only in one type parameter, no unions involved).