### PR TITLE
Make cond(::SparseMatrix, 1 / Inf) discoverable from 2-norm error

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1577,7 +1577,7 @@ function cond(A::AbstractSparseMatrixCSC, p::Real=2)
         normA = opnorm(A, Inf)
         return normA * normAinv
     elseif p == 2
-        throw(ArgumentError("2-norm condition number is not implemented for sparse matrices, try cond(Array(A), 2) instead"))
+        throw(ArgumentError("only 1- and Inf-norm condition number are implemented for sparse matrices, for 2-norm try cond(Array(A), 2) instead"))
     else
         throw(ArgumentError("second argument must be either 1 or Inf, got $p"))
     end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1577,7 +1577,7 @@ function cond(A::AbstractSparseMatrixCSC, p::Real=2)
         normA = opnorm(A, Inf)
         return normA * normAinv
     elseif p == 2
-        throw(ArgumentError("only 1- and Inf-norm condition number are implemented for sparse matrices, for 2-norm try cond(Array(A), 2) instead"))
+        throw(ArgumentError("only 1- and Inf-norm condition numbers are implemented for sparse matrices, for 2-norm try cond(Array(A), 2) instead"))
     else
         throw(ArgumentError("second argument must be either 1 or Inf, got $p"))
     end


### PR DESCRIPTION
Changed error message when trying to compute condition number of sparse matrix in 2-norm, suggesting 1 or Inf norm.

Newbies like me or https://discourse.julialang.org/t/condition-number-of-sparse-matrix/77131/5 got diverted into trying densifying the array, which is very limited in many applications...