### PR TITLE
Use generic_trimatdiv!() in ldiv!() for QRSparse

### DIFF
--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -518,8 +518,23 @@ function LinearAlgebra.ldiv!(X::StridedVecOrMat{T}, F::QRSparse{T}, B::StridedVe
         lmul!(adjoint(F.Q), W0)
 
         # Solve R*X = Q'*P*B
-        ldiv!(UpperTriangular(@view(F.R[Base.OneTo(rnk), Base.OneTo(rnk)])),
-              @view(W0[Base.OneTo(rnk), :]))
+        #
+        # We call generic_trimatdiv! directly instead of going through
+        # ldiv!(UpperTriangular(R_sub), ...) for two reasons:
+        # 1. UpperTriangular requires a square matrix, but F.R is m×n
+        #    so we can only take a column view R[:, 1:rnk] (which is
+        #    m×rnk, not square). A row+column view R[1:rnk, 1:rnk]
+        #    would be square but doesn't match SparseMatrixCSCView,
+        #    causing dispatch to a slow generic fallback.
+        # 2. generic_trimatdiv! is what UpperTriangular ldiv! dispatches
+        #    to anyway — calling it directly with uploc='U', isunitc='N',
+        #    tfun=identity is equivalent. The back-substitution loop
+        #    iterates over axes(B,1) = 1:rnk and searchsortedlast
+        #    excludes entries with row > j, so the extra rows in the
+        #    column view are never accessed.
+        W_rnk = @view(W0[Base.OneTo(rnk), :])
+        LinearAlgebra.generic_trimatdiv!(W_rnk, 'U', 'N', identity,
+                                         @view(F.R[:, Base.OneTo(rnk)]), W_rnk)
 
         # Apply right permutation: scatter solved rows into X using cpiv directly.
         # Zero X first so free variables (beyond rank) are zero in the basic solution.


### PR DESCRIPTION
This avoids having to go through UpperTriangular, which requires making a square matrix out of our rectangular F.R matrix. Taking a view of F.R would hit a slow fallback for ldiv!(), and making a new square matrix would cause allocations.

Fixes #696. Written with help from Claude :robot: 

Benchmark script adapted from BaseBenchmarks:
```julia
m = 10000
n = 9000
getA() = spdiagm(0 => fill(2.0, m),
                 -1 => fill(1.0, m - 1),
                 1 => fill(1.0, m - 1),
                 360 => fill(1.0, m - 360))[:, 1:n]
getB()   = ones(m, 2)

@benchmark qr(A)\B setup=(A=$getA(); B=$getB())

# main
BenchmarkTools.Trial: 28 samples with 1 evaluation per sample.
 Range (min … max):  175.511 ms … 218.146 ms  ┊ GC (min … max): 0.41% … 21.76%
 Time  (median):     178.119 ms               ┊ GC (median):    0.85%
 Time  (mean ± σ):   181.623 ms ±  10.391 ms  ┊ GC (mean ± σ):  2.55% ±  5.57%

  ██▅  ▂     ▂                                                   
  ███▁▁██▁▅▅▅█▁▁▁▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅▁▁▅ ▁
  176 ms           Histogram: frequency by time          218 ms <

 Memory estimate: 45.61 MiB, allocs estimate: 197.

# PR
BenchmarkTools.Trial: 174 samples with 1 evaluation per sample.
 Range (min … max):  18.428 ms … 70.734 ms  ┊ GC (min … max):  0.00% … 66.01%
 Time  (median):     23.961 ms              ┊ GC (median):     2.37%
 Time  (mean ± σ):   28.509 ms ± 13.099 ms  ┊ GC (mean ± σ):  20.07% ± 20.51%

   █    ▂                                                      
  ▆█▅▆▅██▅▅█▇▅▄▃▃▁▁▁▁▃▂▁▂▃▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▃▁▂▃▁▂▁▁▁▁▁▁▁▃▃▂▂▃ ▂
  18.4 ms         Histogram: frequency by time        68.4 ms <

 Memory estimate: 45.61 MiB, allocs estimate: 197.
```