### PR TITLE
CI: Add Apple Silicon (macOS aarch64) to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         env:
           JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
-      - uses: julia-actions/setup-julia@v1.9.6 # TODO: change back to v1
+      - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ steps.determine-julia-arch.outputs.julia-arch }}
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v1
         with:
           # version: '1.6'
           version: 'nightly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest-xlarge
+          - macOS-latest
           - windows-latest
         arch:
           - x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
             exit 1
           fi
       - run: echo JULIA_ARCH is "${JULIA_ARCH:?}"
+        shell: bash
         env:
           JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         env:
           JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v1.9.6
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ steps.determine-julia-arch.outputs.julia-arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,19 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macOS-latest-xlarge
           - windows-latest
         arch:
           - x64
           - x86
+          - aarch64
         exclude:
-          - os: macOS-latest
+          - os: macOS-latest-xlarge
             arch: x86
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 on:
   pull_request:
-    branches:
-      - 'main'
-      - 'release-*'
   push:
     branches:
       - 'main'
@@ -16,13 +13,12 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        version:
+        julia-version:
           - 'nightly'
         os:
           - ubuntu-latest
@@ -71,7 +67,7 @@ jobs:
           JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.version }}
+          version: ${{ matrix.julia-version }}
           arch: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: actions/cache@v4
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,34 +38,6 @@ jobs:
             julia-word-size: '32'
     steps:
       - uses: actions/checkout@v4
-      - name: Determine the value of JULIA_ARCH
-        id: determine-julia-arch
-        shell: bash
-        env:
-          JULIA_WORD_SIZE: ${{ matrix.julia-word-size }}
-        run: |
-          echo "RUNNER_ARCH is: ${RUNNER_ARCH:?}"
-          echo "JULIA_WORD_SIZE is: ${JULIA_WORD_SIZE:?}"
-          if [[ "${JULIA_WORD_SIZE:?}" == "32" ]]; then
-            # If JULIA_WORD_SIZE is 32, then we hard-code JULIA_ARCH
-            # to be x86, because x86 is the only 32-bit arch that we
-            # test.
-            echo "julia-arch=x86" >> "${GITHUB_OUTPUT:?}"
-          elif [[ "$JULIA_WORD_SIZE" == "64" ]]; then
-            # If JULIA_WORD_SIZE is 64, then we set JULIA_ARCH to be
-            # the same as RUNNER_ARCH.
-            #
-            # Note: RUNNER_ARCH is an environment variable that is
-            # automatically set by GitHub Actions.
-            echo "julia-arch=${RUNNER_ARCH:?}" >> "${GITHUB_OUTPUT:?}"
-          else
-            echo "Invalid value for JULIA_WORD_SIZE: ${JULIA_WORD_SIZE:?}"
-            exit 1
-          fi
-      - run: echo JULIA_ARCH is "${JULIA_ARCH:?}"
-        shell: bash
-        env:
-          JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,50 +23,31 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-13 # Intel
-          - macos-14 # Apple Silicon
-        julia-word-size:
-          - '32'
-          - '64'
+          - macOS-13 # intel
+          - macOS-14 # arm
+        julia-arch:
+          - x64
+          - x86
+          - aarch64
         exclude:
-          - os: macos-13
-            julia-word-size: '32'
-          - os: macos-14
-            julia-word-size: '32'
+          - os: ubuntu-latest
+            julia-arch: aarch64
+          - os: windows-latest
+            julia-arch: aarch64
+          - os: macOS-13
+            julia-arch: x86
+          - os: macOS-13
+            julia-arch: aarch64
+          - os: macOS-14
+            julia-arch: x86
+          - os: macOS-14
+            julia-arch: x64
     steps:
       - uses: actions/checkout@v4
