### PR TITLE
SparseMatrixCSC constructor with a Tuple of Integers

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -49,10 +49,12 @@ SparseMatrixCSC(m, n, colptr::ReadOnly, rowval::ReadOnly, nzval::Vector) =
 
 """
     SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer)
+    SparseMatrixCSC{Tv,Ti}(::UndefInitializer, (m,n)::NTuple{2,Integer})
 
 Creates an empty sparse matrix with element type `Tv` and integer type `Ti` of size `m × n`.
 """
 SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer) where {Tv, Ti} = spzeros(Tv, Ti, m, n)
+SparseMatrixCSC{Tv,Ti}(::UndefInitializer, mn::NTuple{2,Integer}) where {Tv, Ti} = spzeros(Tv, Ti, mn...)
 
 """
     FixedSparseCSC{Tv,Ti<:Integer} <: AbstractSparseMatrixCSC{Tv,Ti}

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -50,6 +50,7 @@ SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
     SparseVector{Tv,Ti}(n, nzind, nzval)
 
 SparseVector{Tv, Ti}(::UndefInitializer, n::Integer) where {Tv, Ti}  = SparseVector{Tv, Ti}(n, Ti[], Tv[])
+SparseVector{Tv, Ti}(::UndefInitializer, (n,)::Tuple{Integer}) where {Tv, Ti}  = SparseVector{Tv, Ti}(n, Ti[], Tv[])
 
 """
     FixedSparseVector{Tv,Ti<:Integer} <: AbstractCompressedVector{Tv,Ti}

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -57,10 +57,13 @@ end
     @test sparse([1, 1, 2, 2, 2], [1, 2, 1, 2, 2], -1.0, 2, 2, *) == sparse([1, 1, 2, 2], [1, 2, 1, 2], [-1.0, -1.0, -1.0, 1.0], 2, 2)
     @test sparse(sparse(Int32.(1:5), Int32.(1:5), trues(5))') isa SparseMatrixCSC{Bool,Int32}
     # undef initializer
-    m = SparseMatrixCSC{Float32, Int16}(undef, 3, 4)
-    @test size(m) == (3, 4)
-    @test eltype(m) === Float32
-    @test m == spzeros(3, 4)
+    sz = (3, 4)
+    for m in (SparseMatrixCSC{Float32, Int16}(undef, sz...), SparseMatrixCSC{Float32, Int16}(undef, sz),
+                 similar(SparseMatrixCSC{Float32, Int16}, sz))
+        @test size(m) == sz
+        @test eltype(m) === Float32
+        @test m == spzeros(sz...)
+    end
 end
 
 @testset "spzeros for pattern creation (structural zeros)" begin

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -219,10 +219,14 @@ end
     end
 
     @testset "Undef initializer" begin
-        v = SparseVector{Float32, Int16}(undef, 4)
-        @test size(v) == (4, )
-        @test eltype(v) === Float32
-        @test v == spzeros(Float32, 4)
+        sz = (4,)
+        for v in (SparseVector{Float32, Int16}(undef, sz),
+                    SparseVector{Float32, Int16}(undef, sz...),
+                    similar(SparseVector{Float32, Int16}, sz))
+            @test size(v) == sz
+            @test eltype(v) === Float32
+            @test v == spzeros(Float32, sz...)
+        end
     end
 end
 ### Element access


### PR DESCRIPTION
With this, the following works:
```julia
julia> similar(SparseMatrixCSC{Float64,Int}, 2,2)
2×2 SparseMatrixCSC{Float64, Int64} with 0 stored entries:
  ⋅    ⋅ 
  ⋅    ⋅ 
```
Previously, this used to call the `SparseMatrixCSC` constructor with a `Tuple` of `Int`s, which was not defined. Similar constructors are added for `SparseVector`.

This should probably be backported to v1.11 as well as v1.10. I added the backport 1.10 label, but there doesn't seem to be one for v1.11.