### PR TITLE
cleanup support for Float32 and ComplexF32

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -270,10 +270,10 @@ mutable struct Dense{Tv<:VTypes} <: DenseMatrix{Tv}
         s = unsafe_load(ptr)
         if s.xtype != xtyp(Tv)
             free!(ptr)
-            throw(CHOLMODException("xtype=$(s.xtype) not supported"))
+            throw(CHOLMODException("xtype=$(xtyp(Tv)) not supported"))
         elseif s.dtype != dtyp(Tv)
             free!(ptr)
-            throw(CHOLMODException("dtype=$(s.dtype) not supported"))
+            throw(CHOLMODException("dtype=$(dtyp(Tv)) not supported"))
         end
         obj = new(ptr)
         finalizer(free!, obj)
@@ -294,10 +294,10 @@ mutable struct Sparse{Tv<:VTypes, Ti<:ITypes} <: AbstractSparseMatrix{Tv,Ti}
             throw(CHOLMODException("Ti=$Ti does not match s.itype=$(s.itype)"))
         elseif s.xtype != xtyp(Tv)
             free!(ptr, Ti)
-            throw(CHOLMODException("xtype=$(s.xtype) not supported"))
+            throw(CHOLMODException("xtype=$(xtyp(Tv)) not supported"))
         elseif s.dtype != dtyp(Tv)
             free!(ptr, Ti)
-            throw(CHOLMODException("dtype=$(s.dtype) not supported"))
+            throw(CHOLMODException("dtype=$(dtyp(Tv)) not supported"))
         end
         A = new(ptr)
         finalizer(free!, A)
@@ -337,10 +337,10 @@ mutable struct Factor{Tv<:VTypes, Ti<:ITypes} <: Factorization{Tv}
             throw(CHOLMODException("Ti=$Ti does not match s.itype=$(s.itype)"))
         elseif s.xtype != xtyp(Tv) && s.xtype != CHOLMOD_PATTERN
             free!(ptr, Ti)
-            throw(CHOLMODException("xtype=$(s.xtype) not supported"))
+            throw(CHOLMODException("xtype=$(xtyp(Tv)) not supported"))
         elseif s.dtype != dtyp(Tv)
             free!(ptr, Ti)
-            throw(CHOLMODException("dtype=$(s.dtype) not supported"))
+            throw(CHOLMODException("dtype=$(dtyp(Tv)) not supported"))
         end
         F = new(ptr)
         if register_finalizer

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -214,10 +214,10 @@ function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), order
                                     nonzeros(R_)),
                     p, hpinv)
 end
-LinearAlgebra.qr(A::SparseMatrixCSC{<:Union{Float16,Float32}}; tol=_default_tol(A)) =
-    qr(convert(SparseMatrixCSC{Float64}, A); tol=tol)
-LinearAlgebra.qr(A::SparseMatrixCSC{<:Union{ComplexF16,ComplexF32}}; tol=_default_tol(A)) =
-    qr(convert(SparseMatrixCSC{ComplexF64}, A); tol=tol)
+LinearAlgebra.qr(A::SparseMatrixCSC{Float16}; tol=_default_tol(A)) =
+    qr(convert(SparseMatrixCSC{Float32}, A); tol=tol)
+LinearAlgebra.qr(A::SparseMatrixCSC{ComplexF16}; tol=_default_tol(A)) =
+    qr(convert(SparseMatrixCSC{ComplexF32}, A); tol=tol)
 LinearAlgebra.qr(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}};
    tol=_default_tol(A)) where {T<:AbstractFloat} =
     throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -110,10 +110,16 @@ end
     @test (F.Q*F.R)::SparseMatrixCSC == A[F.prow,F.pcol]
 end
 
-@testset "Issue #585 for element type: $eltyA" for eltyA in (Float64, Float32)
+@testset "Issue #585 for element type: $eltyA" for eltyA in (Float64, Float32, ComplexF64, ComplexF32)
     A = sparse(eltyA[1 0; 0 1])
     F = qr(A)
     @test eltype(F.Q) == eltype(F.R) == eltyA
+end
+
+@testset "Complementing issue #585 for element type: $eltyA" for (eltyA, eltyB) in [(Float16, Float32), (ComplexF16, ComplexF32)]
+    A = sparse(eltyA[1 0; 0 1])
+    F = qr(A)
+    @test eltype(F.Q) == eltype(F.R) == eltyB
 end
 
 @testset "select ordering overdetermined" begin


### PR DESCRIPTION
I fixed the same bug as #585, without realizing that it had already been done. It wasn't a complete waste of time, because the PR #586 left some cleanup to do: the lines
```julia
LinearAlgebra.qr(A::SparseMatrixCSC{<:Union{Float16,Float32}}; tol=_default_tol(A)) =
    qr(convert(SparseMatrixCSC{Float64}, A); tol=tol)
LinearAlgebra.qr(A::SparseMatrixCSC{<:Union{ComplexF16,ComplexF32}}; tol=_default_tol(A)) =
    qr(convert(SparseMatrixCSC{ComplexF64}, A); tol=tol)
```
would have prevented it from working if they actually worked! Luckily they don't, as the correct method is more specific and gets called, but it's still worth fixing. I also changed them to convert `Float16` to `Float32` instead of `Float64`, and the analogous change for complex numbers.

I also fixed the error messages one gets. They were of the form "dtype=$(s.dtype) not supported", which in my case translated to saying that `Float64` wasn't supported when I tried calling it with `Float32`. `s.dtype` is the type that actually got computed, so it clearly is supported. I changed them to say "dtype=$(dtyp(Tv)) not supported".