### PR TITLE
CHOLMOD: fix getindex for unsorted and unpacked Sparse matrices

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1307,11 +1307,24 @@ function getindex(A::Sparse{T}, i0::Integer, i1::Integer) where T
     s.stype < 0 && i0 < i1 && return conj(A[i1,i0])
     s.stype > 0 && i0 > i1 && return conj(A[i1,i0])
 
+    # in an unpacked matrix the entries of column `i1` stop after `nz[i1]`
+    # entries rather than at `p[i1 + 1]`
     r1 = Int(unsafe_load(s.p, i1) + 1)
-    r2 = Int(unsafe_load(s.p, i1 + 1))
+    r2 = s.packed != 0 ? Int(unsafe_load(s.p, i1 + 1)) :
+                         r1 + Int(unsafe_load(s.nz, i1)) - 1
     (r1 > r2) && return zero(T)
-    r1 += Int(searchsortedfirst(view(unsafe_wrap(Array, s.i, (s.nzmax,), own = false), r1:r2), i0 - 1) - 1)
-    ((r1 > r2) || (unsafe_load(s.i, r1) + 1 != i0)) ? zero(T) : unsafe_load(Ptr{T}(s.x), r1)
+
+    # CHOLMOD only guarantees that the row indices of a column are sorted when
+    # `sorted` is set, so a binary search is only valid in that case
+    rows = view(unsafe_wrap(Array, s.i, (s.nzmax,), own = false), r1:r2)
+    if s.sorted != 0
+        k = searchsortedfirst(rows, i0 - 1)
+        (k > length(rows) || rows[k] + 1 != i0) && return zero(T)
+    else
+        k = findfirst(==(i0 - 1), rows)
+        k === nothing && return zero(T)
+    end
+    return unsafe_load(Ptr{T}(s.x), r1 + k - 1)
 end
 
 @inline function getproperty(F::Factor, sym::Symbol)

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -1112,6 +1112,31 @@ end
     @test issparse(F \ Bts')
 end
 
+@testset "getindex with unsorted or unpacked buffers (#758), Ti = $Ti" for Ti ∈ itypes
+    # the product of two matrices with sorted row indices need not be sorted
+    A = sparse(Ti[2, 1, 2], Ti[1, 2, 2], Tv[1, 2, 3])
+    S = CHOLMOD.Sparse(A)
+    P = S'S
+    @test Array(P) == Matrix(sparse(P)) == Matrix(A'A)
+    @test P[1, 2] == (A'A)[1, 2]
+    @test_throws BoundsError P[0, 1]
+    @test_throws BoundsError P[1, 3]
+
+    # a matrix that is both unsorted and unpacked: room for three entries is
+    # reserved in every column, column 1 stores rows 3 and 1 in that order,
+    # column 2 stores row 2 and column 3 is empty
+    U = CHOLMOD.allocate_sparse(3, 3, 9, false, false, 0, Tv, Ti)
+    s = unsafe_load(CHOLMOD.typedpointer(U))
+    unsafe_wrap(Array, s.p, 4) .= Ti[0, 3, 6, 9]
+    unsafe_wrap(Array, s.nz, 3) .= Ti[2, 1, 0]
+    rowval = unsafe_wrap(Array, s.i, 9)
+    nzval = unsafe_wrap(Array, Ptr{Tv}(s.x), 9)
+    rowval[1], nzval[1] = 2, 10 # U[3, 1]
+    rowval[2], nzval[2] = 0, 20 # U[1, 1]
+    rowval[4], nzval[4] = 1, 30 # U[2, 2]
+    @test Array(U) == Tv[20 0 0; 0 30 0; 10 0 0]
+end
+
 end # for Tv ∈ (Float32, Float64)
 
 end # Base.USE_GPL_LIBS


### PR DESCRIPTION
Fixes #758.

`getindex(::Sparse, i, j)` binary-searched the row indices of a column unconditionally, but CHOLMOD only guarantees that a column's row indices are sorted when the struct's `sorted` flag is set. `S'S` returns an unsorted result, so lookups silently missed stored entries — and since `Array` and `show` go through `getindex`, those conversions were wrong too:

```julia
julia> A = sparse([2, 1, 2], [1, 2, 2], Float64[1, 2, 3]);

julia> P = CHOLMOD.Sparse(A)' * CHOLMOD.Sparse(A); # unsorted

julia> P[1, 2]      # before: 0.0, after: 3.0
3.0

julia> Array(P)     # before: [1.0 0.0; 3.0 0.0]
2×2 Matrix{Float64}:
 1.0   3.0
 3.0  13.0
```

Changes:

* Use `searchsortedfirst` only when `sorted` is set; fall back to a linear scan over the column otherwise.
* While computing the range of entries belonging to a column, also handle unpacked matrices (`packed == 0`), where a column ends after `nz[j]` entries rather than at `p[j + 1]`. Previously those reads ran past the end of the column into uninitialized storage.

Tests cover the matrix from the issue plus an explicitly unsorted *and* unpacked matrix built with `allocate_sparse`, over both index types.

Note that `Sparse` is not a public API, so this is not user-facing today; it matters if/when we start relying on this indexing path internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KpwdQ6bpWQKzjGV5prtAR