### PR TITLE
Sparse versions of repeat for matrices and vectors

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -3908,11 +3908,12 @@ function vcat(X::AbstractSparseMatrixCSC...)
         ptr_res = colptr[c]
         for i = 1 : num
             colptrXi = getcolptr(X[i])
+            rowvalXi = rowvals(X[i])
+            nzvalXi = nonzeros(X[i])
             col_length = colptrXi[c + 1] - colptrXi[c]
             ptr_Xi = colptrXi[c]
 
-            stuffcol!(X[i], colptr, rowval, nzval,
-                      ptr_res, ptr_Xi, col_length, mX_sofar)
+            stuffcol!(rowval, nzval, ptr_res, rowvalXi, nzvalXi, ptr_Xi, col_length, mX_sofar)
 
             ptr_res += col_length
             mX_sofar += mX[i]
@@ -3922,12 +3923,8 @@ function vcat(X::AbstractSparseMatrixCSC...)
     SparseMatrixCSC(m, n, colptr, rowval, nzval)
 end
 
-@inline function stuffcol!(Xi::AbstractSparseMatrixCSC, colptr, rowval, nzval,
-                           ptr_res, ptr_Xi, col_length, mX_sofar)
-    colptrXi = getcolptr(Xi)
-    rowvalXi = rowvals(Xi)
-    nzvalXi  = nonzeros(Xi)
-
+@inline function stuffcol!(rowval, nzval, ptr_res, rowvalXi, nzvalXi, ptr_Xi,
+                           col_length, mX_sofar)
     for k=ptr_res:(ptr_res + col_length - 1)
         @inbounds rowval[k] = rowvalXi[ptr_Xi] + mX_sofar
         @inbounds nzval[k]  = nzvalXi[ptr_Xi]

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -3911,9 +3911,8 @@ function vcat(X::AbstractSparseMatrixCSC...)
             col_length = colptrXi[c + 1] - colptrXi[c]
             ptr_Xi = colptrXi[c]
 
-            stuffcol!(rowval, nzval, ptr_res, rowvals(X[i]), nonzeros(X[i]), ptr_Xi, col_length, mX_sofar)
-
-            ptr_res += col_length
+            ptr_res = stuffcol!(rowval, nzval, ptr_res, rowvals(X[i]), nonzeros(X[i]), ptr_Xi,
+                                col_length, mX_sofar)
             mX_sofar += mX[i]
         end
         colptr[c + 1] = ptr_res
@@ -3928,6 +3927,7 @@ end
         @inbounds nzval[k]  = nzvalXi[ptr_Xi]
         ptr_Xi += 1
     end
+    return ptr_res + col_length
 end
 
 function hcat(X::AbstractSparseMatrixCSC...)
@@ -3984,9 +3984,8 @@ function Base.repeat(A::AbstractSparseMatrixCSC, m)
         col_length = getcolptr(A)[c + 1] - ptr_source
         for index_repetition = 0 : (m - 1)
             row_offset = index_repetition * size(A, 1)
-            stuffcol!(rowval, nzval, ptr_res, rowvals(A), nonzeros(A), ptr_source,
-                      col_length, row_offset)
-            ptr_res += col_length
+            ptr_res = stuffcol!(rowval, nzval, ptr_res, rowvals(A), nonzeros(A), ptr_source,
+                                col_length, row_offset)
         end
         colptr[c + 1] = ptr_res
     end

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -3908,13 +3908,13 @@ function vcat(X::AbstractSparseMatrixCSC...)
         ptr_res = colptr[c]
         for i = 1 : num
             colptrXi = getcolptr(X[i])
-            col_length = (colptrXi[c + 1] - 1) - colptrXi[c]
+            col_length = colptrXi[c + 1] - colptrXi[c]
             ptr_Xi = colptrXi[c]
 
             stuffcol!(X[i], colptr, rowval, nzval,
                       ptr_res, ptr_Xi, col_length, mX_sofar)
 
-            ptr_res += col_length + 1
+            ptr_res += col_length
             mX_sofar += mX[i]
         end
         colptr[c + 1] = ptr_res
@@ -3928,7 +3928,7 @@ end
     rowvalXi = rowvals(Xi)
     nzvalXi  = nonzeros(Xi)
 
