### PR TITLE
Reduce eltype combinatorics in the #14005 ldiv testset

### DIFF
--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -1350,6 +1350,10 @@ end
         floattypes = (Float32, Float64, BigFloat)
         complextypes = (ComplexF32, ComplexF64)
         eltypes = (inttypes..., floattypes..., complextypes...)
+        # The full eltype cross product compiles thousands of specializations
+        # (several CI minutes); do it only for the core types and pair the
+        # remaining eltypes with Float64.
+        coretypes = (Int64, Float64, ComplexF64)
 
         for eltypemat in eltypes
             (densemat, sparsemat) = eltypemat in inttypes ? (denseintmat, sparseintmat) :
@@ -1363,6 +1367,8 @@ end
                            LinearAlgebra.UnitLowerTriangular(sparsemat), LinearAlgebra.UnitUpperTriangular(sparsemat) )
 
             for eltypevec in eltypes
+                (eltypemat in coretypes && eltypevec in coretypes) ||
+                    eltypemat == Float64 || eltypevec == Float64 || continue
                 spvecs = eltypevec in inttypes ? sparseintvecs :
                          eltypevec in floattypes ? sparsefloatvecs :
                          eltypevec in complextypes && sparsecomplexvecs


### PR DESCRIPTION
The full 8x8 eltype cross product compiled ~1500 specializations of
\ and ldiv! over tiny matrices, taking 7-15 min per CI job (the
single largest testset). Keep the full cross product for
(Int64, Float64, ComplexF64) and pair the remaining eltypes with
Float64: 6x faster locally (2m05s -> 21s).


