### PR TITLE
sparsematrix: fix swaprows! storage moves

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -4527,7 +4527,6 @@ function Base.swaprows!(A::AbstractSparseMatrixCSC, i, j)
             # Update the rowval and then rotate both nonzeros
             # and the remaining rowvals into the correct place
             rows[rr[iidx]] = j
-            jidx == 0 && continue
             rotate_range = rr[iidx]:jrange[jidx]
             circshift!(@view(vals[rotate_range]), -1)
             circshift!(@view(rows[rotate_range]), -1)
@@ -4535,7 +4534,6 @@ function Base.swaprows!(A::AbstractSparseMatrixCSC, i, j)
             # Same as i, but in the opposite direction
             @assert has_j
             rows[jrange[jidx]] = i
-            iidx > length(rr) && continue
             rotate_range = rr[iidx]:jrange[jidx]
             circshift!(@view(vals[rotate_range]), 1)
             circshift!(@view(rows[rotate_range]), 1)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -4513,7 +4513,7 @@ function Base.swaprows!(A::AbstractSparseMatrixCSC, i, j)
         iidx = searchsortedfirst(@view(rows[rr]), i)
         has_i = iidx <= length(rr) && rows[rr[iidx]] == i
 
-        jrange = has_i ? (iidx:last(rr)) : rr
+        jrange = has_i ? (rr[iidx]:last(rr)) : rr
         jidx = searchsortedlast(@view(rows[jrange]), j)
         has_j = jidx != 0 && rows[jrange[jidx]] == j
 
@@ -4529,16 +4529,16 @@ function Base.swaprows!(A::AbstractSparseMatrixCSC, i, j)
             rows[rr[iidx]] = j
             jidx == 0 && continue
             rotate_range = rr[iidx]:jrange[jidx]
-            circshift!(@view(vals[rotate_range]), 1)
-            circshift!(@view(rows[rotate_range]), 1)
+            circshift!(@view(vals[rotate_range]), -1)
+            circshift!(@view(rows[rotate_range]), -1)
         else
             # Same as i, but in the opposite direction
             @assert has_j
             rows[jrange[jidx]] = i
             iidx > length(rr) && continue
             rotate_range = rr[iidx]:jrange[jidx]
-            circshift!(@view(vals[rotate_range]), -1)
-            circshift!(@view(rows[rotate_range]), -1)
+            circshift!(@view(vals[rotate_range]), 1)
+            circshift!(@view(rows[rotate_range]), 1)
         end
     end
     return nothing

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -1426,6 +1426,21 @@ using Base: swaprows!, swapcols!
         f!(Scopy, i, j); f!(Sdense, i, j)
         @test Scopy == Sdense
     end
+
+    for (A, i, j) in (
+            (sparse([1.0  2.0  3.0;
+                     0.0  0.0  0.0;
+                     4.0  5.0  6.0]), 1, 2),
+            (sparse([1.0  0.0  5.0;
+                     0.0  2.0  0.0;
+                     0.0  3.0  6.0;
+                     7.0  4.0  0.0]), 1, 2),
+            (sparse(reshape([1.0, 2.0, 3.0, 4.0, 0.0, 0.0], 6, 1)), 2, 6))
+        Scopy = copy(A)
+        Sdense = Array(A)
+        swaprows!(Scopy, i, j); swaprows!(Sdense, i, j)
+        @test Scopy == Sdense
+    end
 end
 
 @testset "sprandn with type $T" for T in (Float64, Float32, Float16, ComplexF64, ComplexF32, ComplexF16)


### PR DESCRIPTION
reported on discourse, mostly oneshot by codex 5.5


----------------------------------------------------------------------------------------------------------------
Fix SparseMatrixCSC row swaps when exactly one swapped row is stored in a column. The j search range used a local i index as an absolute storage index, and the single-row move rotations were reversed.

On master:
```julia
julia> A = sparse([1.0 2.0 3.0; 0.0 0.0 0.0; 4.0 5.0 6.0]); Base.swaprows!(A, 1, 2); A
3×3 SparseMatrixCSC{Float64, Int64} with 6 stored entries:
  ⋅   1.0   ⋅ 
 2.0   ⋅   3.0
 4.0  5.0  6.0

julia> B = sparse(reshape([1.0, 2.0, 3.0, 4.0, 0.0, 0.0], 6, 1)); Base.swaprows!(B, 2, 6); rowvals(B)
4-element Vector{Int64}:
 1
 4
 6
 3
```