### PR TITLE
Overwrite fewer methods in ReadOnly

### DIFF
--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -13,7 +13,7 @@ ReadOnly(x::ReadOnly) = x
 Base.getproperty(x::ReadOnly, s::Symbol) = Base.getproperty(parent(x), s)
 @inline Base.parent(x::ReadOnly) = getfield(x, :parent)
 
-for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :eltype]
+for i in [:length, :first, :last, :firstindex, :lastindex]
     @eval Base.@propagate_inbounds @inline Base.$i(x::ReadOnly) = Base.$i(parent(x))
 end
 for i in [:iterate, :axes, :getindex, :size, :strides]


### PR DESCRIPTION
I think there are lots of methods in this file that can be deleted - but I don't totally understand what ReadOnly is used for and took the conservative approach and deleted only the methods that snoop_invalidations tell me cause invalidations. Which are `eachindex` and `eltype`

`Base.resize!` also invalidates but that one at least is actually used.

