### PR TITLE
cholmod: correct the `IndexStyle` method additions

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1358,7 +1358,7 @@ end
 size(F::Factor) = (size(F, 1), size(F, 2))
 axes(A::Union{Dense,Sparse,Factor}) = map(Base.OneTo, size(A))
 
-IndexStyle(::Dense) = IndexLinear()
+IndexStyle(::Type{<:Dense}) = IndexLinear()
 
 size(FC::FactorComponent, i::Integer) = size(FC.F, i)
 size(FC::FactorComponent) = size(FC.F)
@@ -1379,7 +1379,6 @@ function getindex(A::Dense{T}, i::Integer) where {T<:VTypes}
     unsafe_load(Ptr{T}(s.x), i)
 end
 
-IndexStyle(::Sparse) = IndexCartesian()
 function getindex(A::Sparse{T}, i0::Integer, i1::Integer) where T
     s = unsafe_load(typedpointer(A))
     !(1 <= i0 <= s.nrow && 1 <= i1 <= s.ncol) && throw(BoundsError())


### PR DESCRIPTION
One of the methods in question can be simply deleted because `IndexCartesian` is the default.

The other one is changed to be defined on the type instead of on the instance, as intended.

Preventing defining `IndexStyle` methods on instances (as opposed to types) prevents a single invalidation.