### PR TITLE
`ReadOnly` fixes: prevent adding some methods of `size`, `axes`, `eltype`

### DIFF
--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -13,10 +13,10 @@ ReadOnly(x::ReadOnly) = x
 Base.getproperty(x::ReadOnly, s::Symbol) = Base.getproperty(parent(x), s)
 @inline Base.parent(x::ReadOnly) = getfield(x, :parent)
 
-for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :eltype]
+for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :eltype, :axes, :size]
     @eval Base.@propagate_inbounds @inline Base.$i(x::ReadOnly) = Base.$i(parent(x))
 end
-for i in [:iterate, :axes, :getindex, :size, :strides]
+for i in [:iterate, :getindex, :strides]
     @eval(Base.@propagate_inbounds @inline Base.$i(x::ReadOnly, y...) = Base.$i(parent(x), y...))
 end
 

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -13,7 +13,7 @@ ReadOnly(x::ReadOnly) = x
 Base.getproperty(x::ReadOnly, s::Symbol) = Base.getproperty(parent(x), s)
 @inline Base.parent(x::ReadOnly) = getfield(x, :parent)
 
-for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :eltype, :axes, :size]
+for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :axes, :size]
     @eval Base.@propagate_inbounds @inline Base.$i(x::ReadOnly) = Base.$i(parent(x))
 end
 for i in [:iterate, :getindex, :strides]


### PR DESCRIPTION
* Define only single-argument methods for `size` and `axes`.

    * On Nightly Julia, this change prevents two sysimage invalidations, triggered by defining two-argument `axes`.

* Do not add the `eltype` method.

    * New types are not supposed to define `eltype` on instances.

    * New subtypes of `AbstractArray` are not supposed to add methods to `eltype`.