### PR TITLE
Fix some broken links

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ DocTestSetup = :(using SparseArrays, LinearAlgebra)
 Julia has support for sparse vectors and [sparse matrices](https://en.wikipedia.org/wiki/Sparse_matrix)
 in the `SparseArrays` stdlib module. Sparse arrays are arrays that contain enough zeros that storing them in a special data structure leads to savings in space and execution time, compared to dense arrays.
 
-External packages which implement different sparse storage types, multidimensional sparse arrays, and more can be found in [Noteworthy external packages](@ref man-csc)
+External packages which implement different sparse storage types, multidimensional sparse arrays, and more can be found in [Noteworthy external packages](@ref)
 
 ## [Compressed Sparse Column (CSC) Sparse Matrix Storage](@id man-csc)
 

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -15,10 +15,10 @@ Sparse matrix solvers call functions from [SuiteSparse](http://suitesparse.com).
 Other solvers such as [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl/) are available as external packages. [Arpack.jl](https://julialinearalgebra.github.io/Arpack.jl/stable/) provides `eigs` and `svds` for iterative solution of eigensystems and singular value decompositions.
 
 These factorizations are described in more detail in [`Linear Algebra`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/) section of the manual:
-1. [`cholesky`](@ref)
-2. [`ldlt`](@ref)
-3. [`lu`](@ref)
-4. [`qr`](@ref)
+1. [`cholesky`](@ref SparseArrays.CHOLMOD.cholesky)
+2. [`ldlt`](@ref SparseArrays.CHOLMOD.ldlt)
+3. [`lu`](@ref SparseArrays.UMFPACK.lu)
+4. [`qr`](@ref SparseArrays.SPQR.qr)
 
 ```@docs
 SparseArrays.CHOLMOD.cholesky


### PR DESCRIPTION
I fixed a couple of broken links I found while browsing the docs. In doing so I also noticed that all of the internal `@ref` links in `solvers.md` are broken. Is it possible that it's because of a bad Documenter configuration or something? I thought Documenter would be able to pick up references to symbols in the same package.