### PR TITLE
Correctly set zeros with `fill!(::SubArray)` and fix its return value

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -3179,7 +3179,8 @@ function Base.fill!(V::SubArray{Tv, <:Any, <:AbstractSparseMatrixCSC{Tv}, <:Tupl
     else
         _spsetnz_setindex!(A, convert(Tv, x), I, J)
     end
-    return _checkbuffers(A)
+    _checkbuffers(A)
+    V
 end
 """
 Helper method for immediately preceding fill! method. For all (i,j) such that i in I and

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -3207,7 +3207,7 @@ function _spsetz_setindex!(A::AbstractSparseMatrixCSC,
                 kI > lengthI && break
                 entrykIrow = I[kI]
             else # entrykArow == entrykIrow
-                nonzeros(A)[kA] = 0
+                nonzeros(A)[kA] = zero(eltype(A))
                 kA += 1
                 kI += 1
                 (kA > coljAlastk || kI > lengthI) && break

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -1363,7 +1363,9 @@ end
     a = sprand(10, 10, 0.2)
     b = copy(a)
     sa = view(a, 1:10, 2:3)
-    fill!(sa, 0.0)
+    sa_filled = fill!(sa, 0.0)
+    # `fill!` should return the sub array instead of its parent.
+    @test sa_filled === sa
     b[1:10, 2:3] .= 0.0
     @test a == b
     A = sparse([1], [1], [Vector{Float64}(undef, 3)], 3, 3)

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -342,7 +342,7 @@ end
     A = rand(5,5)
     A´ = similar(A)
     Ac = copyto!(A, B)
-    @test Ac === A 
+    @test Ac === A
     @test A == copyto!(A´, Matrix(B))
     # Test copyto!(dense, Rdest, sparse, Rsrc)
     A = rand(5,5)
@@ -1375,6 +1375,17 @@ end
         B[1, jj] = [4.0, 5.0, 6.0]
     end
     @test A == B
+
+    # https://github.com/JuliaSparse/SparseArrays.jl/pull/433
+    struct Foo
+       x::Int
+    end
+    Base.zero(::Type{Foo}) = Foo(0)
+    Base.zero(::Foo) = zero(Foo)
+    C = sparse([1], [1], [Foo(3)], 3, 3)
+    sC = view(C, 1:1, 1:2)
+    fill!(sC, zero(Foo))
+    @test C[1:1, 1:2] == zeros(Foo, 1, 2)
 end
 
 using Base: swaprows!, swapcols!


### PR DESCRIPTION
This PR includes two fixes:

## 1
It is a simple obvious fix to the problem when one tries to do something like the following

```julia
using SparseArrays, StaticArrays
const Vec2 = SVector{2, Float64}
A = rand(Vec2, 2, 2) |> sparse
fill!(view(A, :, :), zero(Vec2))
```

Without the fix, it throws

```
ERROR: MethodError: Cannot `convert` an object of type Int64 to an object of type SVector{2, Float64}

Closest candidates are:
  convert(::Type{T}, ::Factorization) where T<:AbstractArray
   @ LinearAlgebra /usr/share/julia/stdlib/v1.9/LinearAlgebra/src/factorization.jl:59
  convert(::Type{SVector{N, T}}, ::CartesianIndex{N}) where {N, T}
   @ StaticArrays ~/.julia/packages/StaticArrays/jA1zK/src/SVector.jl:13
  convert(::Type{SA}, ::Tuple) where SA<:StaticArray
   @ StaticArrays ~/.julia/packages/StaticArrays/jA1zK/src/convert.jl:179
  ...

Stacktrace:
 [1] setindex!(A::Vector{SVector{2, Float64}}, x::Int64, i1::Int64)
   @ Base ./array.jl:969
 [2] _spsetz_setindex!
   @ /usr/share/julia/stdlib/v1.9/SparseArrays/src/sparsematrix.jl:3033 [inlined]
 [3] fill!(V::SubArray{SVector{2, Float64}, 1, SparseMatrixCSC{SVector{2, Float64}, Int64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, false}, x::SVector{2, Float64})
   @ SparseArrays /usr/share/julia/stdlib/v1.9/SparseArrays/src/sparsematrix.jl:3001
 [4] top-level scope
   @ REPL[61]:1
```

## 2

`fill!(A, ...)` should always return `A`, but without the fix, it returns `A.parent` for sub arrays of the sparse arrays, if zeros are being set.