### PR TITLE
Use `axes` instead of `1:size`

### DIFF
--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -119,7 +119,7 @@ const SpBroadcasted2{Style<:SPVM,Axes,F,Args<:Tuple{SparseVecOrMat,SparseVecOrMa
 @inline numcols(A::AbstractSparseMatrixCSC) = size(A, 2)
 # numrows and numcols respectively yield size(A, 1) and size(A, 2), but avoid a branch
 @inline columns(A::AbstractCompressedVector) = 1
-@inline columns(A::AbstractSparseMatrixCSC) = 1:size(A, 2)
+@inline columns(A::AbstractSparseMatrixCSC) = axes(A,2)
 @inline colrange(A::AbstractCompressedVector, j) = 1:length(nonzeroinds(A))
 @inline colrange(A::AbstractSparseMatrixCSC, j) = nzrange(A, j)
 @inline colstartind(A::AbstractCompressedVector, j) = one(indtype(A))
@@ -311,7 +311,7 @@ function _densestructure!(A::AbstractSparseMatrixCSC)
     expandstorage!(A, nnzA)
     copyto!(getcolptr(A), 1:size(A, 1):(nnzA + 1))
     for k in _densecoloffsets(A)
-        copyto!(rowvals(A), k + 1, 1:size(A, 1))
+        copyto!(rowvals(A), k + 1, axes(A,1))
     end
     return A
 end

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1024,7 +1024,7 @@ function Sparse{Tv, Ti}(A::SparseMatrixCSC{<:Any}, stype::Integer) where {Tv<:VT
         # Need to remove any non real elements in the diagonal because, in contrast to
         # BLAS/LAPACK these are not ignored by CHOLMOD. If even tiny imaginary parts are
         # present CHOLMOD will fail with a non-positive definite/zero pivot error.
-        for j = 1:size(A, 2)
+        for j = axes(A, 2)
             for ip = getcolptr(A)[j]:getcolptr(A)[j + 1] - 1
                 v = nonzeros(A)[ip]
                 unsafe_store!(Ptr{Tv}(s.x), rowvals(A)[ip] == j ? Complex(real(v)) : v, ip)

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -983,7 +983,7 @@ function _AqldivB_kernel!(x::StridedVector{T}, lu::UmfpackLU{T},
 end
 function _AqldivB_kernel!(X::StridedMatrix{T}, lu::UmfpackLU{T},
                           B::StridedMatrix{T}, transposeoptype) where {T<:UMFVTypes}
-    for col in 1:size(X, 2)
+    for col in axes(X, 2)
         solve!(view(X, :, col), lu, view(B, :, col), transposeoptype)
     end
 end
@@ -1002,7 +1002,7 @@ function _AqldivB_kernel!(X::StridedMatrix{Tb}, lu::UmfpackLU{Float64},
     r = similar(B, Float64, size(B, 1))
     i = similar(B, Float64, size(B, 1))
     c = similar(B, Float64, size(B, 1))
-    for j in 1:size(B, 2)
+    for j in axes(B, 2)
         c .= real.(view(B, :, j))
         solve!(r, lu, c, transposeoptype)
         c .= imag.(view(B, :, j))

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -737,11 +737,11 @@ function _logical_index(A::AbstractSparseMatrixCSC{Tv}, I::AbstractArray{Bool}) 
     c = 1
     rowB = 1
 
-    @inbounds for col in 1:size(A, 2)
+    @inbounds for col in axes(A,2)
         r1 = colptrA[col]
         r2 = colptrA[col+1]-1
 
-        for row in 1:size(A, 1)
+        for row in axes(A,1)
             if I[row, col]
                 while (r1 <= r2) && (rowvalA[r1] < row)
                     r1 += 1


### PR DESCRIPTION
This generally makes it easier to read code, as one doesn't need to look up variable definitions from elsewhere.