### PR TITLE
make zero preserve indextype

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -87,7 +87,7 @@ if Base.USE_GPL_LIBS
     include("solvers/spqr.jl")
 end
 
-zero(a::AbstractSparseArray) = spzeros(eltype(a), size(a)...)
+zero(a::AbstractSparseArray{Tv,Ti}) where {Tv,Ti} = spzeros(Tv, Ti, size(a)...)
 
 LinearAlgebra.diagzero(D::Diagonal{<:AbstractSparseMatrix{T}},i,j) where {T} =
     spzeros(T, size(D.diag[i], 1), size(D.diag[j], 2))

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -805,6 +805,13 @@ end
                        7 16 4])
 end
 
+@testset "Issue #574" begin
+    a = spzeros(Float32, Int16, 2, 3)
+    v = spzeros(Float32, Int16, 2)
+    @test eltype(rowvals(zero(a))) <: Int16
+    @test eltype(rowvals(zero(v))) <: Int16
+end
+
 end # SparseTestsBase
 
 end # module


### PR DESCRIPTION
Closes #574

The appropriate function to extract the index type is `indtype`, not `keytype`. Since it already works correctly the only thing to do is fix the `zero` method.