### PR TITLE
Fix generic sparse-dense multiplication

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -69,7 +69,7 @@ Base.@constprop :aggressive function spdensemul!(C, tA, tB, A, B, alpha, beta)
         T = eltype(C)
         _mul!(rangefun, diagop, odiagop, C, A, B, T(alpha), T(beta))
     else
-        @stable_muladdmul LinearAlgebra._generic_matmatmul!(C, 'N', 'N', wrap(A, tA), wrap(B, tB), MulAddMul(alpha, beta))
+        @stable_muladdmul LinearAlgebra._generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(alpha, beta))
     end
     return C
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -109,6 +109,14 @@ end
     end
 end
 
+@testset "multiplication of special sparse with dense matrix" begin
+    # this results in a call of the most generic multiplication code in LinearAlgebra.jl
+    A = randn(2, 2)
+    S = sparse(A)
+    B = rand(1, 2)'
+    @test Symmetric(S) * B ≈ Symmetric(A) * B
+end
+
 @testset "sparse transpose adjoint" begin
     A = sprand(10, 10, 0.75)
     @test A' == SparseMatrixCSC(A')


### PR DESCRIPTION
Fixes #662. Unsurprisingly, this call into `LinearAlgebra` was not covered by tests. The method signature of the internal method must have changed in the v1.11 cycle.