### PR TITLE
Improve performance of `HermOrSym` sparse matrix times dense matrix

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -12,21 +12,13 @@ const DenseTriangular  = UpperOrLowerTriangular{<:Any,<:DenseMatrixUnion}
 const DenseInputVector = Union{StridedVector, BitVector}
 const DenseVecOrMat = Union{DenseMatrixUnion, DenseInputVector}
 
-matprod_dest(A::SparseMatrixCSCUnion2, B::DenseTriangular, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::DenseTriangular, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::StridedMaybeAdjOrTransMat, B::SparseMatrixCSCUnion2, TS) =
+matprod_dest(A, B::SparseMatrixCSCUnion2, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::Union{BitMatrix,AdjOrTrans{<:Any,BitMatrix}}, B::SparseMatrixCSCUnion2, TS) =
+matprod_dest(A, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::DenseTriangular, B::SparseMatrixCSCUnion2, TS) =
+matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::StridedMaybeAdjOrTransMat, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::Union{BitMatrix,AdjOrTrans{<:Any,BitMatrix}}, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::DenseTriangular, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -20,6 +20,15 @@ matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
+# disambiguation
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::SparseMatrixCSCUnion2, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
     @eval begin

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -21,14 +21,16 @@ matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
 matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 # disambiguation
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::SparseMatrixCSCUnion2, TS) =
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::Diagonal, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    _matprod_dest_diag(B, TS)
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
     @eval begin

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -62,12 +62,12 @@ Base.@constprop :aggressive function spdensemul!(C, tA, tB, A, B, alpha, beta)
         _At_or_Ac_mul_B!(transpose, C, A, wrap(B, tB), alpha, beta)
     elseif tA_uc == 'C'
         _At_or_Ac_mul_B!(adjoint, C, A, wrap(B, tB), alpha, beta)
-    elseif tA_uc in ('S', 'H') && tB_uc == 'N'
+    elseif tA_uc in ('S', 'H')
         rangefun = isuppercase(tA) ? nzrangeup : nzrangelo
         diagop = tA_uc == 'S' ? identity : real
         odiagop = tA_uc == 'S' ? transpose : adjoint
         T = eltype(C)
-        _mul!(rangefun, diagop, odiagop, C, A, B, T(alpha), T(beta))
+        _mul!(rangefun, diagop, odiagop, C, A, wrap(B, tB), T(alpha), T(beta))
     else
         @stable_muladdmul LinearAlgebra._generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(alpha, beta))
     end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -12,25 +12,22 @@ const DenseTriangular  = UpperOrLowerTriangular{<:Any,<:DenseMatrixUnion}
 const DenseInputVector = Union{StridedVector, BitVector}
 const DenseVecOrMat = Union{DenseMatrixUnion, DenseInputVector}
 
-matprod_dest(A, B::SparseMatrixCSCUnion2, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-# disambiguation
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
+matprod_dest(A::SparseMatrixCSCUnion2, B::DenseTriangular, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::DenseTriangular, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::Diagonal, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    _matprod_dest_diag(B, TS)
+matprod_dest(A::StridedMaybeAdjOrTransMat, B::SparseMatrixCSCUnion2, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::Union{BitMatrix,AdjOrTrans{<:Any,BitMatrix}}, B::SparseMatrixCSCUnion2, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::DenseTriangular, B::SparseMatrixCSCUnion2, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::StridedMaybeAdjOrTransMat, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::Union{BitMatrix,AdjOrTrans{<:Any,BitMatrix}}, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::DenseTriangular, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
     @eval begin


### PR DESCRIPTION
This fixes the performance regression for the case `Hermitian(sparse)*AdjOrTrans(dense)`. Should be backported.