-      - name: Determine the value of JULIA_ARCH
-        id: determine-julia-arch
-        shell: bash
-        env:
-          JULIA_WORD_SIZE: ${{ matrix.julia-word-size }}
-        run: |
-          echo "RUNNER_ARCH is: ${RUNNER_ARCH:?}"
-          echo "JULIA_WORD_SIZE is: ${JULIA_WORD_SIZE:?}"
-          if [[ "${JULIA_WORD_SIZE:?}" == "32" ]]; then
-            # If JULIA_WORD_SIZE is 32, then we hard-code JULIA_ARCH
-            # to be x86, because x86 is the only 32-bit arch that we
-            # test.
-            echo "julia-arch=x86" >> "${GITHUB_OUTPUT:?}"
-          elif [[ "$JULIA_WORD_SIZE" == "64" ]]; then
-            # If JULIA_WORD_SIZE is 64, then we set JULIA_ARCH to be
-            # the same as RUNNER_ARCH.
-            #
-            # Note: RUNNER_ARCH is an environment variable that is
-            # automatically set by GitHub Actions.
-            echo "julia-arch=${RUNNER_ARCH:?}" >> "${GITHUB_OUTPUT:?}"
-          else
-            echo "Invalid value for JULIA_WORD_SIZE: ${JULIA_WORD_SIZE:?}"
-            exit 1
-          fi
-      - run: echo JULIA_ARCH is "${JULIA_ARCH:?}"
-        shell: bash
-        env:
-          JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
-          arch: ${{ steps.determine-julia-arch.outputs.julia-arch }}
+          arch: ${{ matrix.julia-arch }}
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         env:
           JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
-      - uses: julia-actions/setup-julia@v1.9.6
+      - uses: julia-actions/setup-julia@v1.9.6 # TODO: change back to v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ steps.determine-julia-arch.outputs.julia-arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,27 +25,43 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+          - windows-latest
           - macos-12 # Intel
           - macos-13 # Intel
           - macos-14 # Apple Silicon
-          - windows-latest
-        arch:
-          - x64
-          - x86
-          - aarch64
+        julia-word-size:
+          - '32'
+          - '64'
         exclude:
-          - os: macOS-latest-xlarge
-            arch: x86
-          - os: ubuntu-latest
-            arch: aarch64
-          - os: windows-latest
-            arch: aarch64
+          - os: macos-12
+            julia-word-size: '32'
+          - os: macos-13
+            julia-word-size: '32'
+          - os: macos-14
+            julia-word-size: '32'
     steps:
       - uses: actions/checkout@v4
+      - name: Determine the value of JULIA_ARCH
+        id: determine-julia-arch
+        shell: bash
+        env:
+          JULIA_WORD_SIZE: ${{ matrix.julia-word-size }}
+        run: |
+          echo "RUNNER_ARCH is: ${RUNNER_ARCH:?}"
+          if [[ "${JULIA_WORD_SIZE:?}" == "32" ]]; then
+            echo "julia-arch=x86" >> "${GITHUB_OUTPUT:?}"
+          elif [[ "$JULIA_WORD_SIZE" == "64" ]]; then
+            echo 'a is greater than b'
+            echo "julia-arch=${RUNNER_ARCH:?}" >> "${GITHUB_OUTPUT:?}"
+          else
+            echo "Invalid value for JULIA_WORD_SIZE: ${JULIA_WORD_SIZE:?}"
+            exit 1
+          fi
+      - run: JULIA_ARCH is "${{ steps.determine-julia-arch.outputs.julia-arch }}"
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ runner.arch }}
+          arch: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,26 @@ jobs:
           JULIA_WORD_SIZE: ${{ matrix.julia-word-size }}
         run: |
           echo "RUNNER_ARCH is: ${RUNNER_ARCH:?}"
+          echo "JULIA_WORD_SIZE is: ${JULIA_WORD_SIZE:?}"
           if [[ "${JULIA_WORD_SIZE:?}" == "32" ]]; then
+            # If JULIA_WORD_SIZE is 32, then we hard-code JULIA_ARCH
+            # to be x86, because x86 is the only 32-bit arch that we
+            # test.
             echo "julia-arch=x86" >> "${GITHUB_OUTPUT:?}"
           elif [[ "$JULIA_WORD_SIZE" == "64" ]]; then
