### PR TITLE
5-term mul! with Diagonal

### DIFF
--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -582,15 +582,16 @@ end
     end
 
     @testset "5-arg mul!" begin
-        sA2 = similar(sA)
-        @testset for (alpha, beta) in [(true, false), (true, true), (2,3)]
-            nonzeros(sA2) .= 1
-            sA3 = copy(sA2)
-            D = Diagonal(rand(size(sA,2)))
-            @test mul!(sA2, sA, D, alpha, beta) ≈ dA * D * alpha + sA3 * beta
-            nonzeros(sA2) .= 1
-            D = Diagonal(rand(size(sA,1)))
-            @test mul!(sA2, D, sA, alpha, beta) ≈ D * dA * alpha + sA3 * beta
+        for sA2 in (similar(sA), sprand(size(sA)..., 0.1))
+            @testset for (alpha, beta) in [(true, false), (true, true), (2,3)]
+                nonzeros(sA2) .= 1
+                sA3 = copy(sA2)
+                D = Diagonal(rand(size(sA,2)))
+                @test mul!(sA2, sA, D, alpha, beta) ≈ dA * D * alpha + sA3 * beta
+                nonzeros(sA2) .= 1
+                D = Diagonal(rand(size(sA,1)))
+                @test mul!(sA2, D, sA, alpha, beta) ≈ D * dA * alpha + sA3 * beta
+            end
         end
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -580,6 +580,17 @@ end
         @test lmul!(D, copy(sA)) ≈ D * dA
         @test mul!(sC, D, copy(sA)) ≈ D * dA
     end
+
+    @testset "5-arg mul!" begin
+        sA2 = similar(sA)
+        nonzeros(sA2) .= 1
+        sA3 = copy(sA2)
+        D = Diagonal(rand(size(sA,2)))
+        @test mul!(sA2, sA, D, 3, 2) ≈ dA * D * 3 + sA3 * 2
+        nonzeros(sA2) .= 1
+        D = Diagonal(rand(size(sA,1)))
+        @test mul!(sA2, D, sA, 3, 2) ≈ D * dA * 3 + sA3 * 2
+    end
 end
 
 @testset "conj" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -583,13 +583,15 @@ end
 
     @testset "5-arg mul!" begin
         sA2 = similar(sA)
-        nonzeros(sA2) .= 1
-        sA3 = copy(sA2)
-        D = Diagonal(rand(size(sA,2)))
-        @test mul!(sA2, sA, D, 3, 2) ≈ dA * D * 3 + sA3 * 2
-        nonzeros(sA2) .= 1
-        D = Diagonal(rand(size(sA,1)))
-        @test mul!(sA2, D, sA, 3, 2) ≈ D * dA * 3 + sA3 * 2
+        @testset for (alpha, beta) in [(true, false), (true, true), (2,3)]
+            nonzeros(sA2) .= 1
+            sA3 = copy(sA2)
+            D = Diagonal(rand(size(sA,2)))
+            @test mul!(sA2, sA, D, alpha, beta) ≈ dA * D * alpha + sA3 * beta
+            nonzeros(sA2) .= 1
+            D = Diagonal(rand(size(sA,1)))
+            @test mul!(sA2, D, sA, alpha, beta) ≈ D * dA * alpha + sA3 * beta
+        end
     end
 end
 


### PR DESCRIPTION
This speeds up certain 5-term multiplications involving sparse matrices and a `Diagonal`, as the operations become O(N) from O(N^2).
On main
```julia
julia> using SparseArrays, LinearAlgebra

julia> S = sprand(5_000, 5_000, 0.00001);

julia> S2 = similar(S);

julia> D = Diagonal(axes(S,1));

julia> @b (S2,S,D) mul!(_[1], _[2], _[3], true, false)
190.253 ms
```
vs this PR
```julia
julia> @b (S2,S,D) mul!(_[1], _[2], _[3], true, false)
6.830 μs
```