### PR TITLE
Intermediate test relaxation

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -138,7 +138,7 @@ end
             ACa = sparse(trop(AC)) # copied and adjoint
             @test AT \ B ≈ AC \ B
             @test ATa \ B ≈ ACa \ B
-            @test ATa \ sparse(B) == ATa \ B
+            @test ATa \ sparse(B) ≈ ATa \ B
             @test Matrix(ATa) \ B ≈ ATa \ B
             @test ATa * ( ATa \ B ) ≈ B
         end


### PR DESCRIPTION
This is an intermediate change to make https://github.com/JuliaLang/julia/pull/50058 pass CI. So we need to first merge this here, then bump the stdlib, then merge https://github.com/JuliaLang/julia/pull/50058 (and backport to v1.10), then this test relaxation can be reverted (but doesn't have to), then #396 should be merged, and again bump the stdlib including backport to v1.10... roughly.