### PR TITLE
CI: don't run `threads` tests in Windows GHA CI

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,9 @@ if Base.USE_GPL_LIBS
                 @warn "Skipping `threads` tests on Windows on GitHub Actions CI"
                 @test_broken false
             else
+                @info "Beginning `threads` tests..."
                 include("threads.jl")
+                @info "Finished `threads` tests"
             end
         end
         # test both nthreads==1 and nthreads>1. spawn a process to test whichever

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,18 @@ if Base.USE_GPL_LIBS
     # Test multithreaded execution
     @testset "threaded SuiteSparse tests" verbose = true begin
         @testset "threads = $nt" begin
-            include("threads.jl")
+            # 1. If the OS is Windows and we are in GitHub Actions CI, we do NOT run the `threads` tests.
+            # 2. If the OS is Windows and we are NOT in GitHub Actions CI, we DO run the `threads` tests.
+            # 3. If the OS is NOT Windows, we DO run the `threads` tests.
+            #
+            # So, just for example:
+            # - If the OS is Windows and we are in Buildkite CI, we DO run the `threads` tests.
+            if Sys.iswindows() && is_github_actions_ci()
+                @warn "Skipping `threads` tests on Windows on GitHub Actions CI"
+                @test_broken false
+            else
+                include("threads.jl")
+            end
         end
         # test both nthreads==1 and nthreads>1. spawn a process to test whichever
         # case we are not running currently.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,12 @@ if Base.USE_GPL_LIBS
     # Test multithreaded execution
     @testset "threaded SuiteSparse tests" verbose = true begin
         @testset "threads = $nt" begin
+            include("threads.jl")
+        end
+        # test both nthreads==1 and nthreads>1. spawn a process to test whichever
+        # case we are not running currently.
+        other_nthreads = nt == 1 ? 4 : 1
+        @testset "threads = $other_nthreads" begin
             # 1. If the OS is Windows and we are in GitHub Actions CI, we do NOT run the `threads` tests.
             # 2. If the OS is Windows and we are NOT in GitHub Actions CI, we DO run the `threads` tests.
             # 3. If the OS is NOT Windows, we DO run the `threads` tests.
@@ -34,29 +40,21 @@ if Base.USE_GPL_LIBS
                 @warn "Skipping `threads` tests on Windows on GitHub Actions CI"
                 @test_broken false
             else
-                @info "Beginning `threads` tests..."
-                include("threads.jl")
-                @info "Finished `threads` tests"
-            end
-        end
-        # test both nthreads==1 and nthreads>1. spawn a process to test whichever
-        # case we are not running currently.
-        other_nthreads = nt == 1 ? 4 : 1
-        @testset "threads = $other_nthreads" begin
-            let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
-                p = run(
-                        pipeline(
-                            setenv(
-                                cmd,
-                                "JULIA_NUM_THREADS" => other_nthreads,
-                                dir=@__DIR__()),
-                            stdout = stdout,
-                            stderr = stderr),
-                        wait = false)
-                if !success(p)
-                    error("SuiteSparse threads test failed with nthreads == $other_nthreads")
-                else
-                    @test true # mimic the one @test in threads.jl
+                let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
+                    p = run(
+                            pipeline(
+                                setenv(
+                                    cmd,
+                                    "JULIA_NUM_THREADS" => other_nthreads,
+                                    dir=@__DIR__()),
+                                stdout = stdout,
+                                stderr = stderr),
+                            wait = false)
+                    if !success(p)
+                        error("SuiteSparse threads test failed with nthreads == $other_nthreads")
+                    else
+                        @test true # mimic the one @test in threads.jl
+                    end
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 using Test, LinearAlgebra, SparseArrays
 
+# Some utility functions:
+include("util/gha.jl")
+
 if Base.get_bool_env("SPARSEARRAYS_AQUA_TEST", false)
     include("ambiguous.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,12 +30,13 @@ if Base.USE_GPL_LIBS
         # case we are not running currently.
         other_nthreads = nt == 1 ? 4 : 1
         @testset "threads = $other_nthreads" begin
-            # 1. If the OS is Windows and we are in GitHub Actions CI, we do NOT run the `threads` tests.
-            # 2. If the OS is Windows and we are NOT in GitHub Actions CI, we DO run the `threads` tests.
+            # 1. If the OS is Windows and we are in GitHub Actions CI, we do NOT run
+            #    the `threads` tests.
+            # 2. If the OS is Windows and we are NOT in GitHub Actions CI, we DO run
+            #    the `threads` tests.
+            #        - So, just as an example, if the OS is Windows and we are in
+            #          Buildkite CI, we DO run the `threads` tests.
             # 3. If the OS is NOT Windows, we DO run the `threads` tests.
-            #
-            # So, just for example:
-            # - If the OS is Windows and we are in Buildkite CI, we DO run the `threads` tests.
             if Sys.iswindows() && is_github_actions_ci()
                 @warn "Skipping `threads` tests on Windows on GitHub Actions CI"
                 @test_broken false

--- a/test/util/gha.jl
+++ b/test/util/gha.jl
@@ -1,0 +1,6 @@
+function is_github_actions_ci()
+    is_ci  = parse(Bool, get(ENV, "CI",             "false"))
+    is_gha = parse(Bool, get(ENV, "GITHUB_ACTIONS", "false"))
+
+    return is_ci && is_gha
+end


### PR DESCRIPTION
Ref #531

1. Do run `threads` tests on non-Windows
2. Do run `threads` tests on Windows on Buildkite CI
3. Do NOT run `threads` tests on Windows on GitHub Actions CI