### PR TITLE
Diagonal-sandwiched triple product for SparseMatrixCSC

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -205,6 +205,9 @@ const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti},SparseTriangular{Tv
 *(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, B::SparseOrTri) = spmatmul(copy(A), B)
 *(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = spmatmul(copy(A), copy(B))
 
+(*)(Da::Diagonal, A::Union{SparseMatrixCSCUnion, AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}}, Db::Diagonal) =
+    Da * (A * Db)
+
 # Gustavson's matrix multiplication algorithm revisited.
 # The result rowval vector is already sorted by construction.
 # The auxiliary Vector{Ti} xb is replaced by a Vector{Bool} of same length.

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -207,6 +207,8 @@ const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti},SparseTriangular{Tv
 
 (*)(Da::Diagonal, A::Union{SparseMatrixCSCUnion, AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}}, Db::Diagonal) = Da * (A * Db)
 function (*)(Da::Diagonal, A::SparseMatrixCSC, Db::Diagonal)
+    (size(Da, 2) == size(A,1) && size(A,2) == size(Db,1)) ||
+        throw(DimensionMismatch("incompatible sizes"))
     T = promote_op(matprod, eltype(Da), promote_op(matprod, eltype(A), eltype(Db)))
     dest = similar(A, T)
     vals_dest = nonzeros(dest)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -912,4 +912,20 @@ end
     @test sparse(3I, 4, 5) == sparse(1:4, 1:4, 3, 4, 5)
     @test sparse(3I, 5, 4) == sparse(1:4, 1:4, 3, 5, 4)
 end
+
+@testset "diagonal-sandwiched triple multiplication" begin
+    D = Diagonal(1:4)
+    S = sprand(Int, 4, 4, 0.2)
+    A = Array(S)
+    C = D * S * D
+    @test C isa SparseMatrixCSC
+    @test C ≈ D * A * D
+    C = D * S' * D
+    @test C isa SparseMatrixCSC
+    @test C ≈ D * A' * D
+    C = D * view(S, :, :) * D
+    @test C isa SparseMatrixCSC
+    @test C ≈ D * A * D
+end
+
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -914,19 +914,22 @@ end
 end
 
 @testset "diagonal-sandwiched triple multiplication" begin
-    D1 = Diagonal(1:4)
-    D2 = Diagonal(2:2:8)
-    S = sprand(4, 4, 0.2)
+    S = sprand(4, 6, 0.2)
+    D1 = Diagonal(axes(S,1))
+    D2 = Diagonal(axes(S,2) .+ 4)
     A = Array(S)
     C = D1 * S * D2
     @test C isa SparseMatrixCSC
     @test C ≈ D1 * A * D2
-    C = D1 * S' * D2
+    C = D2 * S' * D1
     @test C isa SparseMatrixCSC
-    @test C ≈ D1 * A' * D2
+    @test C ≈ D2 * A' * D1
     C = D1 * view(S, :, :) * D2
     @test C isa SparseMatrixCSC
     @test C ≈ D1 * A * D2
+
+    @test_throws DimensionMismatch D2 * S * D2
+    @test_throws DimensionMismatch D1 * S * D1
 end
 
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -914,18 +914,19 @@ end
 end
 
 @testset "diagonal-sandwiched triple multiplication" begin
-    D = Diagonal(1:4)
-    S = sprand(Int, 4, 4, 0.2)
+    D1 = Diagonal(1:4)
+    D2 = Diagonal(2:2:8)
+    S = sprand(4, 4, 0.2)
     A = Array(S)
-    C = D * S * D
+    C = D1 * S * D2
     @test C isa SparseMatrixCSC
-    @test C ≈ D * A * D
-    C = D * S' * D
+    @test C ≈ D1 * A * D2
+    C = D1 * S' * D2
     @test C isa SparseMatrixCSC
-    @test C ≈ D * A' * D
-    C = D * view(S, :, :) * D
+    @test C ≈ D1 * A' * D2
+    C = D1 * view(S, :, :) * D2
     @test C isa SparseMatrixCSC
-    @test C ≈ D * A * D
+    @test C ≈ D1 * A * D2
 end
 
 end


### PR DESCRIPTION
After this,
```julia
julia> using SparseArrays, LinearAlgebra

julia> D = Diagonal(1:4)
4×4 Diagonal{Int64, UnitRange{Int64}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> S = sprand(4, 4, 0.2)
4×4 SparseMatrixCSC{Float64, Int64} with 6 stored entries:
 0.8632  0.206049   ⋅        0.921636
  ⋅       ⋅        0.49266    ⋅ 
  ⋅       ⋅        0.329707   ⋅ 
  ⋅       ⋅         ⋅        0.69844

julia> D * S * D
4×4 SparseMatrixCSC{Float64, Int64} with 6 stored entries:
 0.8632  0.412098   ⋅        3.68655
  ⋅       ⋅        2.95596    ⋅ 
  ⋅       ⋅        2.96736    ⋅ 
  ⋅       ⋅         ⋅       11.175

```
This operation of pre- and post-multiplication by `Diagonal`s is not uncommon, as it scales the rows and columns of the sandwiched matrix. After this PR, the result is a sparse matrix as well.

The new implementation changes the following behavior:
```julia
julia> D = Diagonal(StepRangeLen(NaN, 0, 4));

julia> D * S * D
4×4 SparseMatrixCSC{Float64, Int64} with 3 stored entries:
    ⋅    ⋅      ⋅    ⋅ 
    ⋅    ⋅   NaN     ⋅ 
    ⋅    ⋅   NaN     ⋅ 
 NaN     ⋅      ⋅    ⋅ 
```
whereas, previously, this would have been a dense matrix of `NaN`s. This new behavior is consistent with sparse matrices having a strong zero.

The implementation isn't optimal from a performance perspective, as it uses a sequence of multiplications instead of doing it all in one go. However, the performance may be improved iteratively.