### PR TITLE
`ReadOnly`: do not add single-argument methods to `eachindex`, etc

### DIFF
--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -20,12 +20,8 @@ for i in [:iterate, :getindex, :strides]
     @eval(Base.@propagate_inbounds @inline Base.$i(x::ReadOnly, y...) = Base.$i(parent(x), y...))
 end
 
-function Base.eachindex(i::IndexLinear, x::ReadOnly)
-    eachindex(i, parent(x))
-end
-function Base.eachindex(i::IndexCartesian, x::ReadOnly)
-    eachindex(i, parent(x))
-end
+Base.eachindex(i::IndexLinear, x::ReadOnly) = eachindex(i, parent(x))
+Base.eachindex(i::IndexCartesian, x::ReadOnly) = eachindex(i, parent(x))
 
 Base.unsafe_convert(x::Type{Ptr{T}}, A::ReadOnly) where T = Base.unsafe_convert(x, parent(A))
 Base.elsize(::Type{ReadOnly{T,N,V}}) where {T,N,V} = Base.elsize(V)

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -13,11 +13,18 @@ ReadOnly(x::ReadOnly) = x
 Base.getproperty(x::ReadOnly, s::Symbol) = Base.getproperty(parent(x), s)
 @inline Base.parent(x::ReadOnly) = getfield(x, :parent)
 
-for i in [:length, :first, :last, :eachindex, :firstindex, :lastindex, :axes, :size]
+for i in [:length, :first, :last, :axes, :size]
     @eval Base.@propagate_inbounds @inline Base.$i(x::ReadOnly) = Base.$i(parent(x))
 end
 for i in [:iterate, :getindex, :strides]
     @eval(Base.@propagate_inbounds @inline Base.$i(x::ReadOnly, y...) = Base.$i(parent(x), y...))
+end
+
+function Base.eachindex(i::IndexLinear, x::ReadOnly)
+    eachindex(i, parent(x))
+end
+function Base.eachindex(i::IndexCartesian, x::ReadOnly)
+    eachindex(i, parent(x))
 end
 
 Base.unsafe_convert(x::Type{Ptr{T}}, A::ReadOnly) where T = Base.unsafe_convert(x, parent(A))


### PR DESCRIPTION
Do not add single-argument methods to:

* `eachindex`

* `firstindex`

* `lastindex`

The above have fallbacks that work as intended as long as the two two-argument methods of `eachindex` are defined.

So add the two-argument methods of `eachindex` instead of adding single-argument methods of the three functions.

On nightly Julia, together with PR #652, this PR decreases the amount of sysimage invalidations that happen when loading SparseArrays from $26$ to $17$.

Without PR #652, this PR happens to increase the amount of invalidations, to $28$.