### PR TITLE
Move `fkeep!` docstring to the right function

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1763,35 +1763,6 @@ end
 
 ## fkeep! and children tril!, triu!, droptol!, dropzeros[!]
 
-"""
-    fkeep!(f, A::AbstractSparseArray)
-
-Keep elements of `A` for which test `f` returns `true`. `f`'s signature should be
-
-    f(i::Integer, [j::Integer,] x) -> Bool
-
-where `i` and `j` are an element's row and column indices and `x` is the element's
-value. This method makes a single sweep
-through `A`, requiring `O(size(A, 2), nnz(A))`-time for matrices and `O(nnz(A))`-time for vectors
-and no space beyond that passed in.
-
-# Examples
-```jldoctest
-julia> A = sparse(Diagonal([1, 2, 3, 4]))
-4×4 SparseMatrixCSC{Int64, Int64} with 4 stored entries:
- 1  ⋅  ⋅  ⋅
- ⋅  2  ⋅  ⋅
- ⋅  ⋅  3  ⋅
- ⋅  ⋅  ⋅  4
-
-julia> SparseArrays.fkeep!((i, j, v) -> isodd(v), A)
-4×4 SparseMatrixCSC{Int64, Int64} with 2 stored entries:
- 1  ⋅  ⋅  ⋅
- ⋅  ⋅  ⋅  ⋅
- ⋅  ⋅  3  ⋅
- ⋅  ⋅  ⋅  ⋅
-```
-"""
 function _fkeep!(f::F, A::AbstractSparseMatrixCSC) where F<:Function
     An = size(A, 2)
     Acolptr = getcolptr(A)
@@ -1839,6 +1810,35 @@ function _fkeep!_fixed(f::F, A::AbstractSparseMatrixCSC) where F<:Function
     return A
 end
 
+"""
+    fkeep!(f, A::AbstractSparseArray)
+
+Keep elements of `A` for which test `f` returns `true`. `f`'s signature should be
+
+    f(i::Integer, [j::Integer,] x) -> Bool
+
+where `i` and `j` are an element's row and column indices and `x` is the element's
+value. This method makes a single sweep
+through `A`, requiring `O(size(A, 2), nnz(A))`-time for matrices and `O(nnz(A))`-time for vectors
+and no space beyond that passed in.
+
+# Examples
+```jldoctest
+julia> A = sparse(Diagonal([1, 2, 3, 4]))
+4×4 SparseMatrixCSC{Int64, Int64} with 4 stored entries:
+ 1  ⋅  ⋅  ⋅
+ ⋅  2  ⋅  ⋅
+ ⋅  ⋅  3  ⋅
+ ⋅  ⋅  ⋅  4
+
+julia> SparseArrays.fkeep!((i, j, v) -> isodd(v), A)
+4×4 SparseMatrixCSC{Int64, Int64} with 2 stored entries:
+ 1  ⋅  ⋅  ⋅
+ ⋅  ⋅  ⋅  ⋅
+ ⋅  ⋅  3  ⋅
+ ⋅  ⋅  ⋅  ⋅
+```
+"""
 fkeep!(f::F, A::AbstractSparseMatrixCSC) where F<:Function = _is_fixed(A) ? _fkeep!_fixed(f, A) : _fkeep!(f, A)
 
 # deprecated syntax

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -658,6 +658,12 @@ end
     @test s[3] === -0.0
 end
 
+if isdefined(Docs, :undocumented_names) # new in Julia 1.11
+    @testset "docstrings (issue julia#52725)" begin
+        @test isempty(Docs.undocumented_names(SparseArrays))
+    end
+end
+
 # As part of the migration of SparseArrays.jl into its own repo,
 # these tests have been moved from other files in julia tests to
 # the SparseArrays.jl repo


### PR DESCRIPTION
Handles the `SparseArrays` part of https://github.com/JuliaLang/julia/issues/52725.

The docstring was already there, it was just attached to the wrong function.

In which file should I put the test?
```julia
@test Docs.undocumented_names(SparseArrays) == []
```

cc @stevengj 