### PR TITLE
Speedup for `findmin()/findmax()` on sparse arrays (#510)

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2697,7 +2697,7 @@ function _findr(op, A::AbstractSparseMatrixCSC{Tv}, region) where {Tv}
                 Iv = CartesianIndex(rowval[j], i)
             end
         end
-        return (fill(Sv,1,1), fill(Iv,1,1))
+        return Sv, Iv
     else
         throw(ArgumentError("invalid value for region; must be 1, 2, or (1,2)"))
     end
@@ -2710,8 +2710,8 @@ findmin(A::AbstractSparseMatrixCSC{Tv}, region::Union{Integer,Tuple{Integer},NTu
     _findr(_isless_fm, A, region)
 findmax(A::AbstractSparseMatrixCSC{Tv}, region::Union{Integer,Tuple{Integer},NTuple{2,Integer}}) where {Tv} =
     _findr(_isgreater_fm, A, region)
-findmin(A::AbstractSparseMatrixCSC) = (r=findmin(A,(1,2)); (r[1][1], r[2][1]))
-findmax(A::AbstractSparseMatrixCSC) = (r=findmax(A,(1,2)); (r[1][1], r[2][1]))
+findmin(A::AbstractSparseMatrixCSC; dims::Union{Integer,Tuple{Integer},NTuple{2,Integer}}=(1,2)) = findmin(A, dims)
+findmax(A::AbstractSparseMatrixCSC; dims::Union{Integer,Tuple{Integer},NTuple{2,Integer}}=(1,2)) = findmax(A, dims)
 
 argmin(A::AbstractSparseMatrixCSC) = findmin(A)[2]
 argmax(A::AbstractSparseMatrixCSC) = findmax(A)[2]

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2629,7 +2629,7 @@ function _findz(A::AbstractSparseMatrixCSC{Tv,Ti}, rows=1:size(A, 1), cols=1:siz
     return CartesianIndex(0, 0)
 end
 
-function _findr(op, A, region, Tv)
+function _findr(op, A::AbstractSparseMatrixCSC{Tv}, region) where {Tv}
     require_one_based_indexing(A)
     Ti = eltype(keys(A))
     i1 = first(keys(A))
@@ -2707,9 +2707,9 @@ _isless_fm(a, b)    =  b == b && ( a != a || isless(a, b) )
 _isgreater_fm(a, b) =  b == b && ( a != a || isless(b, a) )
 
 findmin(A::AbstractSparseMatrixCSC{Tv}, region::Union{Integer,Tuple{Integer},NTuple{2,Integer}}) where {Tv} =
-    _findr(_isless_fm, A, region, Tv)
+    _findr(_isless_fm, A, region)
 findmax(A::AbstractSparseMatrixCSC{Tv}, region::Union{Integer,Tuple{Integer},NTuple{2,Integer}}) where {Tv} =
-    _findr(_isgreater_fm, A, region, Tv)
+    _findr(_isgreater_fm, A, region)
 findmin(A::AbstractSparseMatrixCSC) = (r=findmin(A,(1,2)); (r[1][1], r[2][1]))
 findmax(A::AbstractSparseMatrixCSC) = (r=findmax(A,(1,2)); (r[1][1], r[2][1]))
 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2697,7 +2697,7 @@ function _findr(op, A::AbstractSparseMatrixCSC{Tv}, region) where {Tv}
                 Iv = CartesianIndex(rowval[j], i)
             end
         end
-        return Sv, Iv
+        return (fill(Sv,1,1), fill(Iv,1,1))
     else
         throw(ArgumentError("invalid value for region; must be 1, 2, or (1,2)"))
     end
@@ -2710,8 +2710,10 @@ findmin(A::AbstractSparseMatrixCSC{Tv}, region::Union{Integer,Tuple{Integer},NTu
     _findr(_isless_fm, A, region)
 findmax(A::AbstractSparseMatrixCSC{Tv}, region::Union{Integer,Tuple{Integer},NTuple{2,Integer}}) where {Tv} =
     _findr(_isgreater_fm, A, region)
-findmin(A::AbstractSparseMatrixCSC; dims::Union{Integer,Tuple{Integer},NTuple{2,Integer}}=(1,2)) = findmin(A, dims)
-findmax(A::AbstractSparseMatrixCSC; dims::Union{Integer,Tuple{Integer},NTuple{2,Integer}}=(1,2)) = findmax(A, dims)
+findmin(A::AbstractSparseMatrixCSC; dims::Union{Nothing,Integer,Tuple{Integer},NTuple{2,Integer}} = nothing) =
+    isnothing(dims) ? (r = findmin(A, (1,2)); (r[1][1], r[2][1])) : findmin(A, dims)
+findmax(A::AbstractSparseMatrixCSC; dims::Union{Nothing,Integer,Tuple{Integer},NTuple{2,Integer}} = nothing) =
+    isnothing(dims) ? (r = findmax(A, (1,2)); (r[1][1], r[2][1])) : findmax(A, dims)
 
 argmin(A::AbstractSparseMatrixCSC) = findmin(A)[2]
 argmax(A::AbstractSparseMatrixCSC) = findmax(A)[2]

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -241,7 +241,8 @@ dA = Array(sA)
     @testset "empty cases" begin
         errchecker(str) = occursin(": reducing over an empty collection is not allowed", str) ||
                           occursin(": reducing with ", str) ||
-                          occursin("collection slices must be non-empty", str)
+                          occursin("collection slices must be non-empty", str) ||
+                          occursin("array slices must be non-empty", str)
         @test sum(sparse(Int[])) === 0
         @test prod(sparse(Int[])) === 1
         @test_throws errchecker minimum(sparse(Int[]))
@@ -331,10 +332,10 @@ end
 @testset "argmax, argmin, findmax, findmin" begin
     S = sprand(100,80, 0.5)
     A = Array(S)
-    @test @inferred(argmax(S)) == argmax(A)
-    @test @inferred(argmin(S)) == argmin(A)
-    @test @inferred(findmin(S)) == findmin(A)
-    @test @inferred(findmax(S)) == findmax(A)
+    @test argmax(S) == argmax(A)
+    @test argmin(S) == argmin(A)
+    @test findmin(S) == findmin(A)
+    @test findmax(S) == findmax(A)
     for region in [(1,), (2,), (1,2)], m in [findmax, findmin]
         @test m(S, dims=region) == m(A, dims=region)
     end

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -332,10 +332,10 @@ end
 @testset "argmax, argmin, findmax, findmin" begin
     S = sprand(100,80, 0.5)
     A = Array(S)
-    @test argmax(S) == argmax(A)
-    @test argmin(S) == argmin(A)
-    @test findmin(S) == findmin(A)
-    @test findmax(S) == findmax(A)
+    @test @inferred(argmax(S)) == argmax(A)
+    @test @inferred(argmin(S)) == argmin(A)
+    @test @inferred(findmin(S)) == findmin(A)
+    @test @inferred(findmax(S)) == findmax(A)
     for region in [(1,), (2,), (1,2)], m in [findmax, findmin]
         @test m(S, dims=region) == m(A, dims=region)
     end


### PR DESCRIPTION
1. Parameterised `_findr()` on the element type of the sparse array. Otherwise, every single `op()` comparison allocates, every time `_findr()` is called (not sure if there is another way to optimise those allocations away).
2. Added a keyword argument `dims` to the existing functions, with default values to preserve current behaviours when `dims` is not provided.
3. Changed the type of `_findr()` a bit. It's not used anywhere else, and the change simplifies the previous changes.

(Example: https://pastebin.com/raw/47xxMkHa shows different allocation and timing behaviour at different stages of the 2 included commits. The direct `_findr()` needs to be adjusted to account for the type change)

Fixes #510.