### PR TITLE
Add example for UMFPACK control vector

### DIFF
--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -346,7 +346,7 @@ For example to reenable iterative refinement:
     umfpack_control[SparseArrays.UMFPACK.JL_UMFPACK_IRSTEP] = 2.0 # reenable iterative refinement (2 is UMFPACK default max iterative refinement steps)
 
     Alu = lu(A; control = umfpack_control)
-    x = Alu \ b   # solve Ax = b, including UMFPACK iterative refinement  
+    x = Alu \\ b   # solve Ax = b, including UMFPACK iterative refinement  
 
 The individual components of the factorization `F` can be accessed by indexing:
 

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -337,9 +337,16 @@ The permutation `q` can either be a permutation vector or `nothing`. If no permu
 is provided or `q` is `nothing`, UMFPACK's default is used. If the permutation is not zero-based, a
 zero-based copy is made.
 
-The `control` vector defaults to the package's default configuration for UMFPACK, but can be changed by passing a
-vector of length `UMFPACK_CONTROL`. See the UMFPACK manual for possible configurations. The corresponding
-variables are named `JL_UMFPACK_` since Julia uses one-based indexing.
+The `control` vector defaults to the Julia SparseArrays package's default configuration for UMFPACK (NB: this is modified from the UMFPACK defaults to
+disable iterative refinement), but can be changed by passing a vector of length `UMFPACK_CONTROL`, see the UMFPACK manual for possible configurations. 
+For example to reenable iterative refinement:
+
+    umfpack_control = SparseArrays.UMFPACK.get_umfpack_control(Float64, Int64) # read Julia default configuration for a Float64 sparse matrix
+    SparseArrays.UMFPACK.show_umf_ctrl(umfpack_control) # optional - display values
+    umfpack_control[SparseArrays.UMFPACK.JL_UMFPACK_IRSTEP] = 2.0 # reenable iterative refinement (2 is UMFPACK default max iterative refinement steps)
+
+    Alu = lu(A; control = umfpack_control)
+    x = Alu \ b   # solve Ax = b, including UMFPACK iterative refinement  
 
 The individual components of the factorization `F` can be accessed by indexing:
 


### PR DESCRIPTION
Fixes https://github.com/JuliaSparse/SparseArrays.jl/issues/448

Add a note to the documentation for `lu`, explaining that Julia modifies the UMFPACK defaults to disable iterative refinement.

Add an example to illustrate usage of the UMFPACK control vector to reenable iterative refinement