### PR TITLE
Fix `issymmetric` for matrices with empty columns

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -4074,9 +4074,9 @@ function _blockdiag(::Type{Tv}, ::Type{Ti}, X::AbstractSparseMatrixCSC...) where
 end
 
 ## Structure query functions
-issymmetric(A::AbstractSparseMatrixCSC) = is_hermsym(A, identity)
+issymmetric(A::AbstractSparseMatrixCSC) = is_hermsym(A, transpose)
 
-ishermitian(A::AbstractSparseMatrixCSC) = is_hermsym(A, conj)
+ishermitian(A::AbstractSparseMatrixCSC) = is_hermsym(A, adjoint)
 
 function is_hermsym(A::AbstractSparseMatrixCSC, check::Function)
     m, n = size(A)
@@ -4112,6 +4112,12 @@ function is_hermsym(A::AbstractSparseMatrixCSC, check::Function)
                     return false
                 end
             else
+                # if nzrange(A, row) is empty, then A[:, row] is all zeros.
+                # Specifically, A[col, row] is zero.
+                # However, we know at this point that A[row, col] is not zero
+                # This means that the matrix is not symmetric
+                isempty(nzrange(A, row)) && return false
+
                 offset = tracker[row]
 
                 # If the matrix is unsymmetric, there might not exist

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -425,6 +425,27 @@ end
     @test issymmetric(sparse([1 0; 1 0])) == false
     @test issymmetric(sparse([0 1; 1 0])) == true
     @test issymmetric(sparse([1 1; 1 0])) == true
+
+    # test some non-trivial cases
+    local S
+    @testset "random matrices" begin
+        for sparsity in (0.1, 0.01, 0.0)
+            S = sparse(Symmetric(sprand(20, 20, sparsity)))
+            @test issymmetric(S)
+            @test ishermitian(S)
+            S = sparse(Symmetric(sprand(ComplexF64, 20, 20, sparsity)))
+            @test issymmetric(S)
+            @test !ishermitian(S) || isreal(S)
+            S = sparse(Hermitian(sprand(ComplexF64, 20, 20, sparsity)))
+            @test ishermitian(S)
+            @test !issymmetric(S) || isreal(S)
+        end
+    end
+
+    @testset "issue #605" begin
+        S = sparse([2, 3, 1], [1, 1, 3], [1, 1, 1], 3, 3)
+        @test !issymmetric(S)
+    end
 end
 
 @testset "rotations" begin


### PR DESCRIPTION
The `issymmetric` check tracks an `offset` that it uses to go from (row, col) to (col, row). However, currently this doesn't account for the fact that if a column is empty, entries in `colptr` will be identical. E.g., in #605, we have
```julia
julia> S = sparse([2, 3, 1], [1, 1, 3], [1, 1, 1], 3, 3)
3×3 SparseMatrixCSC{Int64, Int64} with 3 stored entries:
 ⋅  ⋅  1
 1  ⋅  ⋅
 1  ⋅  ⋅

julia> SparseArrays.getcolptr(S)
4-element Vector{Int64}:
 1
 3
 3
 4
```
The offset `3` corresponds to rows in the third column, as the second column is empty. This PR checks for empty columns, in which case we may exit the call immediately.

Fixes #605 