### PR TITLE
test: Don't use GPL module when Base.USE_GPL_LIBS=false

### DIFF
--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -1,12 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module CHOLMODTests
+using Test
 
 @static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping CHOLMOD Tests"
 else
 
-using Test
 using SparseArrays.CHOLMOD
 using SparseArrays.CHOLMOD: getcommon
 using Random

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -4,7 +4,7 @@ module CHOLMODTests
 using Test
 
 @static if !Base.USE_GPL_LIBS
-    @info "Not use GPL libs, Skipping CHOLMOD Tests"
+    @info "This Julia build excludes the use of SuiteSparse GPL libraries. Skipping CHOLMOD tests"
 else
 
 using SparseArrays.CHOLMOD

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -2,7 +2,7 @@
 
 module CHOLMODTests
 
-if !Base.USE_GPL_LIBS
+@static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping CHOLMOD Tests"
 else
 

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -2,6 +2,10 @@
 
 module CHOLMODTests
 
+if !Base.USE_GPL_LIBS
+    @info "Not use GPL libs, Skipping CHOLMOD Tests"
+else
+
 using Test
 using SparseArrays.CHOLMOD
 using SparseArrays.CHOLMOD: getcommon
@@ -15,8 +19,6 @@ using SparseArrays
 using SparseArrays: getcolptr
 using SparseArrays.LibSuiteSparse
 using SparseArrays.LibSuiteSparse: cholmod_l_allocate_sparse, cholmod_allocate_sparse
-
-if Base.USE_GPL_LIBS
 
 # CHOLMOD tests
 itypes = sizeof(Int) == 4 ? (Int32,) : (Int32, Int64)

--- a/test/linalg_solvers.jl
+++ b/test/linalg_solvers.jl
@@ -1,12 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module SparseLinalgSolversTests
+using Test
 
 @static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping SparseLinalgSolvers Tests"
 else
 
-using Test
 using SparseArrays
 using Random
 using LinearAlgebra

--- a/test/linalg_solvers.jl
+++ b/test/linalg_solvers.jl
@@ -4,7 +4,7 @@ module SparseLinalgSolversTests
 using Test
 
 @static if !Base.USE_GPL_LIBS
-    @info "Not use GPL libs, Skipping SparseLinalgSolvers Tests"
+    @info "This Julia build excludes the use of SuiteSparse GPL libraries. Skipping SparseLinalgSolvers Tests"
 else
 
 using SparseArrays

--- a/test/linalg_solvers.jl
+++ b/test/linalg_solvers.jl
@@ -2,7 +2,7 @@
 
 module SparseLinalgSolversTests
 
-if !Base.USE_GPL_LIBS
+@static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping SparseLinalgSolvers Tests"
 else
 

--- a/test/linalg_solvers.jl
+++ b/test/linalg_solvers.jl
@@ -2,12 +2,14 @@
 
 module SparseLinalgSolversTests
 
+if !Base.USE_GPL_LIBS
+    @info "Not use GPL libs, Skipping SparseLinalgSolvers Tests"
+else
+
 using Test
 using SparseArrays
 using Random
 using LinearAlgebra
-
-if Base.USE_GPL_LIBS
 
 @testset "explicit zeros" begin
     a = SparseMatrixCSC(2, 2, [1, 3, 5], [1, 2, 1, 2], [1.0, 0.0, 0.0, 1.0])

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -2,6 +2,10 @@
 
 module SPQRTests
 
+if !Base.USE_GPL_LIBS
+    @info "Not use GPL libs, Skipping SPQR Tests"
+else
+
 using Test
 using SparseArrays.SPQR
 using SparseArrays.CHOLMOD
@@ -10,7 +14,7 @@ using SparseArrays: SparseArrays, sparse, sprandn, spzeros, SparseMatrixCSC
 using Random: seed!
 
 # TODO REMOVE SECOND PREDICATE WITH SS7.1
-if Base.USE_GPL_LIBS
+
 @testset "Sparse QR" begin
 m, n = 100, 10
 nn = 100

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -13,7 +13,6 @@ using LinearAlgebra: I, istriu, norm, qr, rank, rmul!, lmul!, Adjoint, Transpose
 using SparseArrays: SparseArrays, sparse, sprandn, spzeros, SparseMatrixCSC
 using Random: seed!
 
-# TODO REMOVE SECOND PREDICATE WITH SS7.1
 
 @testset "Sparse QR" begin
 m, n = 100, 10

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -4,7 +4,7 @@ module SPQRTests
 using Test
 
 @static if !Base.USE_GPL_LIBS
-    @info "Not use GPL libs, Skipping SPQR Tests"
+    @info "This Julia build excludes the use of SuiteSparse GPL libraries. Skipping SPQR Tests"
 else
 
 using SparseArrays.SPQR

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -1,12 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module SPQRTests
+using Test
 
 @static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping SPQR Tests"
 else
 
-using Test
 using SparseArrays.SPQR
 using SparseArrays.CHOLMOD
 using LinearAlgebra: I, istriu, norm, qr, rank, rmul!, lmul!, Adjoint, Transpose, ColumnNorm, RowMaximum, NoPivot

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -2,7 +2,7 @@
 
 module SPQRTests
 
-if !Base.USE_GPL_LIBS
+@static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping SPQR Tests"
 else
 

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -2,7 +2,7 @@
 
 module UMFPACKTests
 
-if !Base.USE_GPL_LIBS
+@static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping UMFPACK Tests"
 else
 

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -4,7 +4,7 @@ module UMFPACKTests
 using Test
 
 @static if !Base.USE_GPL_LIBS
-    @info "Not use GPL libs, Skipping UMFPACK Tests"
+    @info "This Julia build excludes the use of SuiteSparse GPL libraries. Skipping UMFPACK Tests"
 else
 
 using Random

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -1,12 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module UMFPACKTests
+using Test
 
 @static if !Base.USE_GPL_LIBS
     @info "Not use GPL libs, Skipping UMFPACK Tests"
 else
 
-using Test
 using Random
 using SparseArrays
 using Serialization

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -2,6 +2,10 @@
 
 module UMFPACKTests
 
+if !Base.USE_GPL_LIBS
+    @info "Not use GPL libs, Skipping UMFPACK Tests"
+else
+
 using Test
 using Random
 using SparseArrays
@@ -9,7 +13,7 @@ using Serialization
 using LinearAlgebra:
     LinearAlgebra, I, det, issuccess, ldiv!, lu, lu!, Transpose, SingularException, Diagonal, logabsdet
 using SparseArrays: nnz, sparse, sprand, sprandn, SparseMatrixCSC, UMFPACK, increment!
-if Base.USE_GPL_LIBS
+
 function umfpack_report(l::UMFPACK.UmfpackLU)
     UMFPACK.umfpack_report_numeric(l, 0)
     UMFPACK.umfpack_report_symbolic(l, 0)


### PR DESCRIPTION
The GPL module `SparseArrays.CHOLMOD` has already been used before the `if Base.USE_GPL_LIBS` statement.

This results in the error
```
ERROR: LoadError: UndefVarError: `CHOLMOD` not defined in `SparseArrays`
Stacktrace:
```