### PR TITLE
implement in-place `ldiv!` for Cholesky factorization

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1947,6 +1947,10 @@ for TI in IndexTypes
             throw(DimensionMismatch("Factorization and solution should match sizes. " *
                 "Factorization has $(size(L, 1)) columns, but solution has $(size(x, 1)) rows."))
         end
+        if size(x, 2) != size(b, 2)
+            throw(DimensionMismatch("Solution and RHS should have the same number of columns. " *
+                "Solution has $(size(x, 2)) columns, but RHS has $(size(b, 2)) columns."))
+        end
         if !issuccess(L)
             s = unsafe_load(pointer(L))
             if s.is_ll == 1

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1953,8 +1953,8 @@ for TI in IndexTypes
         X_Handle = Ptr{cholmod_dense_struct}(pointer_from_objref(dense_x))
         Y_Handle = Ptr{cholmod_dense_struct}(C_NULL)
         E_Handle = Ptr{cholmod_dense_struct}(C_NULL)
-        GC.@preserve dense_x dense_b begin
-            status = $(cholname(:solve2, TI))(
+        status = GC.@preserve x dense_x b dense_b begin
+            $(cholname(:solve2, TI))(
                 CHOLMOD_A, L,
                 Ref(dense_b), C_NULL,
                 Ref(X_Handle), C_NULL,
@@ -1962,8 +1962,12 @@ for TI in IndexTypes
                 Ref(E_Handle),
                 getcommon($TI))
         end
-        free!(Y_Handle)
-        free!(E_Handle)
+        if Y_Handle != C_NULL
+            free!(Y_Handle)
+        end
+        if E_Handle != C_NULL
+            free!(E_Handle)
+        end
         @assert !iszero(status)
 
         return x

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1947,8 +1947,20 @@ for TI in IndexTypes
         # `cholmod_dense_struct`s in CHOLMOD. Instead, we want to reuse
         # the existing memory. We can do this by creating new
         # `cholmod_dense_struct`s and filling them manually.
-        dense_x = wrap_dense(x)
-        dense_b = wrap_dense(b)
+        # We need to use a special handling for the case of `Dense`
+        # input arrays since the `pointer` refers to the pointer to the
+        # `cholmod_dense`, not to the array values themselves as for
+        # standard arrays.
+        if x isa Dense
+            dense_x = unsafe_load(pointer(x))
+        else
+            dense_x = wrap_dense(x)
+        end
+        if b isa Dense
+            dense_b = unsafe_load(pointer(b))
+        else
+            dense_b = wrap_dense(b)
+        end
 
         X_Handle = Ptr{cholmod_dense_struct}(pointer_from_objref(dense_x))
         Y_Handle = Ptr{cholmod_dense_struct}(C_NULL)

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -13,7 +13,7 @@ using Random
 using Serialization
 using LinearAlgebra:
     I, cholesky, cholesky!, det, diag, eigmax, ishermitian, isposdef, issuccess,
-    issymmetric, ldlt, ldlt!, logdet, norm, opnorm, Diagonal, Hermitian, Symmetric,
+    issymmetric, ldiv!, ldlt, ldlt!, logdet, norm, opnorm, Diagonal, Hermitian, Symmetric,
     PosDefException, ZeroPivotException, RowMaximum
 using SparseArrays
 using SparseArrays: getcolptr

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -284,6 +284,26 @@ end
     end
 end
 
+@testset "ldiv! $Tv $Ti" begin
+    local A, x, x2, b, X, X2, B
+    A = sprand(10, 10, 0.1)
+    A = I + A * A'
+    A = convert(SparseMatrixCSC{Tv,Ti}, A)
+    factor = cholesky(A)
+
+    x = fill(Tv(1), 10)
+    b = A * x
+    x2 = zero(x)
+    @inferred ldiv!(x2, factor, b)
+    @test x2 ≈ x
+
+    X = fill(Tv(1), 10, 5)
+    B = A * X
+    X2 = zero(X)
+    @inferred ldiv!(X2, factor, B)
+    @test X2 ≈ X
+end
+
 end #end for Ti ∈ itypes
 
 for Tv ∈ (Float32, Float64)

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -302,6 +302,17 @@ end
     X2 = zero(X)
     @inferred ldiv!(X2, factor, B)
     @test X2 ≈ X
+
+    c = fill(Tv(1), size(x, 1) + 1)
+    C = fill(Tv(1), size(X, 1) + 1, size(X, 2))
+    y = fill(Tv(1), size(x, 1) + 1)
+    Y = fill(Tv(1), size(X, 1) + 1, size(X, 2))
+    @test_throws DimensionMismatch ldiv!(y, factor, b)
+    @test_throws DimensionMismatch ldiv!(Y, factor, B)
+    @test_throws DimensionMismatch ldiv!(x2, factor, c)
+    @test_throws DimensionMismatch ldiv!(X2, factor, C)
+    @test_throws DimensionMismatch ldiv!(X2, factor, b)
+    @test_throws DimensionMismatch ldiv!(x2, factor, B)
 end
 
 end #end for Ti ∈ itypes

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -138,6 +138,9 @@ Random.seed!(123)
     @test CHOLMOD.isvalid(chma)
     @test unsafe_load(pointer(chma)).is_ll == 1    # check that it is in fact an LLt
     @test chma\b ≈ x
+    x2 = zero(x)
+    @inferred ldiv!(x2, chma, b)
+    @test x2 ≈ x
     @test nnz(chma) == 489
     @test nnz(cholesky(A, perm=1:size(A,1))) > nnz(chma)
     @test size(chma) == size(A)
@@ -365,9 +368,9 @@ end
     @test isa(CHOLMOD.eye(3), CHOLMOD.Dense{Float64})
 end
 
-@testset "Core functionality ($elty, $elty2)" for 
-    elty in (Tv, Complex{Tv}), 
-    Tv2 in (Float32, Float64), 
+@testset "Core functionality ($elty, $elty2)" for
+    elty in (Tv, Complex{Tv}),
+    Tv2 in (Float32, Float64),
     elty2 in (Tv2, Complex{Tv2}),
     Ti ∈ itypes
     A1 = sparse(Ti[1:5; 1], Ti[1:5; 2], elty <: Real ? randn(Tv, 6) : complex.(randn(Tv, 6), randn(Tv, 6)))
@@ -972,7 +975,7 @@ end
     f = ones(size(K, 1))
     u = K \ f
     residual = norm(f - K * u) / norm(f)
-    @test residual < 1e-6 
+    @test residual < 1e-6
 end
 
 @testset "wrapped sparse matrices" begin


### PR DESCRIPTION
I have implemented an in-place `ldiv!` for Cholesky factorizations of sparse matrices. 

Closes #319 
Closes #275
Closes #123
Xref https://discourse.julialang.org/t/is-there-no-ldiv-for-choleski-factorization-of-a-sparse-matrix/114806

### Caveats

The method works locally but is not as elegant as the UMFPack/LU version or the other code in the CHOLMOD wrapper:
- UMFPack accepts arrays/pointers directly whereas CHOLMOD uses `cholmod_dense` structs.
- The `Dense` wrappers in the Julia CHOLMOD module allocate new arrays.

Thus, the code looks a bit different from the remaining code in the file.

The current method still allocates some memory on my system since we do not provide the workspace vectors `Handle_Y` and `Handle_E`. We could store them in the `CHOLMOD.Factor` struct. I tried that, but they were still `C_NULL` after the call to `solve2` (when initialized with `C_NULL`). Thus, re-using them is not working as I understand the docs. Thus, I have not added this complexity to this PR.
Maybe related: https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/45

### Questions

Shall we announce this somewhere in some form of NEWS.md so that people can adopt to this change?