### PR TITLE
1.10: Fixed tests for builds without GPL SuiteSparse

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -555,6 +555,14 @@ copy(S::AbstractSparseMatrixCSC) =
     SparseMatrixCSC(size(S, 1), size(S, 2), copy(getcolptr(S)), copy(rowvals(S)), copy(nonzeros(S)))
 copy(S::FixedSparseCSC) =
     FixedSparseCSC(size(S, 1), size(S, 2), getcolptr(S), rowvals(S), copy(nonzeros(S)))
+function copyto!(A::FixedSparseCSC, B::FixedSparseCSC)
+    size(A) == size(B) || throw(DimensionMismatch("cannot copy sparse matrix with different dimensions into FixedSparseCSC"))
+    nnz(A) == nnz(B) || throw(ArgumentError("cannot change fixed sparse structure via copyto!"))
+    copyto!(parent(getcolptr(A)), getcolptr(B))
+    copyto!(parent(rowvals(A)), rowvals(B))
+    copyto!(nonzeros(A), nonzeros(B))
+    return A
+end
 function copyto!(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)
     # If the two matrices have the same length then all the
     # elements in A will be overwritten.
@@ -711,6 +719,10 @@ uninitialized values for the nonzero locations.
 """
 similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}) where {Ti,TvNew} =
     @if_move_fixed S _sparsesimilar(S, TvNew, Ti)
+
+similar(S::FixedSparseCSC{<:Any,Ti}, ::Type{TvNew}, dims::Dims{2}) where {Ti,TvNew} =
+    dims == size(S) ? move_fixed(_sparsesimilar(S, TvNew, Ti)) :
+                      move_fixed(_sparsesimilar(S, TvNew, Ti, dims))
 
 similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}, dims::Union{Dims{1},Dims{2}}) where {Ti,TvNew} =
     @if_move_fixed S _sparsesimilar(S, TvNew, Ti, dims)
@@ -1008,6 +1020,7 @@ julia> sparse(A)
 sparse(A::AbstractMatrix{Tv}) where {Tv} = convert(SparseMatrixCSC{Tv}, A)
 
 sparse(S::AbstractSparseMatrixCSC) = copy(S)
+sparse(S::FixedSparseCSC) = SparseMatrixCSC(S)
 
 sparse(Q::AbstractQ) = SparseMatrixCSC(Q)
 

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -3,8 +3,6 @@
 module CHOLMODTests
 
 using Test
-using SparseArrays.CHOLMOD
-using SparseArrays.CHOLMOD: getcommon
 using Random
 using Serialization
 using LinearAlgebra:
@@ -13,10 +11,12 @@ using LinearAlgebra:
     PosDefException, ZeroPivotException
 using SparseArrays
 using SparseArrays: getcolptr
-using SparseArrays.LibSuiteSparse
-using SparseArrays.LibSuiteSparse: cholmod_l_allocate_sparse, cholmod_allocate_sparse
 
 if Base.USE_GPL_LIBS
+using SparseArrays.CHOLMOD
+using SparseArrays.CHOLMOD: getcommon
+using SparseArrays.LibSuiteSparse
+using SparseArrays.LibSuiteSparse: cholmod_l_allocate_sparse, cholmod_allocate_sparse
 
 # CHOLMOD tests
 itypes = sizeof(Int) == 4 ? (Int32,) : (Int32, Int64)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -89,6 +89,26 @@ struct_eq(A::AbstractSparseVector, B::AbstractSparseVector) =
     B = similar(F)
     @test typeof(B) == typeof(F)
     @test struct_eq(B, F)
+
+    C = fixed(copy(A))
+    copyto!(C, F)
+    @test C == F
+    @test struct_eq(C, F)
+
+    G = fixed(sparse([1.0 0.0; 0.0 2.0]))
+    H = fixed(sparse([1.0 3.0; 0.0 2.0]))
+    @test_throws DimensionMismatch copyto!(fixed(sprandn(9, 10, 0.3)), F)
+    @test_throws ArgumentError copyto!(G, H)
+
+    Bsame = similar(F, Float32, size(F))
+    @test Bsame isa FixedSparseCSC{Float32, eltype(rowvals(F))}
+    @test _is_fixed(Bsame)
+    @test struct_eq(Bsame, F)
+
+    Bdiff = similar(F, Float32, (size(F, 1) + 1, size(F, 2)))
+    @test typeof(Bdiff) == typeof(Bsame)
+    @test _is_fixed(Bdiff)
+    @test size(Bdiff) == (size(F, 1) + 1, size(F, 2))
 end
 @testset "SparseMatrixCSC conversions" begin
     A = sprandn(10, 10, 0.3)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -152,11 +152,18 @@ end
 @testset "Test factorization" begin
     b = sprandn(10, 10, 0.99) + I
     a = fixed(b)
+    @test sparse(a) isa SparseMatrixCSC
 
-    @test (lu(a) \ randn(10); true)
-    @test b == a
-    @test (qr(a + a') \ randn(10); true)
-    @test b == a
+    if Base.USE_GPL_LIBS
+        @test (lu(a) \ randn(10); true)
+        @test b == a
+        @test (qr(a + a') \ randn(10); true)
+        @test b == a
+    else
+        @test (lu(sparse(a)) \ randn(10); true)
+        @test (qr(sparse(a + a')) \ randn(10); true)
+        @test b == a
+    end
 end
 
 always_false(x...) = false

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -3,14 +3,14 @@
 module SPQRTests
 
 using Test
-using SparseArrays.SPQR
-using SparseArrays.CHOLMOD
 using LinearAlgebra: I, istriu, norm, qr, rank, rmul!, lmul!, Adjoint, Transpose, ColumnNorm, RowMaximum, NoPivot
 using SparseArrays: SparseArrays, sparse, sprandn, spzeros, SparseMatrixCSC
 using Random: seed!
 
 # TODO REMOVE SECOND PREDICATE WITH SS7.1
 if Base.USE_GPL_LIBS
+using SparseArrays.SPQR
+using SparseArrays.CHOLMOD
 @testset "Sparse QR" begin
 m, n = 100, 10
 nn = 100

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -8,8 +8,9 @@ using SparseArrays
 using Serialization
 using LinearAlgebra:
     LinearAlgebra, I, det, issuccess, ldiv!, lu, lu!, Transpose, SingularException, Diagonal, logabsdet
-using SparseArrays: nnz, sparse, sprand, sprandn, SparseMatrixCSC, UMFPACK, increment!
+using SparseArrays: nnz, sparse, sprand, sprandn, SparseMatrixCSC, increment!
 if Base.USE_GPL_LIBS
+using SparseArrays: UMFPACK
 function umfpack_report(l::UMFPACK.UmfpackLU)
     UMFPACK.umfpack_report_numeric(l, 0)
     UMFPACK.umfpack_report_symbolic(l, 0)


### PR DESCRIPTION
GPL-dependent test imports are gated on Base.USE_GPL_LIBS so the test suite no longer references solver bindings that are unavailable in non-GPL builds.

The non-GPL factorization tests fall back to ordinary sparse LU and QR paths, which need mutable SparseMatrixCSC inputs rather than fixed-structure matrices. FixedSparseCSC therefore gains the copy and conversion behavior needed for sparse(a) to produce a normal SparseMatrixCSC and keep those fallback test paths working.