### PR TITLE
Replace `v == zero(v)` with  `_iszero`

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2283,7 +2283,7 @@ function (+)(A::Array, B::SparseMatrixCSCUnion)
     for j in axes(B,2)
         for i in nzrange(B, j)
             rowidx = rowinds[i]
-            C[rowidx,j] = A[rowidx,j] + nzvals[i] 
+            C[rowidx,j] = A[rowidx,j] + nzvals[i]
         end
     end
     return C
@@ -2452,7 +2452,7 @@ function Base._mapreduce(f, op::Union{typeof(Base.mul_prod),typeof(*)}, ::Base.I
     else
         v = f(zero(T))^(nzeros)
         # Bail out early if initial reduction value is zero or if there are no stored elements
-        (v == zero(T) || nnzA == 0) ? v : v*Base._mapreduce(f, op, nzvalview(A))
+        (_iszero(v) || nnzA == 0) ? v : v*Base._mapreduce(f, op, nzvalview(A))
     end
 end
 
@@ -4605,6 +4605,6 @@ function copytrito!(M::AbstractMatrix, S::AbstractSparseMatrixCSC, uplo::Char)
             (uplo == 'U' && row <= col) || (uplo == 'L' && row >= col) || continue
             M[row, col] = nz[i]
         end
-    end 
+    end
     return M
 end

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1932,7 +1932,7 @@ function _spmul!(y::AbstractVector, A::AbstractMatrix, x::AbstractSparseVector, 
         "Matrix A has $m rows, but vector y has a length $(length(y))"))
     m == 0 && return y
     β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
-    α == zero(α) && return y
+    _iszero(α) && return y
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
@@ -1960,7 +1960,7 @@ function _At_or_Ac_mul_B!(tfun::Function,
         "Matrix A has $m columns, but vector y has a length $(length(y))"))
     m == 0 && return y
     β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
-    α == zero(α) && return y
+    _iszero(α) && return y
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
@@ -2055,7 +2055,7 @@ function _spmul!(y::AbstractVector, A::AbstractSparseMatrixCSC, x::AbstractSpars
         "Matrix A has $m rows, but vector y has a length $(length(y))"))
     m == 0 && return y
     β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
-    α == zero(α) && return y
+    _iszero(α) && return y
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
@@ -2087,7 +2087,7 @@ function _At_or_Ac_mul_B!(tfun::Function,
         "Matrix A has $m rows, but vector y has a length $(length(y))"))
     n == 0 && return y
     β != one(β) && LinearAlgebra._rmul_or_fill!(y, β)
-    α == zero(α) && return y
+    _iszero(α) && return y
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)
@@ -2421,7 +2421,7 @@ import Base.fill!
 function fill!(A::Union{AbstractCompressedVector, AbstractSparseMatrixCSC}, x)
     T = eltype(A)
     xT = convert(T, x)
-    if xT == zero(T)
+    if _iszero(xT)
         fill!(nonzeros(A), xT)
     else
         _fillnonzero!(A, xT)


### PR DESCRIPTION
The purpose of this PR is to not call `==` directly, and use `_iszero` instead. This is to help integration with [IntervalArithmetic.jl](https://github.com/JuliaIntervals/IntervalArithmetic.jl) since `==` for our `Interval` type does not always return a Boolean.

Closes https://github.com/JuliaSparse/SparseArrays.jl/issues/609.

I did not change two checks using `===` since this would break the behaviour for `-0.0`. If I understood correctly, it should not be an issue with `Interval`, since it will return `false` consistently (it may be sub-optimal, but not wrong)
cc @dpsanders, @Kolaru
cc also @kalmarek, since you raised https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/628 you may have more experience mixing SparseArrays and IntervalArithmetic

I do not know how to the backporting procedure works, but it'd be great to have this for 1.10 and 1.11.