### PR TITLE
Extend `copytrito!` for a sparse source

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -18,7 +18,7 @@ import Base: +, -, *, \, /, &, |, xor, ==, zero, @propagate_inbounds
 import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!, isbanded,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu,
-    matprod_dest, generic_matvecmul!, generic_matmatmul!
+    matprod_dest, generic_matvecmul!, generic_matmatmul!, copytrito!
 
 import Base: adjoint, argmin, argmax, Array, broadcast, circshift!, complex, Complex,
     conj, conj!, convert, copy, copy!, copyto!, count, diff, findall, findmax, findmin,

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -4558,8 +4558,7 @@ function copytrito!(M::AbstractMatrix, S::AbstractSparseMatrixCSC, uplo::Char)
         for i in nzrange(S, col)
             row = rv[i]
             (uplo == 'U' && row <= col) || (uplo == 'L' && row >= col) || continue
-            v = nz[i]
-            M[row, col] = v 
+            M[row, col] = nz[i]
         end
     end 
     return M

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -623,6 +623,7 @@ end
             @test M[row, col] == S[row, col]
         end
     end
+    @test_throws ArgumentError copytrito!(M, S, 'M')
 end
 
 end # module

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -601,4 +601,28 @@ end
     end
 end
 
+@testset "copytrito!" begin
+    S = sparse([1,2,2,2,3], [1,1,2,2,4], [5, -19, 73, 12, -7])
+    M = fill(Inf, size(S))
+    copytrito!(M, S, 'U')
+    for col in axes(S, 2)
+        for row in 1:min(col, size(S,1))
+            @test M[row, col] == S[row, col]
+        end
+        for row in min(col, size(S,1))+1:size(S,1)
+            @test isinf(M[row, col])
+        end
+    end
+    M .= Inf
+    copytrito!(M, S, 'L')
+    for col in axes(S, 2)
+        for row in 1:col-1
+            @test isinf(M[row, col])
+        end
+        for row in col:size(S, 1)
+            @test M[row, col] == S[row, col]
+        end
+    end
+end
+
 end # module


### PR DESCRIPTION
```julia
julia> S = sprand(100, 100, 0.01);

julia> M = zeros(size(S));

julia> @btime copytrito!($M, $S, 'U');
  20.779 μs (0 allocations: 0 bytes) # main
  2.050 μs (0 allocations: 0 bytes) # this PR
```