### PR TITLE
Fix out-of-bounds access in is_hermsym for stored zeros

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -4128,9 +4128,10 @@ function is_hermsym(A::AbstractSparseMatrixCSC, check::Function)
 
                 offset = tracker[row]
 
-                # If the matrix is unsymmetric, there might not exist
-                # a rowval[offset]
-                if offset > length(rowval)
+                # If the matrix is unsymmetric, the tracker may have moved
+                # past the last stored entry of column `row`, meaning the
+                # partner entry A[col, row] does not exist
+                if offset > colptr[row+1] - 1
                     return false
                 end
 
@@ -4145,8 +4146,13 @@ function is_hermsym(A::AbstractSparseMatrixCSC, check::Function)
                         return false
                     end
                     offset += 1
-                    row2 = rowval[offset]
                     tracker[row] += 1
+                    # Column `row` ran out of stored entries before
+                    # reaching row `col`, so A[col, row] does not exist
+                    if offset > colptr[row+1] - 1
+                        return false
+                    end
+                    row2 = rowval[offset]
                 end
 
                 # Non zero A[i,j] exists but A[j,i] does not exist

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -4130,7 +4130,7 @@ function is_hermsym(A::AbstractSparseMatrixCSC, check::Function)
 
                 # If the matrix is unsymmetric, there might not exist
                 # a rowval[offset]
-                if offset > length(rowval) || offset > colptr[row+1] - 1
+                if offset > colptr[row+1] - 1
                     return false
                 end
 
@@ -4141,7 +4141,7 @@ function is_hermsym(A::AbstractSparseMatrixCSC, check::Function)
                 # We therefore "catch up" here while making sure that
                 # the elements are actually zero.
                 while row2 < col
-                    if _isnotzero(nzval[offset]) || offset >= length(rowval) || offset > colptr[row+1] - 1
+                    if _isnotzero(nzval[offset])
                         return false
                     end
                     offset += 1

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -520,6 +520,15 @@ end
     nonzeros(A)[end - 3]  = 2.0
     @test issymmetric(A) == false
 
+    # stored zeros must not cause out-of-bounds access when the
+    # partner column runs out of stored entries
+    A = sparse([3, 1], [2, 3], [1.0, 0.0], 3, 3)
+    @test issymmetric(A) == false
+    @test ishermitian(A) == false
+    A = sparse([1, 2], [2, 1], [0.0, 0.0], 2, 2)
+    @test issymmetric(A) == true
+    @test ishermitian(A) == true
+
     # 16521
     @test issymmetric(sparse([0 0; 1 0])) == false
     @test issymmetric(sparse([0 1; 0 0])) == false


### PR DESCRIPTION
When old sins come back to haunt you.... (I am responsible for this bug 11 years ago)... I made Claude do some archaeology:

-----

#### History of the `is_hermsym` out-of-bounds bug

The specific crashing loop is from [JuliaLang/julia#15504](https://github.com/JuliaLang/julia/pull/15504), but the bug lineage starts at [JuliaLang/julia#11371](https://github.com/JuliaLang/julia/pull/11371) — a version of this out-of-bounds hole has existed continuously since May 2015. Here is what an empirical run of each historical version of the algorithm shows:

| Case | [#11371](https://github.com/JuliaLang/julia/pull/11371) (2015) | [#15504](https://github.com/JuliaLang/julia/pull/15504) (2016) | [#16526](https://github.com/JuliaLang/julia/pull/16526) (2016) | truth |
|---|---|---|---|---|
| Today's crasher (stored zero, partner column runs out) | wrong answer: `true` | **BoundsError** | **BoundsError** | `false` |
| Exhausted partner column, no stored zeros | **BoundsError** | BoundsError | `false` ✓ | `false` |
| [#15504](https://github.com/JuliaLang/julia/pull/15504) matrix | wrong answer: `false` | `true` ✓ | `true` ✓ | `true` |
| Issue [#16521](https://github.com/JuliaLang/julia/issues/16521) matrix | **BoundsError** | BoundsError | `false` ✓ | `false` |

The history reads like a game of whack-a-mole:

1. [JuliaLang/julia#11371](https://github.com/JuliaLang/julia/pull/11371) ("Improve performance of issym and ishermitian", May 2015) introduced `is_hermsym` with an unguarded `rowval[tracker[row]]` read — already out-of-bounds-capable (reported as [JuliaLang/julia#16521](https://github.com/JuliaLang/julia/issues/16521)), and it returned a silently wrong `true` on today's test matrix.
2. [JuliaLang/julia#15504](https://github.com/JuliaLang/julia/pull/15504) ("fix bug when zeros are stored", March 2016) fixed the stored-zeros wrong answers by adding the catch-up loop — and that loop's unguarded `offset += 1; row2 = rowval[offset]` is *exactly* the line that throws in today's crasher. So the precise bug fixed here was born there.
3. [JuliaLang/julia#16526](https://github.com/JuliaLang/julia/pull/16526) ("fix bug in sparse is_hermsym", May 2016, fixing [JuliaLang/julia#16521](https://github.com/JuliaLang/julia/issues/16521)) added the `offset > length(rowval)` guard — but only before the *first* read, and with the wrong bound (end of `rowval` instead of end of the column). It fixed the no-stored-zeros case and left the stored-zeros hole open for another decade.
4. [#661](https://github.com/JuliaSparse/SparseArrays.jl/pull/661) (2023) re-added `@inbounds`, quietly upgrading the remaining `BoundsError` to undefined behavior.

So if you want a single answer: [JuliaLang/julia#15504](https://github.com/JuliaLang/julia/pull/15504) wrote the line that crashes, but it was replacing a [JuliaLang/julia#11371](https://github.com/JuliaLang/julia/pull/11371) line that gave a wrong answer on the same input. This fix is the third patch to the same ten-line region, all chasing the original 2015 tracker design.
