### PR TITLE
Remove some unnecessary methods that cause invalidations

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1291,7 +1291,6 @@ axes(A::Union{Dense,Sparse,Factor}) = map(Base.OneTo, size(A))
 
 IndexStyle(::Type{<:Dense}) = IndexLinear()
 
-size(FC::FactorComponent, i::Integer) = size(FC.F, i)
 size(FC::FactorComponent) = size(FC.F)
 
 adjoint(FC::FactorComponent{Tv,:L}) where {Tv} = FactorComponent{Tv,:U}(FC.F)

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1287,7 +1287,6 @@ function size(F::Factor, i::Integer)
     return 1
 end
 size(F::Factor) = (size(F, 1), size(F, 2))
-axes(A::Union{Dense,Sparse,Factor}) = map(Base.OneTo, size(A))
 
 IndexStyle(::Type{<:Dense}) = IndexLinear()
 

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -154,7 +154,6 @@ function Base.size(F::QRSparse, i::Integer)
         throw(ArgumentError("second argument must be positive"))
     end
 end
-Base.axes(F::QRSparse) = map(Base.OneTo, size(F))
 
 # From SPQR manual p. 6
 _default_tol(A::AbstractSparseMatrixCSC) =

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -115,7 +115,6 @@ struct QRSparseQ{Tv,Ti<:Integer} <: AbstractQ{Tv}
 end
 
 Base.size(Q::QRSparseQ) = (size(Q.factors, 1), size(Q.factors, 1))
-Base.axes(Q::QRSparseQ) = map(Base.OneTo, size(Q))
 
 Matrix{T}(Q::QRSparseQ) where {T} = lmul!(Q, Matrix{T}(I, size(Q, 1), min(size(Q, 1), Q.n)))
 


### PR DESCRIPTION
- A `axes(::AbstractQ)` already exists in LinearAlgebra that does the same thing.
- Julia already has a generic `Base.size(x, dim)` method that uses `Base.size(x)`.

Should fix these invalidations seen when loading CUDA.jl on 1.13:
```julia
 inserting size(FC::SparseArrays.CHOLMOD.FactorComponent, i::Integer) @ SparseArrays.CHOLMOD ~/.julia/juliaup/julia-1.13.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.13/SparseArrays/src/solvers/cholmod.jl:1363 invalidated:
   backedges: 1: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::AbstractVecOrMat, ::Int64) (9 children)
              2: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::AbstractMatrix, ::Int64) (21 children)
              3: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::AbstractArray, ::Int64) (21 children)

 inserting axes(Q::SparseArrays.SPQR.QRSparseQ) @ SparseArrays.SPQR ~/.julia/juliaup/julia-1.13.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.13/SparseArrays/src/solvers/spqr.jl:143 invalidated:
   backedges: 1: superseding axes(Q::LinearAlgebra.AbstractQ) @ LinearAlgebra ~/.julia/juliaup/julia-1.13.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.13/LinearAlgebra/src/abstractq.jl:78 with MethodInstance for axes(::LinearAlgebra.AbstractQ) (81 children)
   1 mt_cache
```

Could we backport this to 1.13?