### PR TITLE
doc: move solvers doc to `src\solvers.md`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -206,20 +206,6 @@ section of the standard library reference.
 | [`sprandn(m,n,d)`](@ref)   | [`randn(m,n)`](@ref)   | Creates a *m*-by-*n* random matrix (of density *d*) with iid non-zero elements distributed according to the standard normal (Gaussian) distribution.                  |
 | [`sprandn(rng,m,n,d)`](@ref) | [`randn(rng,m,n)`](@ref) | Creates a *m*-by-*n* random matrix (of density *d*) with iid non-zero elements generated with the `rng` random number generator                                   |
 
-## [Sparse Linear Algebra](@id stdlib-sparse-linalg)
-
-Sparse matrix solvers call functions from [SuiteSparse](http://suitesparse.com). The following factorizations are available:
-
-1. [`cholesky`](@ref SparseArrays.CHOLMOD.cholesky)
-2. [`ldlt`](@ref SparseArrays.CHOLMOD.ldlt)
-3. [`lu`](@ref SparseArrays.UMFPACK.lu)
-4. [`qr`](@ref SparseArrays.SPQR.qr)
-
-| Type                  | Description                                   |
-|:----------------------|:--------------------------------------------- |
-| `CHOLMOD.Factor`      | Cholesky and LDLt factorizations              |
-| `UMFPACK.UmfpackLU`   | LU factorization                              |
-| `SPQR.QRSparse`       | QR factorization                              |
 
 ```@meta
 DocTestSetup = nothing

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -4,6 +4,24 @@
 DocTestSetup = :(using LinearAlgebra, SparseArrays)
 ```
 
+## [Sparse Linear Algebra](@id stdlib-sparse-linalg)
+
+Sparse matrix solvers call functions from [SuiteSparse](http://suitesparse.com).
+
+The following factorizations are available:
+
+1. [`cholesky`](@ref SparseArrays.CHOLMOD.cholesky)
+2. [`ldlt`](@ref SparseArrays.CHOLMOD.ldlt)
+3. [`lu`](@ref SparseArrays.UMFPACK.lu)
+4. [`qr`](@ref SparseArrays.SPQR.qr)
+
+| Type                  | Description                                   |
+|:----------------------|:--------------------------------------------- |
+| `CHOLMOD.Factor`      | Cholesky and LDLt factorizations              |
+| `UMFPACK.UmfpackLU`   | LU factorization                              |
+| `SPQR.QRSparse`       | QR factorization                              |
+
+
 ```@docs; canonical=false
 SparseArrays.CHOLMOD.cholesky
 SparseArrays.CHOLMOD.cholesky!


### PR DESCRIPTION
When building julia with `USE_GPL_LIBS:=0`, the documentation builds fails because the documentation for the solver cannot be found.

Only `docs/src/index.md` is copied when building the documentation, so we can move the solver documentation to `docs/src/solver.md` to avoid this problem.


See: https://github.com/JuliaLang/julia/issues/56344
