### PR TITLE
Move `nonzeroinds` to `LinearAlgebra`

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -19,7 +19,7 @@ import Base: Matrix, Vector
 import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!, isbanded, isdiag,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu,
-    matprod_dest, generic_matvecmul!, generic_matmatmul!, copytrito!
+    matprod_dest, generic_matvecmul!, generic_matmatmul!, copytrito!, nonzeroinds
 
 import Base: adjoint, argmin, argmax, Array, broadcast, circshift!, complex, Complex,
     conj, conj!, convert, copy, copy!, copyto!, count, diff, findall, findmax, findmin,


### PR DESCRIPTION
This builds on https://github.com/JuliaLang/LinearAlgebra.jl/pull/1534.

One issue with this would be that direct uses of `SparseArrays.nonzeroinds` would lead to warnings:
```julia
julia> s = sparsevec([2, 6], [2,3])
6-element SparseVector{Int64, Int64} with 2 stored entries:
  [2]  =  2
  [6]  =  3

julia> SparseArrays.nonzeroinds(s)
[ Warning: nonzeroinds is defined in LinearAlgebra and is not public in SparseArrays
2-element Vector{Int64}:
 2
 6
```
This may be remedied by making the function public, but then this had not been declared as `public` anyway.

The other alternative might be to retain the function in `SparseArrays` and just add a method to the one from `LinearAlgebra`, as in the PR linked above. 