### PR TITLE
`LinearAlgebra._generic_mat[vec/mat]mul!` prefers plain `alpha` & `beta`

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -69,7 +69,7 @@ Base.@constprop :aggressive function spdensemul!(C, tA, tB, A, B, alpha, beta)
         T = eltype(C)
         _mul!(rangefun, diagop, odiagop, C, A, B, T(alpha), T(beta))
     else
-        @stable_muladdmul LinearAlgebra._generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(alpha, beta))
+        LinearAlgebra._generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
     end
     return C
 end

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2041,7 +2041,7 @@ Base.@constprop :aggressive function generic_matvecmul!(y::AbstractVector, tA, A
     elseif tA == 'C'
         _At_or_Ac_mul_B!((a,b) -> adjoint(a) * b, y, A, x, alpha, beta)
     else
-        @stable_muladdmul LinearAlgebra._generic_matvecmul!(y, 'N', wrap(A, tA), x, MulAddMul(alpha, beta))
+        LinearAlgebra._generic_matvecmul!(y, 'N', wrap(A, tA), x, alpha, beta)
     end
     return y
 end


### PR DESCRIPTION
The `LinearAlgebra` functions were refactored and accept plain `alpha` and `beta`. Potential `MulAddMul`s are destructured.