### PR TITLE
Respect `IOContext` while displaying a `SparseMatrixCSC`

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -344,7 +344,13 @@ function Base.print_array(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTransp
     end
 end
 
-# struct to generate the column indices of the values
+"""
+    ColumnIndices(S::AbstractSparseMatrixCSC)
+
+Return the column indices of the stored values in `S`.
+This is an internal type that is used in displaying sparse matrices,
+and is not a part of the public interface.
+"""
 struct ColumnIndices{Ti,S<:AbstractSparseMatrixCSC{<:Any,Ti}} <: AbstractVector{Ti}
     arr :: S
 end

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -1575,7 +1575,8 @@ end
     @test String(take!(io)) == "⎡⣿⣿⎤\n" *
                                "⎣⣿⣿⎦"
 
-    I, J, V = shuffle(1:100), shuffle(1:100), [1:100;]
+    # respect IOContext while displaying J
+    I, J, V = shuffle(1:50), shuffle(1:50), [1:50;]
     S = sparse(I, J, V)
     I, J, V = I[sortperm(J)], sort(J), V[sortperm(J)]
     @test repr(S) == "sparse($I, $J, $V, $(size(S,1)), $(size(S,2)))"

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -1574,6 +1574,14 @@ end
     _show_with_braille_patterns(ioc, _filled_sparse(8, 16))
     @test String(take!(io)) == "⎡⣿⣿⎤\n" *
                                "⎣⣿⣿⎦"
+
+    I, J, V = shuffle(1:100), shuffle(1:100), [1:100;]
+    S = sparse(I, J, V)
+    I, J, V = I[sortperm(J)], sort(J), V[sortperm(J)]
+    @test repr(S) == "sparse($I, $J, $V, $(size(S,1)), $(size(S,2)))"
+    limctxt(x) = repr(x, context=:limit=>true)
+    expstr = "sparse($(limctxt(I)), $(limctxt(J)), $(limctxt(V)), $(size(S,1)), $(size(S,2)))"
+    @test limctxt(S) == expstr
 end
 
 @testset "issparse for specialized matrix types" begin


### PR DESCRIPTION
Fix https://github.com/JuliaSparse/SparseArrays.jl/issues/399

On main:
```julia
julia> S = sprand(Int8, 20, 20, 0.3);

julia> [S]
1-element Vector{SparseMatrixCSC{Int8, Int64}}:
 sparse([2, 3, 4, 8, 9, 13, 14, 16, 18, 2  …  8, 13, 16, 17, 19, 4, 6, 10, 18, 19], [1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 15, 15, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 19, 19, 19, 19, 19, 20, 20, 20, 20, 20], Int8[108, 6, -86, 17, 48, 51, 23, 88, 82, -24  …  -27, -3, 24, -56, 109, 73, 70, 101, -100, 46], 20, 20)
```
This PR
```julia
julia> [S]
1-element Vector{SparseMatrixCSC{Int8, Int64}}:
 sparse([2, 3, 4, 8, 9, 13, 14, 16, 18, 2  …  8, 13, 16, 17, 19, 4, 6, 10, 18, 19], [1, 1, 1, 1, 1, 1, 1, 1, 1, 2  …  19, 19, 19, 19, 19, 20, 20, 20, 20, 20], Int8[108, 6, -86, 17, 48, 51, 23, 88, 82, -24  …  -27, -3, 24, -56, 109, 73, 70, 101, -100, 46], 20, 20)
```
The main change is to use an `AbstractVector` for the column indices instead of printing them one by one to the display, which ensures that the `IOContext` is automatically respected in the same way as the row indices and the values.

Indexing into the `AbstractVector` is `O(log n)` as it uses `searchsortedlast`, but since this is used only in display, the performance should not matter much.