### PR TITLE
test: avoid method-overwrite warnings in forbidproperties.jl

### DIFF
--- a/test/forbidproperties.jl
+++ b/test/forbidproperties.jl
@@ -1,5 +1,18 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using SparseArrays
-Base.getproperty(::SparseMatrixCSC, ::Symbol) = error("use accessor function")
-Base.getproperty(::SparseVector, ::Symbol) = error("use accessor function")
+# Only define each `getproperty` override if it isn't already defined. This
+# file is `include`d from multiple sibling test modules, and without this
+# guard each subsequent include would re-set the same `Base` methods,
+# producing spurious method-overwrite warnings (depending on `--warn-overwrite`).
+# `hasmethod` is not sufficient here because the generic `Base.getproperty`
+# fallback for `Any` always exists; we instead check whether `which` returns
+# that fallback method.
+let fallback = which(Base.getproperty, Tuple{Any, Symbol})
+    if which(Base.getproperty, Tuple{SparseMatrixCSC, Symbol}) === fallback
+        Base.getproperty(::SparseMatrixCSC, ::Symbol) = error("use accessor function")
+    end
+    if which(Base.getproperty, Tuple{SparseVector, Symbol}) === fallback
+        Base.getproperty(::SparseVector, ::Symbol) = error("use accessor function")
+    end
+end


### PR DESCRIPTION
`test/forbidproperties.jl` is `include`d from six sibling test modules (`SparseVectorTests`, `SparseLinalgTests`, `SparseTests`, `SparseIssuesTests`, `HigherOrderFnsTests`, `SparseMatrixConstructorIndexingTests`). It defines two methods on `Base.getproperty` for `SparseMatrixCSC` and `SparseVector`. With the [(hopefully) upcoming Julia default `--warn-overwrite=default`](https://github.com/JuliaLang/julia/pull/61430), the second through sixth includes each produce method-overwrite warnings.

Make the overrides idempotent by only defining them when undefined.

I used Claude Opus 4.7 while preparing this.