### PR TITLE
Simplify calling Aqua

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SuiteSparse_jll = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
 
 [compat]
-Aqua = "0.7, 0.8"
+Aqua = "0.8"
 Dates = "<0.0.1, 1"
 InteractiveUtils = "<0.0.1, 1"
 Libdl = "<0.0.1, 1"

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -28,28 +28,7 @@ end
 using Test, LinearAlgebra, SparseArrays, Aqua
 
 @testset "code quality" begin
-    @testset "Method ambiguity" begin
-        Aqua.test_ambiguities([SparseArrays, Base, Core])
-    end
-    @testset "Unbound type parameters" begin
-        @test_broken Aqua.detect_unbound_args_recursively(SparseArrays) == []
-    end
-    @testset "Undefined exports" begin
-        Aqua.test_undefined_exports(SparseArrays)
-    end
-    @testset "Compare Project.toml and test/Project.toml" begin
-        Aqua.test_project_extras(SparseArrays)
-    end
-    @testset "Stale dependencies" begin
-        Aqua.test_stale_deps(SparseArrays)
-    end
-    @testset "Compat bounds" begin
-        Aqua.test_deps_compat(SparseArrays)
-    end
-
-    @testset "Piracy" begin
-        @test_broken Aqua.Piracy.hunt(SparseArrays) == Method[]
-    end
+    Aqua.test_all(SparseArrays; unbound_args=(; broken=true), piracies=(; broken=true))
 end
 
 let ambig = detect_ambiguities(SparseArrays; recursive=true)


### PR DESCRIPTION
This change makes updating Aqua and getting all new functionality as easy as bumping the compat version (for breaking releases).
With the current setup, you don't get any new tests.
Furthermore, we added functionality in Aqua itself to mark certain tests as `broken`.
Lastly, `detect_unbound_args_recursively` and `Piracies.hunt` are purely internal and subject to change in a non-breaking release in the near future.

cc @DilumAluthge 