-    for k=ptr_res:(ptr_res + col_length)
+    for k=ptr_res:(ptr_res + col_length - 1)
         @inbounds rowval[k] = rowvalXi[ptr_Xi] + mX_sofar
         @inbounds nzval[k]  = nzvalXi[ptr_Xi]
         ptr_Xi += 1

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -3908,12 +3908,10 @@ function vcat(X::AbstractSparseMatrixCSC...)
         ptr_res = colptr[c]
         for i = 1 : num
             colptrXi = getcolptr(X[i])
-            rowvalXi = rowvals(X[i])
-            nzvalXi = nonzeros(X[i])
             col_length = colptrXi[c + 1] - colptrXi[c]
             ptr_Xi = colptrXi[c]
 
-            stuffcol!(rowval, nzval, ptr_res, rowvalXi, nzvalXi, ptr_Xi, col_length, mX_sofar)
+            stuffcol!(rowval, nzval, ptr_res, rowvals(X[i]), nonzeros(X[i]), ptr_Xi, col_length, mX_sofar)
 
             ptr_res += col_length
             mX_sofar += mX[i]
@@ -3974,23 +3972,19 @@ end
 # Efficient repetition of sparse matrices
 
 function Base.repeat(A::AbstractSparseMatrixCSC, m)
-    colptr_source = getcolptr(A)
-    rowval_source = rowvals(A)
-    nzval_source = nonzeros(A)
-
     nnz_new = nnz(A) * m
-    colptr = similar(colptr_source, length(colptr_source))
-    rowval = similar(rowval_source, nnz_new)
-    nzval = similar(nzval_source, nnz_new)
+    colptr = similar(getcolptr(A), length(getcolptr(A)))
+    rowval = similar(rowvals(A), nnz_new)
+    nzval = similar(nonzeros(A), nnz_new)
 
     colptr[1] = 1
     for c = 1 : size(A, 2)
         ptr_res = colptr[c]
-        ptr_source = colptr_source[c]
-        col_length = colptr_source[c + 1] - ptr_source
+        ptr_source = getcolptr(A)[c]
+        col_length = getcolptr(A)[c + 1] - ptr_source
         for index_repetition = 0 : (m - 1)
             row_offset = index_repetition * size(A, 1)
