### PR TITLE
More adhereance to 1.10 error types (hopefully)

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1243,16 +1243,16 @@ function hvcat_internal(rows::Tuple{Vararg{Int}}, X1::_SparseConcatGroup, X::_Sp
     if anysparse(X1) || anysparse(X...)
         vcat(_hvcat_rows(rows, X1, X...)...)
     else
-	if X1 isa Number && all(Base.Fix2(isa, Number), X)
-		# Needed to match error type with Base Julia. See https://github.com/JuliaLang/julia/pull/56543#issuecomment-2508637550
-		matrix_len = if length(rows) == 0
-		    0
-		else
-		    length(rows) * rows[1]
-		end
-		if matrix_len != 1 + length(X)
-		    throw(ArgumentError("argument count does not match specified shape (expected $matrix_len, got $(1+length(X)))"))
-		end
+        if X1 isa Number && all(Base.Fix2(isa, Number), X)
+            # Needed to match error type with Base Julia. See https://github.com/JuliaLang/julia/pull/56543#issuecomment-2508637550
+            matrix_len = if length(rows) == 0
+                0
+            else
+                length(rows) * rows[1]
+            end
+            if matrix_len != 1 + length(X)
+                throw(ArgumentError("argument count does not match specified shape (expected $matrix_len, got $(1+length(X)))"))
+	    end
 	end
         Base.typed_hvcat(Base.promote_eltypeof(X1, X...), rows, X1, X...)
     end

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1243,15 +1243,17 @@ function hvcat_internal(rows::Tuple{Vararg{Int}}, X1::_SparseConcatGroup, X::_Sp
     if anysparse(X1) || anysparse(X...)
         vcat(_hvcat_rows(rows, X1, X...)...)
     else
-        # Needed to match error type with Base Julia. See https://github.com/JuliaLang/julia/pull/56543#issuecomment-2508637550
-        matrix_len = if length(rows) == 0
-            0
-        else
-            length(rows) * rows[1]
-        end
-        if matrix_len != 1 + length(X)
-            throw(ArgumentError("argument count does not match specified shape (expected $matrix_len, got $(1+length(X)))"))
-        end
+	if X1 <: Number && all(Base.Fix1(<:, Number), X)
+		# Needed to match error type with Base Julia. See https://github.com/JuliaLang/julia/pull/56543#issuecomment-2508637550
+		matrix_len = if length(rows) == 0
+		    0
+		else
+		    length(rows) * rows[1]
+		end
+		if matrix_len != 1 + length(X)
+		    throw(ArgumentError("argument count does not match specified shape (expected $matrix_len, got $(1+length(X)))"))
+		end
+	end
         Base.typed_hvcat(Base.promote_eltypeof(X1, X...), rows, X1, X...)
     end
 end

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1243,7 +1243,7 @@ function hvcat_internal(rows::Tuple{Vararg{Int}}, X1::_SparseConcatGroup, X::_Sp
     if anysparse(X1) || anysparse(X...)
         vcat(_hvcat_rows(rows, X1, X...)...)
     else
-	if X1 <: Number && all(Base.Fix1(<:, Number), X)
+	if X1 isa Number && all(Base.Fix2(isa, Number), X)
 		# Needed to match error type with Base Julia. See https://github.com/JuliaLang/julia/pull/56543#issuecomment-2508637550
 		matrix_len = if length(rows) == 0
 		    0


### PR DESCRIPTION
It looks like in base that error was only enabled on number inputs, lets see if this fixes it?

cc @gbaraldi @KristofferC 