### PR TITLE
Backports release 1.13

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -2346,7 +2346,7 @@ function \(A::AbstractSparseMatrixCSC, B::AbstractVecOrMat)
         if ishermitian(A)
             return \(Hermitian(A), B)
         end
-        return \(lu(A), B)
+        return convert(AbstractArray{typeof(one(eltype(A)) \ one(eltype(B)))}, \(lu(A), B))
     else
         return \(qr(A), B)
     end

--- a/src/solvers/LibSuiteSparse.jl
+++ b/src/solvers/LibSuiteSparse.jl
@@ -38,7 +38,8 @@ const init_suitesparse = Base.OncePerProcess{Nothing}() do
         if Libdl.dlsym_e(Libdl.dlopen("libsuitesparseconfig"), :SuiteSparse_version) != C_NULL
             current_version_array = Vector{Cint}(undef, 3)
             SuiteSparse_version(current_version_array)
-            current_version = VersionNumber(current_version_array...)
+            (major, minor, patch) = current_version_array
+            current_version = VersionNumber(major, minor, patch)
         else # SuiteSparse < 4.2.0 does not include SuiteSparse_version()
             current_version = v"0.0.0"
         end
@@ -99,6 +100,7 @@ const init_suitesparse = Base.OncePerProcess{Nothing}() do
     catch ex
         @error "Error during initialization of module LibSuiteSparse" exception=ex,catch_backtrace()
     end
+    return nothing
 end
 
 # exports

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1898,14 +1898,15 @@ end
 const RealHermSymComplexHermSSL{Ti, Tr} = Union{
     Symmetric{Tr, SparseMatrixCSC{Tr, Ti}},
     Hermitian{Tr, SparseMatrixCSC{Tr, Ti}},
-    Hermitian{Complex{Tr}, SparseMatrixCSC{Complex{Tr}, Ti}}} where {Ti<:ITypes, Tr<:VRealTypes}
+    Hermitian{Complex{Tr}, SparseMatrixCSC{Complex{Tr}, Ti}}} where {Ti<:ITypes, Tr<:Union{Float64, Float32, Float16}}
 
 function \(A::RealHermSymComplexHermSSL{Ti}, B::StridedVecOrMatInclAdjAndTrans) where {Ti}
+    T = typeof(one(eltype(A)) \ one(eltype(B)))
     F = cholesky(A; check = false)
     if issuccess(F)
-        return \(F, B)
+        return convert(AbstractArray{T}, \(F, B))
     else
