### PR TITLE
added diagonal-sparse multiplication

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -198,8 +198,9 @@ function *(A::Diagonal, b::AbstractSparseVector)
     res = similar(b, T)
     nzind_b = nonzeroinds(b)
     nzval_b = nonzeros(b)
+    nzval_res = nonzeros(res)
     for idx in eachindex(nzind_b)
-        res[nzind_b[idx]] = A.diag[nzind_b[idx]] * nzval_b[idx]
+        nzval_res[idx] = A.diag[nzind_b[idx]] * nzval_b[idx]
     end
     return res
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -191,7 +191,7 @@ end
 function *(A::Diagonal, b::AbstractSparseVector)
     if size(A, 2) != length(b)
         throw(
-            DimensionMismatch("The dimension of the matrix A $(size(A)) and of the vector b $(length(b))")
+            DimensionMismatch(lazy"The dimension of the matrix A $(size(A)) and of the vector b $(length(b))")
         )
     end
     T = promote_eltype(A, b)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -189,6 +189,11 @@ function _A_mul_Bt_or_Bc!(tfun::Function, C::StridedMatrix, A::AbstractMatrix, B
 end
 
 function *(A::Diagonal, b::AbstractSparseVector)
+    if size(A, 2) != length(b)
+        throw(
+            DimensionMismatch("The dimension of the matrix A $(size(A)) and of the vector b $(length(b))")
+        )
+    end
     T = promote_eltype(A, b)
     res = similar(b, T)
     nzind_b = nonzeroinds(b)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -190,12 +190,13 @@ end
 
 function *(A::Diagonal, b::AbstractSparseVector)
     T = promote_eltype(A, b)
+    res = similar(b, T)
     nzind_b = nonzeroinds(b)
     nzval_b = nonzeros(b)
-    if isempty(nzind_b)
-        return zero(T)
+    for idx in eachindex(nzind_b)
+        res[nzind_b[idx]] = A.diag[nzind_b[idx]] * nzval_b[idx]
     end
-    return sum(A.diag[nzind_b[idx]] * nzval_b[idx] for idx in eachindex(nzind_b))
+    return res
 end
 
 # Sparse matrix multiplication as described in [Gustavson, 1978]:

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -188,6 +188,16 @@ function _A_mul_Bt_or_Bc!(tfun::Function, C::StridedMatrix, A::AbstractMatrix, B
     C
 end
 
+function *(A::Diagonal, b::AbstractSparseVector)
+    T = promote_eltype(A, b)
+    nzind_b = nonzeroinds(b)
+    nzval_b = nonzeros(b)
+    if isempty(nzind_b)
+        return zero(T)
+    end
+    return sum(A.diag[nzind_b[idx]] * nzval_b[idx] for idx in eachindex(nzind_b))
+end
+
 # Sparse matrix multiplication as described in [Gustavson, 1978]:
 # http://dl.acm.org/citation.cfm?id=355796
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -673,6 +673,16 @@ end
     end
 end
 
+@testset "diagonal - sparse vector mutliplication" begin
+    for _ in 1:10
+        b = spzeros(10)
+        b[1:3] .= 1:3
+        A = Diagonal(randn(10))
+        @test norm(A * b - A * Vector(b)) <= 10eps()
+        @test norm(A * b - Array(A) * b) <= 10eps()
+    end
+end
+
 @testset "sparse matrix * BitArray" begin
     A = sprand(5,5,0.3)
     MA = Array(A)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -683,6 +683,8 @@ end
         Ac = Diagonal(randn(Complex{Float64}, 10))
         @test norm(Ac * b - Ac * Vector(b)) <= 10eps()
         @test norm(Ac * b - Array(Ac) * b) <= 10eps()
+        @test_throws DimensionMismatch A * [b; 1]
+        @test_throws DimensionMismatch A * b[1:end-1]
     end
 end
 

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -680,6 +680,9 @@ end
         A = Diagonal(randn(10))
         @test norm(A * b - A * Vector(b)) <= 10eps()
         @test norm(A * b - Array(A) * b) <= 10eps()
+        Ac = Diagonal(randn(Complex{Float64}, 10))
+        @test norm(Ac * b - Ac * Vector(b)) <= 10eps()
+        @test norm(Ac * b - Array(Ac) * b) <= 10eps()
     end
 end
 


### PR DESCRIPTION
Adds a specialization for the out-of-place multiplication of Diagonal * sparse-vector, otherwise the current version was O(n) instead of O(nnz)