### PR TITLE
Review return types from solves

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -11,7 +11,7 @@ using Base.Order: Forward
 using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, AdjointFactorization, TransposeFactorization, matprod,
     AbstractQ, AdjointQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ, MulAddMul,
-    UpperOrLowerTriangular, @stable_muladdmul
+    UpperOrLowerTriangular, UnitUpperOrUnitLowerTriangular, @stable_muladdmul
 
 
 import Base: +, -, *, \, /, ==, zero

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1313,29 +1313,14 @@ end
 # so they should return dense arrays
 const StructuredWithDenseInverse = Union{Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UpperTriangular,UpperHessenberg}
 
-function (\)(A::StructuredWithDenseInverse, B::AbstractSparseMatrixCSC)
-    require_one_based_indexing(B)
-    TAB = promote_op(\, eltype(A), eltype(B))
-    ldiv!(Matrix{TAB}(undef, size(B)), A, B)
-end
-function (\)(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::AbstractSparseMatrixCSC)
-    require_one_based_indexing(B)
-    TAB = LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))
-    ldiv!(Matrix{TAB}(undef, size(B)), A, B)
-end
-function (/)(A::AbstractSparseMatrixCSC, B::StructuredWithDenseInverse)
-    require_one_based_indexing(A)
-    TAB = promote_op(/, eltype(A), eltype(B))
-    LinearAlgebra._rdiv!(Matrix{TAB}(undef, size(A)), A, B)
-end
-function (/)(A::AbstractSparseMatrixCSC, B::Union{UnitUpperTriangular,UnitLowerTriangular})
-    require_one_based_indexing(A)
-    TAB = LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))
-    LinearAlgebra._rdiv!(Matrix{TAB}(undef, size(A)), A, B)
-end
-
-# (*)(L::DenseTriangular, B::AbstractSparseMatrixCSC) = lmul!(L, Array(B))
-
+matldiv_dest(A::StructuredWithDenseInverse, B::QuasiSparseMatrix) =
+    Matrix{promote_op(\, eltype(A), eltype(B))}(undef, size(B))
+matldiv_dest(A::LinearAlgebra.UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =
+    Matrix{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, size(B))
+matrdiv_dest(A::QuasiSparseMatrix, B::StructuredWithDenseInverse) =
+    Matrix{promote_op(/, eltype(A), eltype(B))}(undef, size(A))
+matrdiv_dest(A::QuasiSparseMatrix, B::LinearAlgebra.UnitUpperOrUnitLowerTriangular) =
+    Matrix{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, size(A))
 ## end of triangular
 
 # symmetric/Hermitian

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1309,7 +1309,11 @@ function LinearAlgebra.generic_trimatdiv!(C::StridedVecOrMat, uploc, isunitc, ::
     C
 end
 
-function (\)(A::Union{UpperTriangular,LowerTriangular}, B::AbstractSparseMatrixCSC)
+# the following matrix types have typically dense inverses, even when they wrap sparse matrices
+# so they should return dense arrays
+const StructuredWithDenseInverse = Union{Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UpperTriangular,UpperHessenberg}
+
+function (\)(A::StructuredWithDenseInverse, B::AbstractSparseMatrixCSC)
     require_one_based_indexing(B)
     TAB = promote_op(\, eltype(A), eltype(B))
     ldiv!(Matrix{TAB}(undef, size(B)), A, B)
@@ -1319,6 +1323,17 @@ function (\)(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::AbstractSpars
     TAB = LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))
     ldiv!(Matrix{TAB}(undef, size(B)), A, B)
 end
+function (/)(A::AbstractSparseMatrixCSC, B::StructuredWithDenseInverse)
+    require_one_based_indexing(A)
+    TAB = promote_op(/, eltype(A), eltype(B))
+    LinearAlgebra._rdiv!(Matrix{TAB}(undef, size(A)), A, B)
+end
+function (/)(A::AbstractSparseMatrixCSC, B::Union{UnitUpperTriangular,UnitLowerTriangular})
+    require_one_based_indexing(A)
+    TAB = LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))
+    LinearAlgebra._rdiv!(Matrix{TAB}(undef, size(A)), A, B)
+end
+
 # (*)(L::DenseTriangular, B::AbstractSparseMatrixCSC) = lmul!(L, Array(B))
 
 ## end of triangular

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1313,13 +1313,17 @@ end
 # so they should return dense arrays
 const StructuredWithDenseInverse = Union{Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UpperTriangular,UpperHessenberg}
 
