### PR TITLE
CHOLMOD: Prefer `RefValue` to `Ref` for fields and type-assertions

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -173,12 +173,12 @@ end
 
 function getcommon(::Type{Int32})
     LibSuiteSparse.init_suitesparse()
-    return get!(newcommon, task_local_storage(), :cholmod_common)::Ref{cholmod_common}
+    return get!(newcommon, task_local_storage(), :cholmod_common)::Base.RefValue{cholmod_common}
 end
 
 function getcommon(::Type{Int64})
     LibSuiteSparse.init_suitesparse()
-    return get!(newcommon_l, task_local_storage(), :cholmod_common_l)::Ref{cholmod_common}
+    return get!(newcommon_l, task_local_storage(), :cholmod_common_l)::Base.RefValue{cholmod_common}
 end
 
 getcommon() = getcommon(Int)
@@ -264,9 +264,9 @@ mutable struct Factor{Tv<:VTypes, Ti<:ITypes} <: Factorization{Tv}
     ptr::Ptr{cholmod_factor}
     dense_x::cholmod_dense_struct
     dense_b::cholmod_dense_struct
-    X::Ref{Ptr{cholmod_dense_struct}}
-    Y::Ref{Ptr{cholmod_dense_struct}}
-    E::Ref{Ptr{cholmod_dense_struct}}
+    X::Base.RefValue{Ptr{cholmod_dense_struct}}
+    Y::Base.RefValue{Ptr{cholmod_dense_struct}}
+    E::Base.RefValue{Ptr{cholmod_dense_struct}}
     lock::ReentrantLock
     function Factor{Tv, Ti}(ptr::Ptr{cholmod_factor}, register_finalizer = true) where {Tv, Ti}
         if ptr == C_NULL

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -368,6 +368,12 @@ end
 end #end for Ti ∈ itypes
 
 for Tv ∈ (Float32, Float64)
+@testset "per-type buffers should be concretely typed" begin
+    @test @inferred(SparseArrays.CHOLMOD.getcommon()) isa Base.RefValue
+    F = cholesky(sparse(Tv[2 1; 1 2]))
+    @test @inferred((F -> getfield(F, :Y)[])(F)) isa Ptr
+end
+
 @testset "Issue #9915" begin
     sparseI = sparse(Tv(1.0)I, 2, 2)
     @test sparseI \ sparseI == sparseI


### PR DESCRIPTION
`Ref` is an abstract type, so `RefValue` is needed in these positions instead to keep everything type-stable.