### PR TITLE
Fix documentation of `findall` behaviour

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -121,9 +121,9 @@ julia> R = sparsevec(I,V)
 ```
 
 The inverse of the [`sparse`](@ref) and [`sparsevec`](@ref) functions is
-[`findnz`](@ref), which retrieves the inputs used to create the sparse array.
+[`findnz`](@ref), which retrieves the inputs used to create the sparse array (including stored entries equal to zero).
 [`findall(!iszero, x)`](@ref) returns the Cartesian indices of non-zero entries in `x`
-(including stored entries equal to zero).
+(not including stored entries equal to zero).
 
 ```jldoctest sparse_function
 julia> findnz(S)


### PR DESCRIPTION
The current documentation claims that `findall(!iszero, my_sparse_matrixcsc)` would be "including stored entries equal to zero".

This seems counter-intuitive to me. It also seems to be wrong (unless I'm missing something):

```julia
julia> M = sparse([1, 2], [1,1], [0, 1], 2, 2)
2×2 SparseMatrixCSC{Int64, Int64} with 2 stored entries:
 0  ⋅
 1  ⋅

julia> findnz(M)
([1, 2], [1, 1], [0, 1])

julia> findall(!iszero, M)
1-element Vector{CartesianIndex{2}}:
 CartesianIndex(2, 1)
```
I propose to correct the documentation.