### PR TITLE
`ReadOnly`: slightly restrict the dispatch on the `setindex!` method

### DIFF
--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -22,7 +22,7 @@ end
 
 Base.unsafe_convert(x::Type{Ptr{T}}, A::ReadOnly) where T = Base.unsafe_convert(x, parent(A))
 Base.elsize(::Type{ReadOnly{T,N,V}}) where {T,N,V} = Base.elsize(V)
-Base.@propagate_inbounds @inline Base.setindex!(x::ReadOnly, v, ind...) = if v == getindex(parent(x), ind...)
+Base.@propagate_inbounds @inline Base.setindex!(x::ReadOnly, v, ind::Vararg{Integer}) = if v == getindex(parent(x), ind...)
         v
     else
         error("Can't change $(typeof(x)).")


### PR DESCRIPTION
Stricten up `Vararg{Any}` to `Vararg{Integer}`.

The stricter dispatch still satisfies the `AbstractArray` interface, for both cases of `IndexStyle`.

The benefit is that `Integer` excludes some common types, such as `CartesianIndex`. As a result, loading SparseArrays causes only $24$ invalidations in the sysimage after this change, as opposed to $26$ before this change.