### PR TITLE
faster cat performance

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1197,6 +1197,7 @@ _makesparse(x::AbstractMatrix) = convert(SparseMatrixCSC, issparse(x) ? x : spar
 anysparse() = false
 anysparse(X) = X isa AbstractArray && issparse(X)
 anysparse(X, Xs...) = anysparse(X) || anysparse(Xs...)
+anysparse(X::T, Xs::T...) where {T} = anysparse(X)
 
 const _SparseVecConcatGroup = Union{Vector, AbstractSparseVector}
 function hcat(X::_SparseVecConcatGroup...)
@@ -1229,13 +1230,13 @@ function hcat(X1::_SparseConcatGroup, X::_SparseConcatGroup...)
     if anysparse(X1) || anysparse(X...)
         X1, X = _sparse(X1), map(_makesparse, X)
     end
-    return cat(X1, X..., dims=Val(2))
+    return Base.typed_hcat(Base.promote_eltype(X1, X...), X1, X...)
 end
 function vcat(X1::_SparseConcatGroup, X::_SparseConcatGroup...)
     if anysparse(X1) || anysparse(X...)
         X1, X = _sparse(X1), map(_makesparse, X)
     end
-    return cat(X1, X..., dims=Val(1))
+    return Base.typed_vcat(Base.promote_eltype(X1, X...), X1, X...)
 end
 function hvcat(rows::Tuple{Vararg{Int}}, X1::_SparseConcatGroup, X::_SparseConcatGroup...)
     if anysparse(X1) || anysparse(X...)


### PR DESCRIPTION
The generic `cat` does more shape analysis, that typed_cat does not always do (before either may then dispatch to _cat_t), so we can make this faster by calling it instead.

Secondly, we can make `issparse` non-recursive once it hits a base case where all trailing elements are the same. This makes it much better at handling large splat, since we do not need to check each recursively smaller type down to the base case using generic code, and just generate one const method specialized on the full length instead.

Fix JuliaLang/julia#51011