### PR TITLE
unify reduce/reducedim empty case behaviors

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2650,12 +2650,7 @@ function _findr(op, A::AbstractSparseMatrixCSC{Tv}, region) where {Tv}
     N = nnz(A)
     L = widelength(A)
     if L == 0
-        if prod(map(length, Base.reduced_indices(A, region))) != 0
-            throw(ArgumentError("array slices must be non-empty"))
-        else
-            ri = Base.reduced_indices0(A, region)
-            return (zeros(Tv, ri), zeros(Ti, ri))
-        end
+        throw(ArgumentError("reducing over an empty collection is not allowed"))
     end
 
     colptr = getcolptr(A); rowval = rowvals(A); nzval = nonzeros(A); m = size(A, 1); n = size(A, 2)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1682,6 +1682,7 @@ Base._all(f, A::SparseVectorUnion, ::Colon) =
     iszero(length(A)) ? true  : Base._mapreduce(f, &, IndexCartesian(), A)
 
 function Base.mapreducedim!(f, op, R::AbstractVector, A::SparseVectorUnion)
+    isempty(A) && return R
     # dim1 reduction could be safely replaced with a mapreduce
     if length(R) == 1
         I = firstindex(R)


### PR DESCRIPTION
This is the accompanying patch to SparseArray's reduction machinery that matches https://github.com/JuliaLang/julia/pull/55628