### PR TITLE
Comment out forced GC.gc() calls in test_getindex_algs

### DIFF
--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -834,7 +834,9 @@ end
             times = Float64[0,0,0]
             best = [typemax(Float64), 0]
             for searchtype in [0, 1, 2]
-                GC.gc()
+                # stabilizes the debug timings below, but forces 180 full
+                # collections across these loops which dominates the file's GC time
+                # GC.gc()
                 tres = @timed test_getindex_algs(S, I, J, searchtype)
                 res[searchtype+1] = tres[1]
                 times[searchtype+1] = tres[2]
@@ -890,9 +892,9 @@ end
     for I in IA
         Isorted = sort(I)
         for S in SA
-            GC.gc()
+            # GC.gc() # see comment above
             ru = @timed S[I, J]
-            GC.gc()
+            # GC.gc()
             rs = @timed S[Isorted, Jsorted]
             if debug
                 @printf(" %7d | %7d | %7d | %4.2e | %4.2e | %4.2e | %4.2e |\n", round(Int,nnz(S)/size(S, 2)), length(I), length(J), rs[2], ru[2], rs[3], ru[3])


### PR DESCRIPTION
The GC time in `sparsematrix_constructors_indexing` stood out to me:

```
  Test                            (Worker) │ time (s) │ GC (s) │ GC % │ Alloc (MB) │ RSS (MB) │
  threads_suite                        (3) │    15.82 │   0.13 │  0.8 │     587.28 │   514.05 │
  issues                               (1) │   164.34 │   1.59 │  1.0 │    5697.31 │   631.73 │
  allowscalar                          (1) │     0.22 │   0.00 │  0.0 │       3.72 │   632.32 │
  umfpack                              (2) │   168.33 │   1.41 │  0.8 │    4689.58 │  1338.08 │
  cholmod                              (3) │   331.74 │   3.95 │  1.2 │   11726.66 │   839.48 │
  sparsematrix_constructors_indexing   (2) │   294.01 │  25.58 │  8.7 │    6004.70 │  1338.08 │
```

Turns out we call `GC.gc()` a whole bunch of time explicitly. 


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
