### PR TITLE
Make destination array type in sparse multiplication consistent

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -19,7 +19,7 @@ import Base: Matrix, Vector
 import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!, isbanded, isdiag,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu,
-    matprod_dest, generic_matvecmul!, generic_matmatmul!, generic_matmatmul_wrapper!, copytrito!
+    matop_dest, generic_matvecmul!, generic_matmatmul!, generic_matmatmul_wrapper!, copytrito!
 
 import Base: adjoint, argmin, argmax, Array, broadcast, circshift!, complex, Complex,
     conj, conj!, convert, copy, copy!, copyto!, count, diff, findall, findmax, findmin,

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -12,22 +12,25 @@ const DenseTriangular  = UpperOrLowerTriangular{<:Any,<:DenseMatrixUnion}
 const DenseInputVector = Union{StridedVector, BitVector}
 const DenseVecOrMat = Union{DenseMatrixUnion, DenseInputVector}
 
-matprod_dest(A::SparseMatrixCSCUnion2, B::DenseTriangular, TS) =
+matprod_dest(A, B::SparseMatrixCSCUnion2, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+# disambiguation
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::DenseTriangular, TS) =
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::StridedMaybeAdjOrTransMat, B::SparseMatrixCSCUnion2, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::Union{BitMatrix,AdjOrTrans{<:Any,BitMatrix}}, B::SparseMatrixCSCUnion2, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::DenseTriangular, B::SparseMatrixCSCUnion2, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::StridedMaybeAdjOrTransMat, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::Union{BitMatrix,AdjOrTrans{<:Any,BitMatrix}}, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::DenseTriangular, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::Diagonal, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    _matprod_dest_diag(B, TS)
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
     @eval begin

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -29,6 +29,14 @@ matprod_dest(A::LinearAlgebra.StructuredMatrix, B::HermOrSym{<:Any,<:SparseMatri
     similar(A, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.StructuredMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::SparseMatrixCSCUnion2, B::StructuredMatrix, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::StructuredMatrix, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, B::StructuredMatrix, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::StructuredMatrix, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -37,6 +37,14 @@ matprod_dest(A::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.Struc
     similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.StructuredMatrix, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::SparseMatrixCSCUnion2, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
@@ -47,6 +55,8 @@ matprod_dest(A::LinearAlgebra.BandedMatrix, B::UpperOrLowerTriangular{<:Any,<:Sp
     similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::Diagonal, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     _matprod_dest_diag(B, TS)
+matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::Diagonal, TS) =
+    _matprod_dest_diag(A, TS)
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
     @eval begin

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -11,52 +11,16 @@ const DenseMatrixUnion = Union{StridedMatrix, BitMatrix}
 const DenseTriangular  = UpperOrLowerTriangular{<:Any,<:DenseMatrixUnion}
 const DenseInputVector = Union{StridedVector, BitVector}
 const DenseVecOrMat = Union{DenseMatrixUnion, DenseInputVector}
+const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLowerTriangular{T,S}, UpperHessenberg{T,S}}
+const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
 
-matprod_dest(A, B::SparseMatrixCSCUnion2, TS) =
+matprod_dest(A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::QuasiSparseMatrix, B, TS) = similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::QuasiSparseMatrix, B::QuasiSparseMatrix, TS) = similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::LinearAlgebra.BandedMatrix, B::QuasiSparseMatrix, TS) =
+    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::QuasiSparseMatrix, B::LinearAlgebra.BandedMatrix, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-# disambiguation
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::SparseMatrixCSCUnion2, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.StructuredMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::SparseMatrixCSCUnion2, B::LinearAlgebra.StructuredMatrix, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.StructuredMatrix, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.StructuredMatrix, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.StructuredMatrix, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::SparseMatrixCSCUnion2, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::Diagonal, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
-    _matprod_dest_diag(B, TS)
-matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::Diagonal, TS) =
-    _matprod_dest_diag(A, TS)
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
     @eval begin

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -7,6 +7,7 @@ using Random: rand!
 const tilebufsize = 10800  # Approximately 32k/3
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
+const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
 const DenseMatrixUnion = Union{StridedMatrix, BitMatrix}
 const DenseTriangular  = UpperOrLowerTriangular{<:Any,<:DenseMatrixUnion}
 const DenseInputVector = Union{StridedVector, BitVector}
@@ -15,9 +16,10 @@ const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLow
 const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
 
 matprod_dest(A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::LinearAlgebra.BandedMatrix, B::QuasiSparseMatrix, TS) =
+# sparse products with banded matrices should return sparse arrays (Diagonal is handled by fallback)
+matprod_dest(A::BiTriSym, B::QuasiSparseMatrix, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::QuasiSparseMatrix, B::LinearAlgebra.BandedMatrix, TS) =
+matprod_dest(A::QuasiSparseMatrix, B::BiTriSym, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -15,8 +15,6 @@ const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLow
 const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
 
 matprod_dest(A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::QuasiSparseMatrix, B, TS) = similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::QuasiSparseMatrix, B::QuasiSparseMatrix, TS) = similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::QuasiSparseMatrix, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::QuasiSparseMatrix, B::LinearAlgebra.BandedMatrix, TS) =

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -11,6 +11,8 @@ const DenseMatrixUnion = Union{StridedMatrix, BitMatrix}
 const DenseTriangular  = UpperOrLowerTriangular{<:Any,<:DenseMatrixUnion}
 const DenseInputVector = Union{StridedVector, BitVector}
 const DenseVecOrMat = Union{DenseMatrixUnion, DenseInputVector}
