### PR TITLE
Explicitly import `Matrix` and `Vector` in CHOLMOD

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -11,7 +11,8 @@
 module CHOLMOD
 
 import Base: (*), convert, copy, eltype, getindex, getproperty, show, size,
-             IndexStyle, IndexLinear, IndexCartesian, adjoint, axes
+             IndexStyle, IndexLinear, IndexCartesian, adjoint, axes,
+             Matrix, Vector
 using Base: require_one_based_indexing
 
 using LinearAlgebra


### PR DESCRIPTION
These were being extended in the module, but weren't explicitly imported from `Base`.