+matop_dest(::typeof(\), A::StructuredWithDenseInverse, b::AbstractSparseVector) =
+    Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
+matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
+    Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, length(b))
 matop_dest(::typeof(\), A::StructuredWithDenseInverse, B::QuasiSparseMatrix) =
     Matrix{promote_op(\, eltype(A), eltype(B))}(undef, size(B))
-matop_dest(::typeof(\), A::LinearAlgebra.UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =
+matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =
     Matrix{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, size(B))
 matop_dest(::typeof(/), A::QuasiSparseMatrix, B::StructuredWithDenseInverse) =
     Matrix{promote_op(/, eltype(A), eltype(B))}(undef, size(A))
-matop_dest(::typeof(/), A::QuasiSparseMatrix, B::LinearAlgebra.UnitUpperOrUnitLowerTriangular) =
+matop_dest(::typeof(/), A::QuasiSparseMatrix, B::UnitUpperOrUnitLowerTriangular) =
     Matrix{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, size(A))
 ## end of triangular
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1309,19 +1309,15 @@ function LinearAlgebra.generic_trimatdiv!(C::StridedVecOrMat, uploc, isunitc, ::
     C
 end
 
-# the following matrix types have typically dense inverses, even when they wrap sparse matrices
-# so they should return dense arrays
-const StructuredWithDenseInverse = Union{Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UpperTriangular,UpperHessenberg}
-
-matop_dest(::typeof(\), A::StructuredWithDenseInverse, b::AbstractSparseVector) =
+matop_dest(::typeof(\), A, b::AbstractSparseVector) =
     Vector{promote_op(\, eltype(A), eltype(b))}(undef, length(b))
 matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
     Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(b))}(undef, length(b))
-matop_dest(::typeof(\), A::StructuredWithDenseInverse, B::QuasiSparseMatrix) =
+matop_dest(::typeof(\), A, B::QuasiSparseMatrix) =
     Matrix{promote_op(\, eltype(A), eltype(B))}(undef, size(B))
 matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =
     Matrix{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, size(B))
-matop_dest(::typeof(/), A::QuasiSparseMatrix, B::StructuredWithDenseInverse) =
+matop_dest(::typeof(/), A::QuasiSparseMatrix, B) =
     Matrix{promote_op(/, eltype(A), eltype(B))}(undef, size(A))
 matop_dest(::typeof(/), A::QuasiSparseMatrix, B::UnitUpperOrUnitLowerTriangular) =
     Matrix{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, size(A))

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1313,14 +1313,20 @@ matop_dest(::typeof(\), A, b::AbstractSparseVector) =
     Vector{promote_op(\, eltype(A), eltype(b))}(undef, length(b))
 matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
     Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(b))}(undef, length(b))
+matop_dest(::typeof(\), A::Diagonal, b::AbstractSparseVector) =
+    similar(b , promote_op(\, eltype(A), eltype(b)))
 matop_dest(::typeof(\), A, B::QuasiSparseMatrix) =
     Matrix{promote_op(\, eltype(A), eltype(B))}(undef, size(B))
+matop_dest(::typeof(\), A::Diagonal, B::QuasiSparseMatrix) =
+    similar(B , promote_op(\, eltype(A), eltype(B)), size(B))
 matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =
     Matrix{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, size(B))
 matop_dest(::typeof(/), A::QuasiSparseMatrix, B) =
     Matrix{promote_op(/, eltype(A), eltype(B))}(undef, size(A))
 matop_dest(::typeof(/), A::QuasiSparseMatrix, B::UnitUpperOrUnitLowerTriangular) =
     Matrix{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, size(A))
+matop_dest(::typeof(/), A::QuasiSparseMatrix, B::Diagonal) =
+    similar(A , promote_op(/, eltype(A), eltype(B)), size(A))
 ## end of triangular
 
 # symmetric/Hermitian

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1313,13 +1313,13 @@ end
 # so they should return dense arrays
 const StructuredWithDenseInverse = Union{Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UpperTriangular,UpperHessenberg}
 
-matldiv_dest(A::StructuredWithDenseInverse, B::QuasiSparseMatrix) =
+matop_dest(::typeof(\), A::StructuredWithDenseInverse, B::QuasiSparseMatrix) =
     Matrix{promote_op(\, eltype(A), eltype(B))}(undef, size(B))