+const QuasiTriangularWrapper{T} = Union{LowerTriangular{T},UnitLowerTriangular{T},
+            UpperTriangular{T},UnitUpperTriangular{T},UpperHessenberg{T}}
 
 matprod_dest(A, B::SparseMatrixCSCUnion2, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
@@ -21,6 +23,14 @@ matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
 matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 # disambiguation
+matprod_dest(A::QuasiTriangularWrapper, B::SparseMatrixCSCUnion2, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::QuasiTriangularWrapper, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::QuasiTriangularWrapper, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
+matprod_dest(A::QuasiTriangularWrapper, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+    similar(A, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -17,8 +17,8 @@ const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<
 
 matprod_dest(A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
 # sparse products with banded matrices should return sparse arrays (Diagonal is handled by fallback)
-matprod_dest(A::BiTriSym, B::QuasiSparseMatrix, TS) =
-    similar(B, TS, (size(A, 1), size(B, 2)))
+matprod_dest(::BiTriSym, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B))
+matprod_dest(::Diagonal, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
 matprod_dest(A::QuasiSparseMatrix, B::BiTriSym, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -11,8 +11,6 @@ const DenseMatrixUnion = Union{StridedMatrix, BitMatrix}
 const DenseTriangular  = UpperOrLowerTriangular{<:Any,<:DenseMatrixUnion}
 const DenseInputVector = Union{StridedVector, BitVector}
 const DenseVecOrMat = Union{DenseMatrixUnion, DenseInputVector}
-const QuasiTriangularWrapper{T} = Union{LowerTriangular{T},UnitLowerTriangular{T},
-            UpperTriangular{T},UnitUpperTriangular{T},UpperHessenberg{T}}
 
 matprod_dest(A, B::SparseMatrixCSCUnion2, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
@@ -23,13 +21,13 @@ matprod_dest(A, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
 matprod_dest(A, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 # disambiguation
-matprod_dest(A::QuasiTriangularWrapper, B::SparseMatrixCSCUnion2, TS) =
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::QuasiTriangularWrapper, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::QuasiTriangularWrapper, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::QuasiTriangularWrapper, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
+matprod_dest(A::LinearAlgebra.StructuredMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -29,13 +29,13 @@ matprod_dest(A::LinearAlgebra.StructuredMatrix, B::HermOrSym{<:Any,<:SparseMatri
     similar(A, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.StructuredMatrix, B::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::SparseMatrixCSCUnion2, B::StructuredMatrix, TS) =
+matprod_dest(A::SparseMatrixCSCUnion2, B::LinearAlgebra.StructuredMatrix, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::StructuredMatrix, TS) =
+matprod_dest(A::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.StructuredMatrix, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, B::StructuredMatrix, TS) =
+matprod_dest(A::HermOrSym{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.StructuredMatrix, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
-matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::StructuredMatrix, TS) =
+matprod_dest(A::UpperOrLowerTriangular{<:Any,<:SparseMatrixCSCUnion2}, B::LinearAlgebra.StructuredMatrix, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))
 matprod_dest(A::LinearAlgebra.BandedMatrix, B::SparseMatrixCSCUnion2, TS) =
     similar(B, TS, (size(A, 1), size(B, 2)))

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -16,12 +16,12 @@ const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLow
 const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
 const QuasiStridedMatrix = Union{StridedMatrix, DenseViewWrappers{<:Any,<:StridedMatrix}}
 
-matop(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector, TS) = Vector{TS}(undef, length(b))
-matop(::typeof(*), A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
+matop_dest(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector, TS) = Vector{TS}(undef, length(b))
+matop_dest(::typeof(*), A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
 # sparse products with banded matrices should return sparse arrays (Diagonal is handled by fallback)
-matop(::typeof(*), ::BiTriSym, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B))
-matop(::typeof(*), ::Diagonal, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
-matop(::typeof(*), A::QuasiSparseMatrix, B::BiTriSym, TS) =
+matop_dest(::typeof(*), ::BiTriSym, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B))
+matop_dest(::typeof(*), ::Diagonal, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
+matop_dest(::typeof(*), A::QuasiSparseMatrix, B::BiTriSym, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -14,12 +14,14 @@ const DenseInputVector = Union{StridedVector, BitVector}
 const DenseVecOrMat = Union{DenseMatrixUnion, DenseInputVector}
 const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLowerTriangular{T,S}, UpperHessenberg{T,S}}
 const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
+const QuasiStridedMatrix = Union{StridedMatrix, DenseViewWrappers{<:Any,<:StridedMatrix}}
 
-matprod_dest(A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
+matop(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector, TS) = Vector{TS}(undef, length(b))
+matop(::typeof(*), A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
 # sparse products with banded matrices should return sparse arrays (Diagonal is handled by fallback)
-matprod_dest(::BiTriSym, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B))
-matprod_dest(::Diagonal, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
-matprod_dest(A::QuasiSparseMatrix, B::BiTriSym, TS) =
+matop(::typeof(*), ::BiTriSym, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B))
+matop(::typeof(*), ::Diagonal, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
+matop(::typeof(*), A::QuasiSparseMatrix, B::BiTriSym, TS) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -51,12 +51,12 @@ const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLow
 const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
 const QuasiStridedMatrix = Union{StridedMatrix, DenseViewWrappers{<:Any,<:StridedMatrix}}
 
-matop_dest(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector, TS) = Vector{TS}(undef, length(b))
-matop_dest(::typeof(*), A, B::QuasiSparseMatrix, TS) = similar(A, TS, (size(A, 1), size(B, 2)))
+matop_dest(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector) = Vector{TS}(undef, size(A, 1))
+matop_dest(::typeof(*), A, B::QuasiSparseMatrix) = similar(A, TS, (size(A, 1), size(B, 2)))
 # sparse products with banded matrices should return sparse arrays (Diagonal is handled by fallback)
-matop_dest(::typeof(*), ::BiTriSym, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B))
-matop_dest(::typeof(*), ::Diagonal, B::QuasiSparseMatrix, TS) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
-matop_dest(::typeof(*), A::QuasiSparseMatrix, B::BiTriSym, TS) =
+matop_dest(::typeof(*), ::BiTriSym, B::QuasiSparseMatrix) = similar(B, TS, size(B))
+matop_dest(::typeof(*), ::Diagonal, B::QuasiSparseMatrix) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
+matop_dest(::typeof(*), A::QuasiSparseMatrix, B::BiTriSym) =
     similar(A, TS, (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -51,13 +51,18 @@ const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLow
 const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
 const QuasiStridedMatrix = Union{StridedMatrix, DenseViewWrappers{<:Any,<:StridedMatrix}}
 
-matop_dest(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector) = Vector{TS}(undef, size(A, 1))
-matop_dest(::typeof(*), A, B::QuasiSparseMatrix) = similar(A, TS, (size(A, 1), size(B, 2)))
+matop_dest(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector) =
+    Vector{promote_op(matprod, eltype(A), eltype(b))}(undef, size(A, 1))
+matop_dest(::typeof(*), A, B::QuasiSparseMatrix) =
+    similar(A, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
 # sparse products with banded matrices should return sparse arrays (Diagonal is handled by fallback)
-matop_dest(::typeof(*), ::BiTriSym, B::QuasiSparseMatrix) = similar(B, TS, size(B))
-matop_dest(::typeof(*), ::Diagonal, B::QuasiSparseMatrix) = similar(B, TS, size(B)) # disambiguation with LinearAlgebra
+matop_dest(::typeof(*), A::BiTriSym, B::QuasiSparseMatrix) =
+    similar(B, promote_op(matprod, eltype(A), eltype(B)), size(B))
+# needed for disambiguation with LinearAlgebra
+matop_dest(::typeof(*), A::Diagonal, B::QuasiSparseMatrix) =
+    similar(B, promote_op(matprod, eltype(A), eltype(B)), size(B))
 matop_dest(::typeof(*), A::QuasiSparseMatrix, B::BiTriSym) =
-    similar(A, TS, (size(A, 1), size(B, 2)))
+    similar(A, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
 
 for op ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
     @eval begin

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1880,16 +1880,6 @@ _fliptri(A::UnitUpperTriangular) = UnitLowerTriangular(parent(parent(A)))
 _fliptri(A::LowerTriangular) = UpperTriangular(parent(parent(A)))
 _fliptri(A::UnitLowerTriangular) = UnitUpperTriangular(parent(parent(A)))
 
-function (*)(A::_StridedOrTriangularMatrix{Ta}, x::AbstractSparseVector{Tx}) where {Ta,Tx}
-    require_one_based_indexing(A, x)
-    m, n = size(A)
-    length(x) == n || throw(DimensionMismatch(
-        "Matrix A has $n columns, but vector x has a length $(length(x))"))
-    Ty = promote_op(matprod, eltype(A), eltype(x))
-    y = Vector{Ty}(undef, m)
-    mul!(y, A, x)
-end
-
 # TODO: remove
 Base.@constprop :aggressive generic_matvecmul!(y::AbstractVector, tA, A::StridedMatrix, x::AbstractSparseVector,
                                             _add::MulAddMul = MulAddMul()) =
@@ -1977,26 +1967,6 @@ function _At_or_Ac_mul_B!(tfun::Function,
     end
     return y
 end
-
-function *(A::AdjOrTrans{<:Any,<:StridedMatrix}, x::AbstractSparseVector)
-    require_one_based_indexing(A, x)
-    m, n = size(A)
-    length(x) == n || throw(DimensionMismatch(
-        "Matrix A has $n columns, but vector x has a length $(length(x))"))
-    Ty = promote_op(matprod, eltype(A), eltype(x))
-    y = Vector{Ty}(undef, m)
-    mul!(y, A, x, true, false)
-end
-function *(A::LinearAlgebra.HermOrSym{<:Any,<:StridedMatrix}, x::AbstractSparseVector)
-    require_one_based_indexing(A, x)
-    m, n = size(A)
-    length(x) == n || throw(DimensionMismatch(
-        "Matrix A has $n columns, but vector x has a length $(length(x))"))
-    Ty = promote_op(matprod, eltype(A), eltype(x))
-    y = Vector{Ty}(undef, m)
-    mul!(y, A, x, true, false)
-end
-
 
 ### BLAS-2 / sparse A * sparse x -> dense y
 
@@ -2153,6 +2123,15 @@ function _At_or_Ac_mul_B(tfun::Function, A::AbstractSparseMatrixCSC{TvA,TiA}, x:
     return @if_move_fixed A x SparseVector(n, ynzind, ynzval)
 end
 
+matop(::typeof(\), A::Union{UpperTriangular,LowerTriangular}, b::AbstractSparseVector) =
+    Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
+matop(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
+    Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, length(b))
+
+matop(::typeof(/), b::AbstractSparseVector, B::Union{UpperTriangular,LowerTriangular}) =
+    Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
+matop(::typeof(/), b::AbstractSparseVector, B::UnitUpperOrUnitLowerTriangular) =
+    Vector{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, length(b))
 
 # define matrix division operations involving triangular matrices and sparse vectors
 # the valid left-division operations are A[t|c]_ldiv_B[!] and \
@@ -2162,17 +2141,6 @@ for isunittri in (true, false), islowertri in (true, false)
     unitstr = isunittri ? "Unit" : ""
     halfstr = islowertri ? "Lower" : "Upper"
     tritype = :(LinearAlgebra.$(Symbol(unitstr, halfstr, "Triangular")))
-
-    # build out-of-place left-division operations
-    # broad method where elements are Numbers
-    @eval function \(A::$tritype{<:TA,<:AbstractMatrix}, b::AbstractCompressedVector{Tb}) where {TA<:Number,Tb<:Number}
-        TAb = $(isunittri ?
-            :(typeof(zero(TA)*zero(Tb) + zero(TA)*zero(Tb))) :
-            :(typeof((zero(TA)*zero(Tb) + zero(TA)*zero(Tb))/one(TA))) )
-        return LinearAlgebra.ldiv!(convert(AbstractArray{TAb}, A), convert(Array{TAb}, b))
-    end
-    # fallback where elements are not Numbers
-    @eval \(A::$tritype, b::AbstractCompressedVector) = LinearAlgebra.ldiv!(A, copy(b))
 
     # faster method requiring good view support of the
     # triangular matrix type. hence the StridedMatrix restriction.

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2123,14 +2123,14 @@ function _At_or_Ac_mul_B(tfun::Function, A::AbstractSparseMatrixCSC{TvA,TiA}, x:
     return @if_move_fixed A x SparseVector(n, ynzind, ynzval)
 end
 
-matop(::typeof(\), A::Union{UpperTriangular,LowerTriangular}, b::AbstractSparseVector) =
+matop_dest(::typeof(\), A::Union{UpperTriangular,LowerTriangular}, b::AbstractSparseVector) =
     Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
-matop(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
+matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
     Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, length(b))
 
-matop(::typeof(/), b::AbstractSparseVector, B::Union{UpperTriangular,LowerTriangular}) =
+matop_dest(::typeof(/), b::AbstractSparseVector, B::Union{UpperTriangular,LowerTriangular}) =
     Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
-matop(::typeof(/), b::AbstractSparseVector, B::UnitUpperOrUnitLowerTriangular) =
+matop_dest(::typeof(/), b::AbstractSparseVector, B::UnitUpperOrUnitLowerTriangular) =
     Vector{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, length(b))
 
 # define matrix division operations involving triangular matrices and sparse vectors

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2143,7 +2143,7 @@ for isunittri in (true, false), islowertri in (true, false)
     end
     # fallback where elements are not Numbers
     @eval \(A::$tritype, b::AbstractCompressedVector) = LinearAlgebra.ldiv!(A, copy(b))
-    
+
     # faster method requiring good view support of the
     # triangular matrix type. hence the StridedMatrix restriction.
     for (istrans, applyxform, xformtype, xformop) in (

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2123,15 +2123,6 @@ function _At_or_Ac_mul_B(tfun::Function, A::AbstractSparseMatrixCSC{TvA,TiA}, x:
     return @if_move_fixed A x SparseVector(n, ynzind, ynzval)
 end
 
-matop_dest(::typeof(\), A::Union{UpperTriangular,LowerTriangular}, b::AbstractSparseVector) =
-    Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
-matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
-    Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, length(b))
-
-matop_dest(::typeof(/), b::AbstractSparseVector, B::Union{UpperTriangular,LowerTriangular}) =
-    Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
-matop_dest(::typeof(/), b::AbstractSparseVector, B::UnitUpperOrUnitLowerTriangular) =
-    Vector{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, length(b))
 
 # define matrix division operations involving triangular matrices and sparse vectors
 # the valid left-division operations are A[t|c]_ldiv_B[!] and \
@@ -2142,6 +2133,17 @@ for isunittri in (true, false), islowertri in (true, false)
     halfstr = islowertri ? "Lower" : "Upper"
     tritype = :(LinearAlgebra.$(Symbol(unitstr, halfstr, "Triangular")))
 
+    # build out-of-place left-division operations
+    # broad method where elements are Numbers
+    @eval function \(A::$tritype{<:TA,<:AbstractMatrix}, b::AbstractCompressedVector{Tb}) where {TA<:Number,Tb<:Number}
+        TAb = $(isunittri ?
+            :(typeof(zero(TA)*zero(Tb) + zero(TA)*zero(Tb))) :
+            :(typeof((zero(TA)*zero(Tb) + zero(TA)*zero(Tb))/one(TA))) )
+        return LinearAlgebra.ldiv!(convert(AbstractArray{TAb}, A), convert(Array{TAb}, b))
+    end
+    # fallback where elements are not Numbers
+    @eval \(A::$tritype, b::AbstractCompressedVector) = LinearAlgebra.ldiv!(A, copy(b))
+    
     # faster method requiring good view support of the
     # triangular matrix type. hence the StridedMatrix restriction.
     for (istrans, applyxform, xformtype, xformop) in (

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -110,12 +110,13 @@ end
 end
 
 @testset "destination array density in multiplication" begin
-    for tA in (adjoint, transpose, Hermitian, Symmetric, UpperTriangular, UpperHessenberg)
+    wrappers = (adjoint, transpose, Hermitian, Symmetric, UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular, UpperHessenberg)
+    for tA in wrappers
         A = randn(5,5)
         At = tA(A)
         S = sprandn(5,5,0.3)
         St = tA(S)
-        for tB in (adjoint, transpose, Hermitian, Symmetric, UpperTriangular, UpperHessenberg)
+        for tB in wrappers
             B = sprandn(5,5, 0.3)
             Bt = tB(B)
             C = At*Bt

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -120,14 +120,14 @@ end
             Bt = tB(B)
             C = At*Bt
             @test C ≈ Matrix(At) * Matrix(Bt)
-            @test C isa DenseVecOrMat
+            @test !issparse(C)
             D = St*Bt
             @test D ≈ Matrix(St) * Matrix(Bt)
-            @test D isa SparseMatrixCSC
+            @test issparse(D)
         end
         b = sprandn(5, 0.3)
         c = At * b
-        @test c ≈ Matrix(A) * Vector(b)
+        @test c ≈ Matrix(At) * Vector(b)
         @test c isa DenseVector
         d = St*b
         @test d ≈ Matrix(St) * Vector(b)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -138,10 +138,10 @@ end
                     SymTridiagonal(ones(5), ones(4)))
             M = St*T
             @test M ≈ Matrix(St) * Matrix(T)
-            @test M isa SparseMatrixCSC
+            @test issparse(M)
             N = T*St
             @test N ≈ Matrix(T) * Matrix(St)
-            @test N isa SparseMatrixCSC
+            @test issparse(N)
         end
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -109,6 +109,43 @@ end
     end
 end
 
+@testset "destination array density in multiplication" begin
+    for tA in (adjoint, transpose, Hermitian, Symmetric, UpperTriangular, UpperHessenberg)
+        A = randn(5,5)
+        At = tA(A)
+        S = sprandn(5,5,0.3)
+        St = tA(S)
+        for tB in (adjoint, transpose, Hermitian, Symmetric, UpperTriangular, UpperHessenberg)
+            B = sprandn(5,5, 0.3)
+            Bt = tB(B)
+            C = At*Bt
+            @test C ≈ Matrix(At) * Matrix(Bt)
+            @test C isa DenseVecOrMat
+            D = St*Bt
+            @test D ≈ Matrix(St) * Matrix(Bt)
+            @test D isa SparseMatrixCSC
+        end
+        b = sprandn(5, 0.3)
+        c = At * b
+        @test c ≈ Matrix(A) * Vector(b)
+        @test c isa DenseVector
+        d = St*b
+        @test d ≈ Matrix(St) * Vector(b)
+        @test d isa SparseVector
+        for T in (Diagonal(randn(5)),
+                    Bidiagonal(ones(5), ones(4), :U),
+                    Tridiagonal(ones(4), ones(5), ones(4)),
+                    SymTridiagonal(ones(5), ones(4)))
+            M = St*T
+            @test M ≈ Matrix(St) * Matrix(T)
+            @test M isa SparseMatrixCSC
+            N = T*St
+            @test N ≈ Matrix(T) * Matrix(St)
+            @test N isa SparseMatrixCSC
+        end
+    end
+end
+
 @testset "multiplication of special sparse with dense matrix" begin
     # this results in a call of the most generic multiplication code in LinearAlgebra.jl
     A = randn(2, 2)


### PR DESCRIPTION
This intends to fix the unexpected matrix return type behaviour observed in https://github.com/JuliaSparse/SparseArrays.jl/issues/685#issue-4179979925. The goal is determine the return type by the (potentially) non-sparse factor. For `BandedMatrix` types, however, the return type should be sparse, since these are themselves "sparse".

I can't seem to be able to run tests, but it seems that this yields a major speed-up in multiplication, and so fixes #685 (to be confirmed).