-            echo 'a is greater than b'
+            # If JULIA_WORD_SIZE is 64, then we set JULIA_ARCH to be
+            # the same as RUNNER_ARCH.
+            #
+            # Note: RUNNER_ARCH is an environment variable that is
+            # automatically set by GitHub Actions.
             echo "julia-arch=${RUNNER_ARCH:?}" >> "${GITHUB_OUTPUT:?}"
           else
             echo "Invalid value for JULIA_WORD_SIZE: ${JULIA_WORD_SIZE:?}"
             exit 1
           fi
-      - run: JULIA_ARCH is "${{ steps.determine-julia-arch.outputs.julia-arch }}"
+      - run: JULIA_ARCH is "${JULIA_ARCH:?}"
+        env:
+          JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-12 # Intel
+          - macos-13 # Intel
+          - macos-14 # Apple Silicon
           - windows-latest
         arch:
           - x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,34 @@ jobs:
             julia-word-size: '32'
     steps:
       - uses: actions/checkout@v4
+      - name: Determine the value of JULIA_ARCH
+        id: determine-julia-arch
+        shell: bash
+        env:
+          JULIA_WORD_SIZE: ${{ matrix.julia-word-size }}
+        run: |
+          echo "RUNNER_ARCH is: ${RUNNER_ARCH:?}"
+          echo "JULIA_WORD_SIZE is: ${JULIA_WORD_SIZE:?}"
+          if [[ "${JULIA_WORD_SIZE:?}" == "32" ]]; then
+            # If JULIA_WORD_SIZE is 32, then we hard-code JULIA_ARCH
+            # to be x86, because x86 is the only 32-bit arch that we
+            # test.
+            echo "julia-arch=x86" >> "${GITHUB_OUTPUT:?}"
+          elif [[ "$JULIA_WORD_SIZE" == "64" ]]; then
+            # If JULIA_WORD_SIZE is 64, then we set JULIA_ARCH to be
+            # the same as RUNNER_ARCH.
+            #
+            # Note: RUNNER_ARCH is an environment variable that is
+            # automatically set by GitHub Actions.
+            echo "julia-arch=${RUNNER_ARCH:?}" >> "${GITHUB_OUTPUT:?}"
+          else
+            echo "Invalid value for JULIA_WORD_SIZE: ${JULIA_WORD_SIZE:?}"
+            exit 1
+          fi
+      - run: echo JULIA_ARCH is "${JULIA_ARCH:?}"
+        shell: bash
+        env:
+          JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          arch: ${{ runner.arch }}
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,12 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-12 # Intel
           - macos-13 # Intel
           - macos-14 # Apple Silicon
         julia-word-size:
           - '32'
           - '64'
         exclude:
-          - os: macos-12
-            julia-word-size: '32'
           - os: macos-13
             julia-word-size: '32'
           - os: macos-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             echo "Invalid value for JULIA_WORD_SIZE: ${JULIA_WORD_SIZE:?}"
             exit 1
           fi
-      - run: JULIA_ARCH is "${JULIA_ARCH:?}"
+      - run: echo JULIA_ARCH is "${JULIA_ARCH:?}"
         env:
           JULIA_ARCH: ${{ steps.determine-julia-arch.outputs.julia-arch }}
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
GitHub Actions now offers free Apple Silicon macOS runners for public repositories:

> Today, GitHub is excited to announce the launch of a new M1 macOS runner! This runner is available for all plans, free in public repositories, and eligible to consume included free plan minutes in private repositories. The new runner executes Actions workflows with a 3 vCPU, 7 GB RAM, and 14 GB of storage VM, which provides the latest Mac hardware Actions has to offer. The new runner operates exclusively on macOS 14 and to use it, simply update the `runs-on` key in your YAML workflow file to `macos-14`.

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

https://discourse.julialang.org/t/github-actions-now-offers-free-apple-silicon-macos-runners-for-public-repositories/109641