### PR TITLE
fix error message in sparse_check

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -143,8 +143,8 @@ function sparse_check(n::Integer, colptr::Vector{Ti}, rowval, nzval) where Ti
     throwmonotonic(ckp, ck, k) = throw(ArgumentError("$ckp == colptr[$(k-1)] > colptr[$k] == $ck"))
 
     sparse_check_length("colptr", colptr, n+1, String) # don't check upper bound
-    ckp = Ti(1)
-    ckp == colptr[1] || throwstart(ckp)
+    ckp = colptr[1]
+    ckp == Ti(1) || throwstart(ckp)
     @inbounds for k = 2:n+1
         ck = colptr[k]
         ckp <= ck || throwmonotonic(ckp, ck, k)


### PR DESCRIPTION
There was a typo in `sparse_check`, that didn't affect the checking but led to a nonsensical error message:
```julia
julia> sparse_check(2, [2,1,2], [1], [2])
ERROR: ArgumentError: 1 == colptr[1] != 1
```
With the PR we get:
```julia
julia> sparse_check(2, [2,1,2], [1], [2])
ERROR: ArgumentError: 2 == colptr[1] != 1
```