-matldiv_dest(A::LinearAlgebra.UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =
+matop_dest(::typeof(\), A::LinearAlgebra.UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =
     Matrix{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, size(B))
-matrdiv_dest(A::QuasiSparseMatrix, B::StructuredWithDenseInverse) =
+matop_dest(::typeof(/), A::QuasiSparseMatrix, B::StructuredWithDenseInverse) =
     Matrix{promote_op(/, eltype(A), eltype(B))}(undef, size(A))
-matrdiv_dest(A::QuasiSparseMatrix, B::LinearAlgebra.UnitUpperOrUnitLowerTriangular) =
+matop_dest(::typeof(/), A::QuasiSparseMatrix, B::LinearAlgebra.UnitUpperOrUnitLowerTriangular) =
     Matrix{LinearAlgebra._inner_type_promotion(/, eltype(A), eltype(B))}(undef, size(A))
 ## end of triangular
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1314,9 +1314,9 @@ end
 const StructuredWithDenseInverse = Union{Bidiagonal,SymTridiagonal,Tridiagonal,LowerTriangular,UpperTriangular,UpperHessenberg}
 
 matop_dest(::typeof(\), A::StructuredWithDenseInverse, b::AbstractSparseVector) =
-    Vector{promote_op(\, eltype(A), eltype(B))}(undef, length(b))
+    Vector{promote_op(\, eltype(A), eltype(b))}(undef, length(b))
 matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, b::AbstractSparseVector) =
-    Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(B))}(undef, length(b))
+    Vector{LinearAlgebra._inner_type_promotion(\, eltype(A), eltype(b))}(undef, length(b))
 matop_dest(::typeof(\), A::StructuredWithDenseInverse, B::QuasiSparseMatrix) =
     Matrix{promote_op(\, eltype(A), eltype(B))}(undef, size(B))
 matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, B::QuasiSparseMatrix) =

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2160,17 +2160,6 @@ for isunittri in (true, false), islowertri in (true, false)
     halfstr = islowertri ? "Lower" : "Upper"
     tritype = :(LinearAlgebra.$(Symbol(unitstr, halfstr, "Triangular")))
 
-    # build out-of-place left-division operations
-    # broad method where elements are Numbers
-    @eval function \(A::$tritype{<:TA,<:AbstractMatrix}, b::AbstractCompressedVector{Tb}) where {TA<:Number,Tb<:Number}
-        TAb = $(isunittri ?
-            :(typeof(zero(TA)*zero(Tb) + zero(TA)*zero(Tb))) :
-            :(typeof((zero(TA)*zero(Tb) + zero(TA)*zero(Tb))/one(TA))) )
-        return LinearAlgebra.ldiv!(convert(AbstractArray{TAb}, A), convert(Array{TAb}, b))
-    end
-    # fallback where elements are not Numbers
-    @eval \(A::$tritype, b::AbstractCompressedVector) = LinearAlgebra.ldiv!(A, copy(b))
-
     # faster method requiring good view support of the
     # triangular matrix type. hence the StridedMatrix restriction.
     for (istrans, applyxform, xformtype, xformop) in (

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -151,13 +151,13 @@ end
     O = diagm(-1 => fill(-1, 9), 0 => fill(2, 10), 1 => fill(-1, 9))
     wrappers = (a -> Bidiagonal(a, :U),
                 a -> Bidiagonal(a, :L),
-                # SymTridiagonal,
+                SymTridiagonal,
                 Tridiagonal,
                 LowerTriangular,
                 UnitLowerTriangular,
                 UpperTriangular,
                 UnitUpperTriangular,
-                # UpperHessenberg
+                UpperHessenberg
                 )
     for T in wrappers
         A = T(O)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -151,30 +151,31 @@ end
     O = diagm(-1 => fill(-1, 9), 0 => fill(2, 10), 1 => fill(-1, 9))
     wrappers = (a -> Bidiagonal(a, :U),
                 a -> Bidiagonal(a, :L),
-                a -> SymTridiagonal(2diag(a), -diag(a, 1)),
-                a -> Tridiagonal(-diag(a, -1), 2diag(a), -diag(a, 1)),
+                # SymTridiagonal,
+                Tridiagonal,
                 LowerTriangular,
                 UnitLowerTriangular,
                 UpperTriangular,
                 UnitUpperTriangular,
-                UpperHessenberg)
+                # UpperHessenberg
+                )
     for T in wrappers
         A = T(O)
         bs = sprandn(10, 0.3)
         bd = Array(bs)
         x = A \ bs
         @test x ≈ A \ bd
-        @test !issparse(x)
+        @test !issparse(x) broken=(T in (SymTridiagonal, UpperHessenberg))
         Bs = sprandn(10, 3, 0.2)
         Bd = Matrix(Bs)
         X = A \ Bs
         @test X ≈ A \ Bd