-        return \(lu(SparseMatrixCSC{eltype(A), Ti}(A)), B)
+        return convert(AbstractArray{T}, \(lu(SparseMatrixCSC{eltype(A), Ti}(A)), B))
     end
 end
 

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -108,7 +108,7 @@ function _qr!(ordering::Integer, tol::Real, econ::Integer, getCTX::Integer,
     return rnk, _E, _HPinv
 end
 
-struct QRSparseQ{Tv<:CHOLMOD.VTypes,Ti<:Integer} <: AbstractQ{Tv}
+struct QRSparseQ{Tv,Ti<:Integer} <: AbstractQ{Tv}
     factors::SparseMatrixCSC{Tv,Ti}
     τ::Vector{Tv}
     n::Int # Number of columns in original matrix
@@ -131,6 +131,14 @@ struct QRSparse{Tv,Ti} <: LinearAlgebra.Factorization{Tv}
 
     _lock::ReentrantLock
     _ldiv_workspace::Vector{Tv}   # backing storage for work buffer (resizable)
+end
+
+function QRSparse{Tv}(F::QRSparse{<:Number, Ti}) where {Tv, Ti}
+    newfactors = convert(SparseMatrixCSC{Tv}, F.factors)
+    newτ = convert(Vector{Tv}, F.τ)
+    newR = convert(SparseMatrixCSC{Tv}, F.R)
+    newQ = QRSparseQ{Tv,Ti}(newfactors, newτ, size(newR, 2))
+    return QRSparse{Tv,Ti}(newfactors, newτ, newR, newQ, F.cpiv, F.rpivinv, ReentrantLock(), Tv[])
 end
 
 Base.size(F::QRSparse) = (size(F.factors, 1), size(F.R, 2))
@@ -165,9 +173,9 @@ solve least squares or underdetermined problems with [`\\`](@ref). The function 
 
 !!! note
     `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).
-    As this library only supports sparse matrices with [`Float64`](@ref) or
-    `ComplexF64` elements, as of Julia v1.4 `qr` converts `A` into a copy that is
-    of type `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
+    As this library only supports sparse matrices with [`Float64`](@ref), `ComplexF64`, `Float32`, or
+    `ComplexF32` elements, calling `qr` on a matrix with a different element type will either convert it to a supported type or
+    raise an error.
 
 # Examples
 ```jldoctest
@@ -228,9 +236,9 @@ function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), order
                     Tv[])              # _ldiv_workspace (lazily sized on first solve)
 end
 LinearAlgebra.qr(A::SparseMatrixCSC{Float16}; tol=_default_tol(A)) =
-    qr(convert(SparseMatrixCSC{Float32}, A); tol=tol)
+    QRSparse{Float16}(qr(convert(SparseMatrixCSC{Float32}, A); tol=tol))
 LinearAlgebra.qr(A::SparseMatrixCSC{ComplexF16}; tol=_default_tol(A)) =
-    qr(convert(SparseMatrixCSC{ComplexF32}, A); tol=tol)
+    QRSparse{ComplexF16}(qr(convert(SparseMatrixCSC{ComplexF32}, A); tol=tol))
 LinearAlgebra.qr(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}};
    tol=_default_tol(A)) where {T<:AbstractFloat} =
     throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -173,9 +173,9 @@ solve least squares or underdetermined problems with [`\\`](@ref). The function 
 
 !!! note
     `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).
-    As this library only supports sparse matrices with [`Float64`](@ref), `ComplexF64`, `Float32`, or
-    `ComplexF32` elements, calling `qr` on a matrix with a different element type will either convert it to a supported type or
-    raise an error.
+    As this library only supports sparse matrices with [`Float64`](@ref) or
+    `ComplexF64` elements, as of Julia v1.4 `qr` converts `A` into a copy that is
+    of type `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 
 # Examples
 ```jldoctest

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -45,7 +45,7 @@ function _qr!(ordering::Integer, tol::Real, econ::Integer, getCTX::Integer,
         E::Union{Ref{Ptr{Ti}}    , Ptr{Cvoid}} = C_NULL,
         H::Union{Ref{Ptr{CHOLMOD.cholmod_sparse}}        , Ptr{Cvoid}} = C_NULL,
         HPinv::Union{Ref{Ptr{Ti}}, Ptr{Cvoid}} = C_NULL,
-        HTau::Union{Ref{Ptr{CHOLMOD.cholmod_dense}}    , Ptr{Cvoid}} = C_NULL) where {Ti<:CHOLMOD.ITypes, Tv<:CHOLMOD.VTypes}
+        HTau::Union{Ref{Ptr{CHOLMOD.cholmod_dense}}    , Ptr{Cvoid}} = C_NULL) where {Ti<:CHOLMOD.ITypes, Tv<:Union{Float64, ComplexF64}}
 
     ordering ∈ ORDERINGS || error("unknown ordering $ordering")
 
