### PR TITLE
Change default QR tolerance to match SPQR

### DIFF
--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -146,7 +146,7 @@ Matrix{T}(Q::QRSparseQ) where {T} = lmul!(Q, Matrix{T}(I, size(Q, 1), min(size(Q
 
 # From SPQR manual p. 6
 _default_tol(A::AbstractSparseMatrixCSC) =
-    20*sum(size(A))*eps(real(eltype(A)))*maximum(norm(view(A, :, i)) for i in 1:size(A, 2))
+    20*sum(size(A))*eps()*maximum(norm(view(A, :, i)) for i in 1:size(A, 2))
 
 """
     qr(A::SparseMatrixCSC; tol=_default_tol(A), ordering=ORDERING_DEFAULT) -> QRSparse


### PR DESCRIPTION
SPQR uses just the double precision epsilon even for Float32.

https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/131471310ef0600b231b8fa7c10a55c3f70afbd9/SPQR/Source/spqr_tol.cpp#L29C6-L30C57