### PR TITLE
Run test files in parallel with ParallelTestRunner

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Dates = "<0.0.1, 1"
 InteractiveUtils = "<0.0.1, 1"
 Libdl = "<0.0.1, 1"
 LinearAlgebra = "<0.0.1, 1"
+ParallelTestRunner = "2"
 Pkg = "<0.0.1, 1"
 Printf = "<0.0.1, 1"
 Random = "<0.0.1, 1"
@@ -27,9 +28,10 @@ julia = "1.11"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Dates", "InteractiveUtils", "Pkg", "Printf", "Test"]
+test = ["Aqua", "Dates", "InteractiveUtils", "ParallelTestRunner", "Pkg", "Printf", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,71 +1,32 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Test, LinearAlgebra, SparseArrays
 
 include("util/gha.jl")
 
-include("allowscalar.jl")
-include("fixed.jl")
-include("higherorderfns.jl")
-include("sparsematrix_constructors_indexing.jl")
-include("sparsematrix_ops.jl")
-include("sparsevector.jl")
-include("issues.jl")
+testfiles = ["allowscalar.jl", "fixed.jl", "higherorderfns.jl",
+             "sparsematrix_constructors_indexing.jl", "sparsematrix_ops.jl",
+             "sparsevector.jl", "issues.jl"]
 
 if Base.USE_GPL_LIBS
-
-    include("cholmod.jl")
-    include("umfpack.jl")
-    include("spqr.jl")
-    include("linalg.jl")
-    include("linalg_solvers.jl")
-
-    nt = @static if isdefined(Threads, :maxthreadid)
-        Threads.maxthreadid()
-    else
-        Threads.nthreads()
-    end
-
-    # 1. If the OS is Windows and we are in GitHub Actions CI, we do NOT run
-    #    the `threads` tests.
-    # 2. If the OS is Windows and we are NOT in GitHub Actions CI, we DO run
-    #    the `threads` tests.
-    #        - So, just as an example, if the OS is Windows and we are in
-    #          Buildkite CI, we DO run the `threads` tests.
-    # 3. If the OS is NOT Windows, we DO run the `threads` tests.
+    append!(testfiles, ["cholmod.jl", "umfpack.jl", "spqr.jl", "linalg.jl",
+                        "linalg_solvers.jl"])
     if Sys.iswindows() && is_github_actions_ci()
         @warn "Skipping `threads` tests on Windows on GitHub Actions CI"
-        @test_skip false
     else
-        @debug "Beginning the `threads` tests..."
-
-        # Test multithreaded execution
-        @testset "threaded SuiteSparse tests" verbose = true begin
-            @testset "threads = $nt" begin
-                include("threads.jl")
-            end
-            # test both nthreads==1 and nthreads>1. spawn a process to test whichever
-            # case we are not running currently.
-            other_nthreads = nt == 1 ? 4 : 1
-            @testset "threads = $other_nthreads" begin
-                let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
-                    p = run(
-                            pipeline(
-                                setenv(
-                                    cmd,
-                                    "JULIA_NUM_THREADS" => other_nthreads,
-                                    dir=@__DIR__()),
-                                stdout = stdout,
-                                stderr = stderr),
-                            wait = false)
-                    if !success(p)
-                        error("SuiteSparse threads test failed with nthreads == $other_nthreads")
-                    else
-                        @test true # mimic the one @test in threads.jl
-                    end
-                end
-            end
-        end
-
-        @debug "Finished the `threads` tests..."
+        push!(testfiles, "threads_suite.jl")
     end
+end
+
+# ParallelTestRunner comes from the Pkg.test target; Julia base CI runs this
+# file without it and falls back to the serial path.
+if Base.find_package("ParallelTestRunner") !== nothing
+    using ParallelTestRunner
+    # Auto CPU thread count detection in ParallelTestRunner is bad
+    push!(ARGS, "--jobs=$(Sys.CPU_THREADS)")
+    testsuite = Dict{String,Expr}(splitext(f)[1] => :(include($(joinpath(@__DIR__, f))))
+                                  for f in testfiles)
+    runtests(SparseArrays, ARGS; testsuite)
+else
+    foreach(include, testfiles)
 end

--- a/test/threads_suite.jl
+++ b/test/threads_suite.jl
@@ -1,0 +1,36 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test, SparseArrays
+
+nt = @static if isdefined(Threads, :maxthreadid)
+    Threads.maxthreadid()
+else
+    Threads.nthreads()
+end
+
+@testset "threaded SuiteSparse tests" verbose = true begin
+    @testset "threads = $nt" begin
+        include("threads.jl")
+    end
+    # test both nthreads==1 and nthreads>1. spawn a process to test whichever
+    # case we are not running currently.
+    other_nthreads = nt == 1 ? 4 : 1
+    @testset "threads = $other_nthreads" begin
+        let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
+            p = run(
+                    pipeline(
+                        setenv(
+                            cmd,
+                            "JULIA_NUM_THREADS" => other_nthreads,
+                            dir=@__DIR__()),
+                        stdout = stdout,
+                        stderr = stderr),
+                    wait = false)
+            if !success(p)
+                error("SuiteSparse threads test failed with nthreads == $other_nthreads")
+            else
+                @test true # mimic the one @test in threads.jl
+            end
+        end
+    end
+end


### PR DESCRIPTION
The suite ran serially in one process. No single file dominates
(largest ~7 of ~30 CI minutes), so file-level parallelism maps well
onto the 4-core CI runners. ParallelTestRunner comes from the Pkg.test
target; Julia base CI falls back to the serial include loop. The
threads testset moves to threads_suite.jl so it can be scheduled as a
regular test file.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