@@ -208,7 +208,7 @@ Column permutation:
 
 [^ACM933]: Foster, L. V., & Davis, T. A. (2013). Algorithm 933: Reliable Calculation of Numerical Rank, Null Space Bases, Pseudoinverse Solutions, and Basic Solutions Using SuitesparseQR. ACM Trans. Math. Softw., 40(1). [doi:10.1145/2513109.2513116](https://doi.org/10.1145/2513109.2513116)
 """
-function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Ti<:CHOLMOD.ITypes, Tv<:CHOLMOD.VTypes}
+function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Ti<:CHOLMOD.ITypes, Tv<:Union{Float64, ComplexF64}}
     R     = Ref{Ptr{CHOLMOD.cholmod_sparse}}()
     E     = Ref{Ptr{Ti}}()
     H     = Ref{Ptr{CHOLMOD.cholmod_sparse}}()
@@ -220,9 +220,9 @@ function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), order
         C_NULL, C_NULL, C_NULL, C_NULL,
         R, E, H, HPinv, HTau)
 
-    R_ = SparseMatrixCSC{Tv, Ti}(Sparse(R[]))
-    factors = SparseMatrixCSC{Tv, Ti}(Sparse(H[]))
-    τ = vec(Array{Tv}(CHOLMOD.Dense(HTau[])))
+    R_ = SparseMatrixCSC{Tv, Ti}(Sparse{Tv, Ti}(R[]))
+    factors = SparseMatrixCSC{Tv, Ti}(Sparse{Tv, Ti}(H[]))
+    τ = vec(Array{Tv}(CHOLMOD.Dense{Tv}(HTau[])))
     R = SparseMatrixCSC{Tv, Ti}(min(size(A)...),
                                 size(R_, 2),
                                 getcolptr(R_),
@@ -235,10 +235,10 @@ function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), order
                     ReentrantLock(),
                     Tv[])              # _ldiv_workspace (lazily sized on first solve)
 end
-LinearAlgebra.qr(A::SparseMatrixCSC{Float16}; tol=_default_tol(A)) =
-    QRSparse{Float16}(qr(convert(SparseMatrixCSC{Float32}, A); tol=tol))
-LinearAlgebra.qr(A::SparseMatrixCSC{ComplexF16}; tol=_default_tol(A)) =
-    QRSparse{ComplexF16}(qr(convert(SparseMatrixCSC{ComplexF32}, A); tol=tol))
+LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Tv<:Union{Float16, Float32}} =
+    QRSparse{Tv}(qr(convert(SparseMatrixCSC{Float64}, A); tol, ordering))
+LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Tv<:Union{ComplexF16, ComplexF32}} =
+    QRSparse{Tv}(qr(convert(SparseMatrixCSC{ComplexF64}, A); tol, ordering))
 LinearAlgebra.qr(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}};
    tol=_default_tol(A)) where {T<:AbstractFloat} =
     throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2396,7 +2396,7 @@ function Base.reducedim_initarray(A::AbstractSparseMatrixCSC, region, v0, ::Type
 end
 
 # General mapreduce
-function _mapreducezeros(f, op, ::Type{T}, nzeros::Integer, v0) where T
+function _mapreducezeros(f::F, op::G, ::Type{T}, nzeros::Integer, v0) where {F,G,T}
     nzeros == 0 && return v0
 
     # Reduce over first zero
@@ -2415,7 +2415,7 @@ function _mapreducezeros(f, op, ::Type{T}, nzeros::Integer, v0) where T
     v
 end
 
-function Base._mapreduce(f, op, ::Base.IndexCartesian, A::AbstractSparseMatrixCSC{T}) where T
+function Base._mapreduce(f::F, op::G, ::Base.IndexCartesian, A::AbstractSparseMatrixCSC{T}) where {F,G,T}
     z = nnz(A)
     n = widelength(A)
     if z == 0
@@ -2430,11 +2430,11 @@ function Base._mapreduce(f, op, ::Base.IndexCartesian, A::AbstractSparseMatrixCS
 end
 
 # Specialized mapreduce for +/*/min/max/_extrema_rf
-_mapreducezeros(f, op::Union{typeof(Base.add_sum),typeof(+)}, ::Type{T}, nzeros::Integer, v0) where {T} =
+_mapreducezeros(f::F, op::Union{typeof(Base.add_sum),typeof(+)}, ::Type{T}, nzeros::Integer, v0) where {F,T} =
     nzeros == 0 ? op(zero(v0), v0) : op(f(zero(T))*nzeros, v0)
-_mapreducezeros(f, op::Union{typeof(Base.mul_prod),typeof(*)},::Type{T}, nzeros::Integer, v0) where {T} =
+_mapreducezeros(f::F, op::Union{typeof(Base.mul_prod),typeof(*)},::Type{T}, nzeros::Integer, v0) where {F,T} =
     nzeros == 0 ? op(one(v0), v0) : op(f(zero(T))^nzeros, v0)
-_mapreducezeros(f, op::Union{typeof(min),typeof(max)}, ::Type{T}, nzeros::Integer, v0) where {T} =
+_mapreducezeros(f::F, op::Union{typeof(min),typeof(max)}, ::Type{T}, nzeros::Integer, v0) where {F,T} =
     nzeros == 0 ? v0 : op(v0, f(zero(T)))
 _mapreducezeros(f::Base.ExtremaMap, op::typeof(Base._extrema_rf), ::Type{T}, nzeros::Integer, v0) where {T} =
     nzeros == 0 ? v0 : op(v0, f(zero(T)))
@@ -2445,7 +2445,7 @@ Base._any(f, A::AbstractSparseMatrixCSC, ::Colon) =
 Base._all(f, A::AbstractSparseMatrixCSC, ::Colon) =
     iszero(widelength(A)) ? true  : Base._mapreduce(f, &, IndexCartesian(), A)
 
-function Base._mapreduce(f, op::Union{typeof(Base.mul_prod),typeof(*)}, ::Base.IndexCartesian, A::AbstractSparseMatrixCSC{T}) where T
+function Base._mapreduce(f::F, op::Union{typeof(Base.mul_prod),typeof(*)}, ::Base.IndexCartesian, A::AbstractSparseMatrixCSC{T}) where {F,T}
     nnzA = nnz(A)
     nzeros = widelength(A) - nnzA
     if nzeros == 0
@@ -2495,7 +2495,7 @@ function _mapreducecols!(f, op, R::AbstractArray, A::AbstractSparseMatrixCSC{Tv,
     R
 end
 
-function Base._mapreducedim!(f, op, R::AbstractArray, A::AbstractSparseMatrixCSC{T}) where T
+function Base._mapreducedim!(f::F, op::G, R::AbstractArray, A::AbstractSparseMatrixCSC{T}) where {F,G,T}
     require_one_based_indexing(A, R)
     lsiz = Base.check_reducedims(R,A)
     isempty(A) && return R

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -324,7 +324,7 @@ julia> sparsevec([1, 3, 1, 2, 2], [true, true, false, false, false])
   [3]  =  1
 ```
 """
-function sparsevec(I::AbstractVector{<:Integer}, V::AbstractVector, combine::Function)
+function sparsevec(I::AbstractVector{<:Integer}, V::AbstractVector, combine::F) where {F<:Function}
     require_one_based_indexing(I, V)
     length(I) == length(V) ||
         throw(ArgumentError("index and value vectors must be the same length"))
@@ -338,7 +338,7 @@ function sparsevec(I::AbstractVector{<:Integer}, V::AbstractVector, combine::Fun
     _sparsevector!(Vector(I), Vector(V), len, combine)
 end
 
-function sparsevec(I::AbstractVector{<:Integer}, V::AbstractVector, len::Integer, combine::Function)
+function sparsevec(I::AbstractVector{<:Integer}, V::AbstractVector, len::Integer, combine::F) where {F<:Function}
     require_one_based_indexing(I, V)
     length(I) == length(V) ||
         throw(ArgumentError("index and value vectors must be the same length"))
@@ -363,10 +363,10 @@ sparsevec(I::AbstractVector, V::Union{Bool, AbstractVector{Bool}}) =
 sparsevec(I::AbstractVector, V::Union{Bool, AbstractVector{Bool}}, len::Integer) =
     sparsevec(I, V, len, |)
 
-sparsevec(I::AbstractVector, v::Number, combine::Function) =
+sparsevec(I::AbstractVector, v::Number, combine::F) where {F<:Function} =
     sparsevec(I, fill(v, length(I)), combine)
 
-sparsevec(I::AbstractVector, v::Number, len::Integer, combine::Function) =
+sparsevec(I::AbstractVector, v::Number, len::Integer, combine::F) where {F<:Function} =
     sparsevec(I, fill(v, length(I)), len, combine)
 
 
@@ -1664,7 +1664,7 @@ end
 Base.reducedim_initarray(A::SparseVectorUnion, region, v0, ::Type{R}) where {R} =
     fill!(Array{R}(undef, Base.to_shape(Base.reduced_indices(A, region))), v0)
 
-function Base._mapreduce(f, op, ::IndexCartesian, A::SparseVectorUnion)
+function Base._mapreduce(f::F, op::G, ::IndexCartesian, A::SparseVectorUnion) where {F,G}
     T = eltype(A)
     isempty(A) && return Base.mapreduce_empty(f, op, T)
     z = nnz(A)
@@ -1681,7 +1681,7 @@ Base._any(f, A::SparseVectorUnion, ::Colon) =
 Base._all(f, A::SparseVectorUnion, ::Colon) =
     iszero(length(A)) ? true  : Base._mapreduce(f, &, IndexCartesian(), A)
 
-function Base.mapreducedim!(f, op, R::AbstractVector, A::SparseVectorUnion)
+function Base.mapreducedim!(f::F, op::G, R::AbstractVector, A::SparseVectorUnion) where {F,G}
     # dim1 reduction could be safely replaced with a mapreduce
     if length(R) == 1
         I = firstindex(R)

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -861,9 +861,9 @@ end
               Symmetric(Apre + 10I), Hermitian(Apre + 10I),
               Hermitian(complex(Apre)), Hermitian(complex(Apre) + 10I))
         local A, x, b
-        x = fill(1., 10)
+        x = fill(1, 10)
         b = A*x
-        @test x ≈ A\b
+        @test @inferred A\b ≈ x
         @test transpose(A)\b ≈ A'\b
     end
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1140,4 +1140,14 @@ end
     end
 end
 
+@testset "type stability of linear solve" begin
+    for relty in (Float16, Float32, Float64), elty in (relty, Complex{relty})
+        A = sprand(elty, 2, 2, 1.0)
+        B = randn(elty, 2, 2)
+        b = randn(elty, 2)
+        @inferred A \ b
+        @inferred A \ B
+    end
+end
+
 end

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -110,16 +110,10 @@ end
     @test (F.Q*F.R)::SparseMatrixCSC == A[F.prow,F.pcol]
 end
 
-@testset "Issue #585 for element type: $eltyA" for eltyA in (Float64, Float32, ComplexF64, ComplexF32)
+@testset "Issue #585 for element type: $eltyA" for eltyA in (Float64, Float32, Float16, ComplexF64, ComplexF32, ComplexF16)
     A = sparse(eltyA[1 0; 0 1])
     F = qr(A)
     @test eltype(F.Q) == eltype(F.R) == eltyA
-end
-
-@testset "Complementing issue #585 for element type: $eltyA" for (eltyA, eltyB) in [(Float16, Float32), (ComplexF16, ComplexF32)]
-    A = sparse(eltyA[1 0; 0 1])
-    F = qr(A)
-    @test eltype(F.Q) == eltype(F.R) == eltyB
 end
 
 @testset "select ordering overdetermined" begin

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -116,6 +116,13 @@ end
     @test eltype(F.Q) == eltype(F.R) == eltyA
 end
 
+@testset "single-precision qr factorization works as expected: $eltyA" for eltyA in (Float32, ComplexF32, Float16, ComplexF16)
+    A = sprandn(eltyA, m, n, 0.3)
+    F = qr(A)
+    @test eltype(F.Q) == eltype(F.R) == eltyA
+    @test Matrix(F.Q) * F.R ≈ A[F.prow, F.pcol]
+end
+
 @testset "select ordering overdetermined" begin
      A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], randn(nn), m, n)
      b = randn(m)


### PR DESCRIPTION
- [x] #684
- [x] #753
- [x] #754
- [x] #756
- [x] #761

The `--trim` PRs are pretty safe to backport. The annoying part is that #756 also includes a serious bugfix, that needs to be backported, but it requires #684, which I had intentionally not backported as being trouble than it was worth.