### PR TITLE
Run only the Aqua tests in the aqua CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,9 @@ jobs:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
       - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          SPARSEARRAYS_AQUA_TEST: true
+      - name: Run Aqua and ambiguity tests
+        run: |
+          julia --color=yes -e 'using Pkg; Pkg.activate(temp=true); Pkg.develop(path=pwd()); Pkg.add(name="Aqua", version="0.8"); include(joinpath(pwd(), "test", "ambiguous.jl"))'
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,6 @@ using Test, LinearAlgebra, SparseArrays
 
 include("util/gha.jl")
 
-if Base.get_bool_env("SPARSEARRAYS_AQUA_TEST", false)
-    include("ambiguous.jl")
-end
-
 include("allowscalar.jl")
 include("fixed.jl")
 include("higherorderfns.jl")


### PR DESCRIPTION
Since https://github.com/JuliaSparse/SparseArrays.jl/pull/537 the aqua job runs the aqua-specific test *and then all the other tests as well!*. That is clearly a waste.