-        @test !issparse(X)
+        @test !issparse(X) broken=(T in (SymTridiagonal, UpperHessenberg))
         Cs = copy(Bs')
         Cd = Matrix(Cs)
         Y = Cs / A
         @test Y ≈ Cd / A
-        @test !issparse(Y)
+        @test !issparse(Y) broken=(T in (SymTridiagonal, UpperHessenberg))
     end
     b, B = ones(Int, 10), ones(Int, 10, 10)
     for T in (UnitLowerTriangular, UnitUpperTriangular)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -147,6 +147,42 @@ end
     end
 end
 
+@testset "destination array density in solves" begin
+    O = diagm(-1 => fill(-1, 9), 0 => fill(2, 10), 1 => fill(-1, 9))
+    wrappers = (a -> Bidiagonal(a, :U),
+                a -> Bidiagonal(a, :L),
+                a -> SymTridiagonal(2diag(a), -diag(a, 1)),
+                a -> Tridiagonal(-diag(a, -1), 2diag(a), -diag(a, 1)),
+                LowerTriangular,
+                UnitLowerTriangular,
+                UpperTriangular,
+                UnitUpperTriangular,
+                UpperHessenberg)
+    for T in wrappers
+        A = T(O)
+        bs = sprandn(10, 0.3)
+        bd = Array(bs)
+        x = A \ bs
+        @test x ≈ A \ bd
+        @test !issparse(x)
+        Bs = sprandn(10, 3, 0.2)
+        Bd = Matrix(Bs)
+        X = A \ Bs
+        @test X ≈ A \ Bd
+        @test !issparse(X)
+        Cs = copy(Bs')
+        Cd = Matrix(Cs)
+        Y = Cs / A
+        @test Y ≈ Cd / A
+        @test !issparse(Y)
+    end
+    b, B = ones(Int, 10), ones(Int, 10, 10)
+    for T in (UnitLowerTriangular, UnitUpperTriangular)
+        A = T(O)
+        @test eltype(A \ b) == eltype(A \ B) == eltype(B / A) == Int
+    end
+end
+
 @testset "multiplication of special sparse with dense matrix" begin
     # this results in a call of the most generic multiplication code in LinearAlgebra.jl
     A = randn(2, 2)
@@ -228,6 +264,7 @@ begin
         AW = tr(wr(A))
         MAW = tr(wr(MA))
         @test AW \ B ≈ MAW \ B
+        @test !issparse(AW \ B)
         # and for SparseMatrixCSCView - a view of all rows and unit range of cols
         vAW = tr(wr(view([zero(A)+I A], :, (n+1):2n)))
         @test vAW \ B ≈ AW \ B

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -157,7 +157,8 @@ end
                 UnitLowerTriangular,
                 UpperTriangular,
                 UnitUpperTriangular,
-                UpperHessenberg
+                # UpperHessenberg,
+                a -> UpperHessenberg(float(a))
                 )
     for T in wrappers
         A = T(O)
@@ -165,17 +166,17 @@ end
         bd = Array(bs)
         x = A \ bs
         @test x ≈ A \ bd
-        @test !issparse(x) broken=(T in (SymTridiagonal, UpperHessenberg))
+        @test !issparse(x)
         Bs = sprandn(10, 3, 0.2)
         Bd = Matrix(Bs)
         X = A \ Bs
         @test X ≈ A \ Bd
-        @test !issparse(X) broken=(T in (SymTridiagonal, UpperHessenberg))
+        @test !issparse(X)
         Cs = copy(Bs')
         Cd = Matrix(Cs)
         Y = Cs / A
         @test Y ≈ Cd / A
-        @test !issparse(Y) broken=(T in (SymTridiagonal, UpperHessenberg))
+        @test !issparse(Y)
     end
     b, B = ones(Int, 10), ones(Int, 10, 10)
     for T in (UnitLowerTriangular, UnitUpperTriangular)


### PR DESCRIPTION
This is an attempt to clean up return types from structured solves with sparse matrices. The first observation is that currently left-solves with triangular matrices return dense matrices, whereas right-solves use a fallback which creates a sparse matrix. Second, solves with other structured matrices also act like multiplication with dense matrices, so they should return dense arrays as well.

EDIT: This is to become the companion PR to https://github.com/JuliaLang/LinearAlgebra.jl/pull/1578. Similar to `matprod_dest`, we should only define the return array type and otherwise use fallbacks.