### PR TITLE
Add versioned Manifest files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Manifest.toml
+Manifest-v*.*.toml
 docs/build


### PR DESCRIPTION
Julia v1.11 supports Manifest files with the version in the filename, and we may ignore these files as well.