### PR TITLE
Algebraic operators for SparseMatrixCSCView

### DIFF
--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -8,7 +8,7 @@ import Base: map, map!, broadcast, copy, copyto!
 
 using Base: front, tail, to_shape
 
-using ..SparseArrays: SparseVector, SparseMatrixCSC, FixedSparseCSC,
+using ..SparseArrays: SparseVector, SparseMatrixCSC, FixedSparseCSC, SparseMatrixCSCView,
                       AbstractCompressedVector, AbstractSparseVector, AbstractSparseMatrixCSC,
                       AbstractSparseMatrix, AbstractSparseArray,
                       SparseVectorUnion, AdjOrTransSparseVectorUnion,
@@ -1182,7 +1182,7 @@ _sparsifystructured(x) = x
 
 
 # (12) map[!] over combinations of sparse and structured matrices
-SparseOrStructuredMatrix = Union{FixedSparseCSC,SparseMatrixCSC,LinearAlgebra.StructuredMatrix}
+SparseOrStructuredMatrix = Union{FixedSparseCSC,SparseMatrixCSC,SparseMatrixCSCView,LinearAlgebra.StructuredMatrix}
 map(f::Tf, A::SparseOrStructuredMatrix, Bs::Vararg{SparseOrStructuredMatrix,N}) where {Tf,N} =
     (_checksameshape(A, Bs...); _noshapecheck_map(f, _sparsifystructured(A), map(_sparsifystructured, Bs)...))
 map!(f::Tf, C::AbstractSparseMatrixCSC, A::SparseOrStructuredMatrix, Bs::Vararg{SparseOrStructuredMatrix,N}) where {Tf,N} =

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2236,13 +2236,13 @@ function conj(A::AbstractSparseMatrixCSC{<:Complex})
     map!(conj, view(nzval, 1:nnz(A)), nzvalview(A))
     return SparseMatrixCSC(size(A, 1), size(A, 2), copy(getcolptr(A)), copy(rowvals(A)), nzval)
 end
-imag(A::AbstractSparseMatrixCSC{Tv,Ti}) where {Tv<:Real,Ti} = spzeros(Tv, Ti, size(A, 1), size(A, 2))
+imag(A::SparseMatrixCSCView{Tv,Ti}) where {Tv<:Real,Ti} = spzeros(Tv, Ti, size(A, 1), size(A, 2))
 
 ## Binary arithmetic and boolean operators
-(+)(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC) = map(+, A, B)
-(-)(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC) = map(-, A, B)
+(+)(A::SparseMatrixCSCView, B::SparseMatrixCSCView) = map(+, A, B)
+(-)(A::SparseMatrixCSCView, B::SparseMatrixCSCView) = map(-, A, B)
 
-function (+)(A::AbstractSparseMatrixCSC, B::Array)
+function (+)(A::SparseMatrixCSCView, B::Array)
     Base.promote_shape(axes(A), axes(B))
     C = Ref(zero(eltype(A))) .+ B
     rowinds, nzvals = rowvals(A), nonzeros(A)
@@ -2254,7 +2254,7 @@ function (+)(A::AbstractSparseMatrixCSC, B::Array)
     end
     return C
 end
-function (+)(A::Array, B::AbstractSparseMatrixCSC)
+function (+)(A::Array, B::SparseMatrixCSCView)
     Base.promote_shape(axes(A), axes(B))
     C = A .+ Ref(zero(eltype(B)))
     rowinds, nzvals = rowvals(B), nonzeros(B)
@@ -2266,7 +2266,7 @@ function (+)(A::Array, B::AbstractSparseMatrixCSC)
     end
     return C
 end
-function (-)(A::AbstractSparseMatrixCSC, B::Array)
+function (-)(A::SparseMatrixCSCView, B::Array)
     Base.promote_shape(axes(A), axes(B))
     C = Ref(zero(eltype(A))) .- B
     rowinds, nzvals = rowvals(A), nonzeros(A)
@@ -2278,7 +2278,7 @@ function (-)(A::AbstractSparseMatrixCSC, B::Array)
     end
     return C
 end
