### PR TITLE
`ldiv!` for `Diagonal` and a sparse vector

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1312,7 +1312,7 @@ function rdiv!(A::AbstractSparseMatrixCSC{T}, D::Diagonal{T}) where T
     A
 end
 
-function ldiv!(D::Diagonal{T}, A::AbstractSparseMatrixCSC{T}) where {T}
+function ldiv!(D::Diagonal{T}, A::Union{AbstractSparseMatrixCSC{T}, AbstractSparseVector{T}}) where {T}
     # require_one_based_indexing(A)
     if size(A, 1) != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $(size(A, 1)) rows"))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -338,6 +338,9 @@ end
             @test lmul!(transpose(copy(D)), copy(b)) ≈ transpose(MD)*bd
             @test lmul!(adjoint(copy(D)), copy(b)) ≈ MD'*bd
         end
+
+        v = sprand(eltype(D), size(D,1), 0.1)
+        @test ldiv!(D, copy(v)) == D \ Array(v)
     end
 end
 


### PR DESCRIPTION
This improves performance:
```julia
julia> using LinearAlgebra, SparseArrays

julia> D = Diagonal(rand(3000));

julia> S = sprand(size(D,1), 0.01);

julia> @btime ldiv!($D, $S);
  30.053 μs (0 allocations: 0 bytes) # master
  1.585 μs (0 allocations: 0 bytes) # PR
```