-            stuffcol!(rowval, nzval, ptr_res, rowval_source, nzval_source, ptr_source,
+            stuffcol!(rowval, nzval, ptr_res, rowvals(A), nonzeros(A), ptr_source,
                       col_length, row_offset)
             ptr_res += col_length
         end

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1320,8 +1320,7 @@ function Base.repeat(v::AbstractSparseVector, m)
     ptr_res = 1
     for index_repetition = 0:(m-1)
         row_offset = index_repetition * length(v)
-        stuffcol!(nzind, nzval, ptr_res, nonzeroinds(v), nonzeros(v), 1, nnz_source, row_offset)
-        ptr_res += nnz_source
+        ptr_res = stuffcol!(nzind, nzval, ptr_res, nonzeroinds(v), nonzeros(v), 1, nnz_source, row_offset)
     end
     @assert ptr_res == nnz_new + 1
 

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1314,14 +1314,13 @@ function Base.repeat(v::AbstractSparseVector, m)
     nnz_source = nnz(v)
     nnz_new = nnz_source * m
 
-    nzind_source, nzval_source = findnz(v)
-    nzind = similar(nzind_source, nnz_new)
-    nzval = similar(nzval_source, nnz_new)
+    nzind = similar(nonzeroinds(v), nnz_new)
+    nzval = similar(nonzeros(v), nnz_new)
 
     ptr_res = 1
     for index_repetition = 0:(m-1)
         row_offset = index_repetition * length(v)
-        stuffcol!(nzind, nzval, ptr_res, nzind_source, nzval_source, 1, nnz_source, row_offset)
+        stuffcol!(nzind, nzval, ptr_res, nonzeroinds(v), nonzeros(v), 1, nnz_source, row_offset)
         ptr_res += nnz_source
     end
     @assert ptr_res == nnz_new + 1
@@ -1331,11 +1330,9 @@ end
 
 function Base.repeat(v::AbstractSparseVector, m, n)
     w = repeat(v, m)
-    nzind_source, nzval_source = findnz(w)
-
-    colptr = Vector{eltype(nzind_source)}(1 .+ nnz(w) * (0:n))
-    rowval = repeat(nzind_source, n)
-    nzval = repeat(nzval_source, n)
+    colptr = Vector{eltype(nonzeroinds(w))}(1 .+ nnz(w) * (0:n))
+    rowval = repeat(nonzeroinds(w), n)
+    nzval = repeat(nonzeros(w), n)
     SparseMatrixCSC(length(w), n, colptr, rowval, nzval)
 end
 

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1308,6 +1308,38 @@ hvcat(rows::Tuple{Vararg{Int}}, n1::Number, ns::Vararg{Number}) = invoke(hvcat, 
 hvcat(rows::Tuple{Vararg{Int}}, n1::N, ns::Vararg{N}) where {N<:Number} = invoke(hvcat, Tuple{typeof(rows), Vararg{N}}, rows, n1, ns...)
 
 
+### Efficient repetition of sparse vectors
+
+function Base.repeat(v::AbstractSparseVector, m)
+    nnz_source = nnz(v)
+    nnz_new = nnz_source * m
+
+    nzind_source, nzval_source = findnz(v)
+    nzind = similar(nzind_source, nnz_new)
+    nzval = similar(nzval_source, nnz_new)
+
+    ptr_res = 1
+    for index_repetition = 0:(m-1)
+        row_offset = index_repetition * length(v)
+        stuffcol!(nzind, nzval, ptr_res, nzind_source, nzval_source, 1, nnz_source, row_offset)
+        ptr_res += nnz_source
+    end
+    @assert ptr_res == nnz_new + 1
+
+    SparseVector(length(v) * m, nzind, nzval)
+end
+
+function Base.repeat(v::AbstractSparseVector, m, n)
+    w = repeat(v, m)
+    nzind_source, nzval_source = findnz(w)
+
+    colptr = Vector{eltype(nzind_source)}(1 .+ nnz(w) * (0:n))
+    rowval = repeat(nzind_source, n)
+    nzval = repeat(nzval_source, n)
+    SparseMatrixCSC(length(w), n, colptr, rowval, nzval)
+end
+
+
 # make sure UniformScaling objects are converted to sparse matrices for concatenation
 promote_to_array_type(A::Tuple{Vararg{Union{_SparseConcatGroup,UniformScaling}}}) = anysparse(A...) ? SparseMatrixCSC : Matrix
 promote_to_arrays_(n::Int, ::Type{SparseMatrixCSC}, J::UniformScaling) = sparse(J, n, n)

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -302,6 +302,19 @@ end
     end
 end
 
+@testset "repeat tests" begin
+    A = sprand(6, 4, 0.5)
+    A_full = Matrix(A)
+    for m = 0:3
+        @test issparse(repeat(A, m))
+        @test repeat(A, m) == repeat(A_full, m)
+        for n = 0:3
+            @test issparse(repeat(A, m, n))
+            @test repeat(A, m, n) == repeat(A_full, m, n)
+        end
+    end
+end
+
 @testset "copyto!" begin
     A = sprand(5, 5, 0.2)
     B = sprand(5, 5, 0.2)

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -635,6 +635,18 @@ end
         end
     end
 end
+
+@testset "repeat" begin
+    for m = 0:3
+        @test issparse(repeat(spv_x1, m))
+        @test repeat(spv_x1, m) == repeat(x1_full, m)
+        for n = 0:3
+            @test issparse(repeat(spv_x1, m, n))
+            @test repeat(spv_x1, m, n) == repeat(x1_full, m, n)
+        end
+    end
+end
+
 @testset "sparsemat: combinations with sparse matrix" begin
     let S = sprand(4, 8, 0.5)
         Sf = Array(S)


### PR DESCRIPTION
Calling `repeat` for sparse matrices or vectors currently calls the `Base` function, which ends up building the result rather inefficiently with indexing brackets.

This would add sparse versions that use the info that inputs are in CSC format to provide more efficient implementations. To keep it simple it is limited to the straightforward cases of outer repetition along the first two dimensions. Row-wise repetition is intentionally kept close to the implementation for `vcat`, also using its helper function `stuffcol!` (with slight modifications). Column-wise repetition is kept simple by deferring to `Base.repeat` on the `colptr`, `rowval`, and `nzval` components of the CSC format.