-function (-)(A::Array, B::AbstractSparseMatrixCSC)
+function (-)(A::Array, B::SparseMatrixCSCView)
     Base.promote_shape(axes(A), axes(B))
     C = A .- Ref(zero(eltype(B)))
     rowinds, nzvals = rowvals(B), nonzeros(B)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2236,13 +2236,13 @@ function conj(A::AbstractSparseMatrixCSC{<:Complex})
     map!(conj, view(nzval, 1:nnz(A)), nzvalview(A))
     return SparseMatrixCSC(size(A, 1), size(A, 2), copy(getcolptr(A)), copy(rowvals(A)), nzval)
 end
-imag(A::SparseMatrixCSCView{Tv,Ti}) where {Tv<:Real,Ti} = spzeros(Tv, Ti, size(A, 1), size(A, 2))
+imag(A::SparseMatrixCSCUnion{Tv,Ti}) where {Tv<:Real,Ti} = spzeros(Tv, Ti, size(A, 1), size(A, 2))
 
 ## Binary arithmetic and boolean operators
-(+)(A::SparseMatrixCSCView, B::SparseMatrixCSCView) = map(+, A, B)
-(-)(A::SparseMatrixCSCView, B::SparseMatrixCSCView) = map(-, A, B)
+(+)(A::SparseMatrixCSCUnion, B::SparseMatrixCSCUnion) = map(+, A, B)
+(-)(A::SparseMatrixCSCUnion, B::SparseMatrixCSCUnion) = map(-, A, B)
 
-function (+)(A::SparseMatrixCSCView, B::Array)
+function (+)(A::SparseMatrixCSCUnion, B::Array)
     Base.promote_shape(axes(A), axes(B))
     C = Ref(zero(eltype(A))) .+ B
     rowinds, nzvals = rowvals(A), nonzeros(A)
@@ -2254,7 +2254,7 @@ function (+)(A::SparseMatrixCSCView, B::Array)
     end
     return C
 end
-function (+)(A::Array, B::SparseMatrixCSCView)
+function (+)(A::Array, B::SparseMatrixCSCUnion)
     Base.promote_shape(axes(A), axes(B))
     C = A .+ Ref(zero(eltype(B)))
     rowinds, nzvals = rowvals(B), nonzeros(B)
@@ -2266,7 +2266,7 @@ function (+)(A::Array, B::SparseMatrixCSCView)
     end
     return C
 end
-function (-)(A::SparseMatrixCSCView, B::Array)
+function (-)(A::SparseMatrixCSCUnion, B::Array)
     Base.promote_shape(axes(A), axes(B))
     C = Ref(zero(eltype(A))) .- B
     rowinds, nzvals = rowvals(A), nonzeros(A)
@@ -2278,7 +2278,7 @@ function (-)(A::SparseMatrixCSCView, B::Array)
     end
     return C
 end
-function (-)(A::Array, B::SparseMatrixCSCView)
+function (-)(A::Array, B::SparseMatrixCSCUnion)
     Base.promote_shape(axes(A), axes(B))
     C = A .- Ref(zero(eltype(B)))
     rowinds, nzvals = rowvals(B), nonzeros(B)


### PR DESCRIPTION
Fix #441

```julia
julia> S = sparse([1,2,2,2,3], [1,1,2,2,4], [5, -19, 73, 12, -7])
3×4 SparseMatrixCSC{Int64, Int64} with 4 stored entries:
   5   ⋅  ⋅   ⋅
 -19  85  ⋅   ⋅
   ⋅   ⋅  ⋅  -7

julia> Sv = view(S, :, 1:3)
3×3 view(::SparseMatrixCSC{Int64, Int64}, :, 1:3) with eltype Int64:
   5   0  0
 -19  85  0
   0   0  0

julia> Sv + Sv
3×3 SparseMatrixCSC{Int64, Int64} with 3 stored entries:
  10    ⋅  ⋅
 -38  170  ⋅
   ⋅    ⋅  ⋅
```