### PR TITLE
Clarify pros, cons and limitations of Cholesky and LDLt

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1563,6 +1563,9 @@ Setting the optional `shift` keyword argument computes the factorization of
 it should be a permutation of `1:size(A,1)` giving the ordering to use
 (instead of CHOLMOD's default AMD ordering).
 
+See also [`ldlt`](@ref) for a similar factorization that does not require
+positive definiteness, but can be significantly slower than `cholesky`.
+
 # Examples
 
 In the following example, the fill-reducing permutation used is `[3, 2, 1]`.
@@ -1728,6 +1731,10 @@ To include the effects of permutation, it is typically preferable to extract
 `P'*L`) and `LtP = F.UP` (the equivalent of `L'*P`).
 The complete list of supported factors is `:L, :PtL, :D, :UP, :U, :LD, :DU, :PtLD, :DUP`.
 
+Unlike the related Cholesky factorization, the ``LDL'`` factorization does not
+require `A` to be positive definite. However, it still requires all leading
+principal minors to be well-conditioned and will fail if this is not satisfied.
+
 When `check = true`, an error is thrown if the decomposition fails.
 When `check = false`, responsibility for checking the decomposition's
 validity (via [`issuccess`](@ref)) lies with the user.
@@ -1736,6 +1743,9 @@ Setting the optional `shift` keyword argument computes the factorization of
 `A+shift*I` instead of `A`. If the `perm` argument is provided,
 it should be a permutation of `1:size(A,1)` giving the ordering to use
 (instead of CHOLMOD's default AMD ordering).
+
+See also [`cholesky`](@ref) for a factorization that can be significantly
+faster than `ldlt`, but requires `A` to be positive definite.
 
 !!! note
     This method uses the CHOLMOD[^ACM887][^DavisHager2009] library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).


### PR DESCRIPTION
I find it worth pointing out explicitly in the docs that LDLt, which mathematically looks like a drop-in replacement for Cholesky that does away with the positive definiteness requirement, comes with the following caveats:

* It fails for a lot of matrices (for example, `ldlt(Symmetric(sprandn(1000, 1000, p)))` basically never succeeds for any relevant sparsity `p`) due to the requirement that all leading principal minors be well-conditioned
* In CHOLMOD, `ldlt` is significantly slower than `cholesky` as it does not have a supernodal implementation

So I made some docstring edits to clarify the relationship and tradeoffs between `cholesky` and `ldlt`.

Citation for these claims: pages 106-107 in the CHOLMOD user guide at https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v7.10.3/CHOLMOD/Doc/CHOLMOD_UserGuide.pdf