### PR TITLE
Improved the dot product between two vectors and a sparse matrix

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -340,18 +340,21 @@ function dot(A::AbstractSparseMatrixCSC{T1,S1},B::AbstractSparseMatrixCSC{T2,S2}
 end
 
 function dot(x::AbstractVector{T1}, A::AbstractSparseMatrixCSC{T2}, y::AbstractVector{T3}) where {T1,T2,T3}
-    Base.require_one_based_indexing(x, y)
+    require_one_based_indexing(x, y)
     m, n = size(A)
     (length(x) == m && n == length(y)) || throw(DimensionMismatch())
     T = promote_type(T1, T2, T3)
     s = zero(T)
     (iszero(m) || iszero(n)) && return s
+
+    rowvals = getrowval(A)
+    nzvals = getnzval(A)
     
     @inbounds @simd for col in 1:n
         ycol = y[col]
         for j in nzrange(A, col)
-            row = A.rowval[j]
-            val = A.nzval[j]
+            row = rowvals[j]
+            val = nzvals[j]
             s += dot(x[row], val, ycol)
         end
     end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -352,7 +352,7 @@ function dot(x::AbstractVector{T1}, A::AbstractSparseMatrixCSC{T2}, y::AbstractV
         for j in nzrange(A, col)
             row = A.rowval[j]
             val = A.nzval[j]
-            s += dot(conj(x[row]), val, ycol)
+            s += dot(x[row], val, ycol)
         end
     end
     return s

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -347,8 +347,8 @@ function dot(x::AbstractVector{T1}, A::AbstractSparseMatrixCSC{T2}, y::AbstractV
     require_one_based_indexing(x, y)
     m, n = size(A)
     (length(x) == m && n == length(y)) || throw(DimensionMismatch())
-    T = promote_type(T1, T2, T3)
-    s = zero(T)
+    s = dot(zero(T1), zero(T2), zero(T3))
+    T = typeof(s)
     (iszero(m) || iszero(n)) && return s
 
     rowvals = getrowval(A)


### PR DESCRIPTION
The changed function is a little bit faster than the current one.

```julia
N1 = 1024*10
N2 = 1024*20
T = Float64

x = Array(sprand(T, N1, 0.1))
y = Array(sprand(T, N2, 0.1))
A = sprand(T, N1, N2, 1/N1)

@benchmark dot($x, $A, $y)

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  45.800 μs … 287.700 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     57.800 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   58.845 μs ±  10.107 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

               ▁█                                               
  ▁▁▂▃▄▅▅▃▃▄▃▃▄██▆▄▃▂▃▂▂▂▂▁▁▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  45.8 μs         Histogram: frequency by time         96.6 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.



@benchmark mydot($x, $A, $y)

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  37.200 μs … 896.900 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     50.900 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   49.762 μs ±  14.435 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▂▁▃             ▆█▃                                          
  ▆████▅▄▄▃▃▃▂▂▃▃▅▄███▇▅▃▃▂▂▂▂▂▂▂▂▁▁▁▁▁▁▂▂▂▂▁▂▂▁▁▂▂▂▁▁▁▁▁▁▁▁▁▁ ▂
  37.2 μs         Histogram: frequency by time         84.9 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

And with vectors without zeros:
```julia
x = rand(T, N1)
y = rand(T, N2)
A = sprand(T, N1, N2, 1/N1)

@benchmark dot($x, $A, $y)

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  166.900 μs …  1.750 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     214.800 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   224.317 μs ± 37.141 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                 ▆█                                             
  ▁▁▁▁▁▁▂▂▂▂▆▅▇▅▅███▆▆▄▆█▆▄▃▂▂▃▃▂▂▂▂▂▂▂▂▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  167 μs          Histogram: frequency by time          331 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.


@benchmark mydot($x, $A, $y)

BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  146.700 μs … 991.600 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     178.900 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   184.942 μs ±  25.418 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▁   ▃▃▅██▆▃▁ ▁▂                                           
  ▂▁▂▄▅█▄▃▃███████████▇▆█▅█▄▄▃▃▂▂▂▂▂▂▂▁▁▁▁▁▂▂▂▂▂▁▁▁▁▂▂▂▁▁▁▁▁▁▁▁ ▃
  147 μs           Histogram: frequency by time          277 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```