### PR TITLE
Code quality cleanup

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -560,7 +560,7 @@ function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, tf
     end
     return C
 end
-function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, _, xA::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion}, B::AbstractVecOrMat)
+function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, ::Function, xA::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion}, B::AbstractVecOrMat)
     A = parent(xA)
     nrowC = size(C, 1)
     ncol = checksquare(A)


### PR DESCRIPTION
This PR contains a few small edits that should be backported to v1.10.

* resolve a method ambiguity in a rare case (previously, we didn't check method ambiguity because there was no way to distinguish the methods in the sysimage from those same in this package)
* apparently, an update of Aqua.jl allows us to tighten some code quality checks