### PR TITLE
Optimize row-indexing in `AdjOrTrans` of sparse matrix

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -683,8 +683,10 @@ function getindex(x::AbstractSparseMatrixCSC, I::AbstractUnitRange, j::Integer)
     return @if_move_fixed x SparseVector(length(I), [rowvals(x)[i] - first(I) + 1 for i = r1:r2], nonzeros(x)[r1:r2])
 end
 
-getindex(M::AdjOrTrans{T,<:AbstractSparseMatrixCSC{T}}, i, ::Colon) where {T} =
+getindex(M::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, i::Integer, ::Colon) =
     map!(wrapperop(M), M.parent[:,i])
+getindex(M::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, i::AbstractVector, ::Colon) =
+    copy(wrapperop(M)(M.parent[:,i]))
 
 # In the general case, we piggy back upon SparseMatrixCSC's optimized solution
 @inline getindex(A::AbstractSparseMatrixCSC, I::AbstractVector, J::Integer) =

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -683,6 +683,9 @@ function getindex(x::AbstractSparseMatrixCSC, I::AbstractUnitRange, j::Integer)
     return @if_move_fixed x SparseVector(length(I), [rowvals(x)[i] - first(I) + 1 for i = r1:r2], nonzeros(x)[r1:r2])
 end
 
+getindex(M::AdjOrTrans{T,<:AbstractSparseMatrixCSC{T}}, i, ::Colon) where {T} =
+    map!(wrapperop(M), M.parent[:,i])
+
 # In the general case, we piggy back upon SparseMatrixCSC's optimized solution
 @inline getindex(A::AbstractSparseMatrixCSC, I::AbstractVector, J::Integer) =
     let M = A[I, [J]]

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -294,6 +294,13 @@ end
             bIv[I] .= true
             @test Array(r) == Array(x)[bIv]
         end
+
+        let x = sprand(ComplexF64, 10, 10, 0.5)
+            for t in (transpose, adjoint)
+                xt = t(x)
+                @test xt[1,:] == t.(x[:,1])
+            end
+        end
     end
     @testset "index with colon" begin
         @test issparse(spzeros(0)[:])

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -299,6 +299,7 @@ end
             for t in (transpose, adjoint)
                 xt = t(x)
                 @test xt[1,:] == t.(x[:,1])
+                @test xt[2:4,:] == t(x[:,2:4])
             end
         end
     end


### PR DESCRIPTION
This uses both optimized column-indexing and `map!`, as suggested by https://github.com/JuliaSparse/SparseArrays.jl/issues/628#issuecomment-2898646451 @SobhanMP.

Fixes #628.