### PR TITLE
Add `indtype` for `SparseMatrixCSCColumnSubset`

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -313,6 +313,8 @@ Base.@propagate_inbounds nzrange(S::SparseMatrixCSCColumnSubset, col::Integer) =
 nzrange(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangeup(S.data, i)
 nzrange(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangelo(S.data, i)
 
+indtype(S::SparseMatrixCSCColumnSubset{<:Any,Ti}) where {Ti} = Ti
+
 const AbstractSparseMatrixCSCInclAdjointAndTranspose = Union{AbstractSparseMatrixCSC,Adjoint{<:Any,<:AbstractSparseMatrixCSC},Transpose{<:Any,<:AbstractSparseMatrixCSC}}
 function Base.isstored(A::AbstractSparseMatrixCSC, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -236,6 +236,13 @@ end
     end
 end
 
+@testset "Column view of sparse matrix " begin
+    S = sparse(1:4, 1:4, 1:4)
+    Sv = @view S[:,1:2]
+    @test Sv * sparse(ones(2)) == Sv*ones(2) == Matrix(Sv) * ones(2)
+    @test Sv * sparse(ones(2,2)) == Sv*ones(2,2) == Matrix(Sv) * ones(2,2)
+end
+
 @testset "in-place sparse-sparse mul!" begin
     for n in (20, 30)
         sA = sprandn(ComplexF64, n, n, 0.1); A = Array(sA)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -238,7 +238,7 @@ end
 
 @testset "Column view of sparse matrix " begin
     S = sparse(1:4, 1:4, 1:4)
-    Sv = @view S[:,1:2]
+    Sv = @view S[:,3:4]
     @test Sv * sparse(ones(2)) == Sv*ones(2) == Matrix(Sv) * ones(2)
     @test Sv * sparse(ones(2,2)) == Sv*ones(2,2) == Matrix(Sv) * ones(2,2)
 end


### PR DESCRIPTION
Fixes #699. Should be backported.