### PR TITLE
tests to use fallback exception to handle `FieldError` exception

### DIFF
--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -27,7 +27,7 @@ itypes = sizeof(Int) == 4 ? (Int32,) : (Int32, Int64)
     else
         A = sparse(iltyA[1:n; rand(1:m, nn - n)], iltyA[1:n; rand(1:n, nn - n)], complex.(randn(nn), randn(nn)), m, n)
     end
-    
+
     F = qr(A)
     @test size(F) == (m,n)
     @test size(F, 1) == m
@@ -39,7 +39,7 @@ itypes = sizeof(Int) == 4 ? (Int32,) : (Int32, Int64)
         @test istriu(F.R)
         @test isperm(F.pcol)
         @test isperm(F.prow)
-        @test_throws ErrorException F.T
+        @test_throws isdefined(Base, :FieldError) ? FieldError : ErrorException F.T
     end
 
     @testset "apply Q" begin

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -178,7 +178,7 @@ end
             lua = lu(A)
             umfpack_report(lua)
             @test nnz(lua) == 18
-            @test_throws ErrorException lua.Z
+            @test_throws isdefined(Base, :FieldError) ? FieldError : ErrorException lua.Z
             L,U,p,q,Rs = lua.:(:)
             @test L == lua.L
             @test U == lua.U


### PR DESCRIPTION
with [#54504](https://github.com/JuliaLang/julia/pull/54504) field access exception is raised as `FieldError` exception now.