### PR TITLE
Update CI workflow for Julia and checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,17 @@ jobs:
           - x64
           - x86
         include:
+          - os: ubuntu-latest
+            julia-arch: aarch64
+            julia-version: 'nightly'      
           - os: macOS-latest
             julia-arch: aarch64
             julia-version: 'nightly'
-          - os: macOS-13
+          - os: macOS-15-intel
             julia-arch: x64
             julia-version: 'nightly'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
@@ -62,7 +65,7 @@ jobs:
         julia-arch:
           - x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
@@ -75,7 +78,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
           version: 'nightly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
           - x64
           - x86
         include:
-          - os: ubuntu-latest
-            julia-arch: aarch64
-            julia-version: 'nightly'      
           - os: macOS-latest
             julia-arch: aarch64
             julia-version: 'nightly'


### PR DESCRIPTION
Updated CI configuration to use actions/checkout@v6 and added macOS-15-intel for macos x86 tests. 
