### PR TITLE
Add Finch to list of External Julia Sparse Array Libraries

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -258,3 +258,5 @@ Several other Julia packages provide sparse matrix implementations that should b
 6. [LuxurySparse.jl](https://github.com/QuantumBFS/LuxurySparse.jl) provides static sparse array formats, as well as a coordinate format.
 
 7. [ExtendableSparse.jl](https://github.com/j-fu/ExtendableSparse.jl) enables fast insertion into sparse matrices using a lazy approach to new stored indices.
+
+8. [Finch.jl](https://github.com/willow-ahrens/Finch.jl) supports extensive multidimensional sparse array formats and operations through a mini tensor language and compiler, all in native Julia. Support for COO, CSF, CSR, CSC and more, as well as operations like broadcast, reduce, etc. and custom operations.


### PR DESCRIPTION
[Finch](https://github.com/willow-ahrens/Finch.jl) is a library for multidimensional sparse array processing that supports a wide variety of formats and operators. It's one of the few Julia libraries to support sparse tensors, it's highly flexible, and it's design could only exist in Julia. Would you please consider adding it to the list?