### PR TITLE
Make `isequal` on sparse vectors and matrices walk stored entries only

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -2337,7 +2337,11 @@ function (-)(A::Array, B::SparseMatrixCSCUnion)
 end
 
 ## full equality
-function ==(A1::AbstractSparseMatrixCSC, A2::AbstractSparseMatrixCSC)
+# Compare two CSC matrices by walking their stored entries only. `eq` is the elementwise
+# predicate (`==` or `isequal`); stored entries without a counterpart are compared against
+# the implicit zero of the other matrix so that e.g. `isequal(-0.0, 0.0)` and
+# `isequal(NaN, NaN)` behave as they do for dense arrays.
+function _iseq(eq::F, A1::AbstractSparseMatrixCSC, A2::AbstractSparseMatrixCSC) where {F}
     size(A1) != size(A2) && return false
     @inbounds for i in axes(A1, 2)
         nz1, nz2 = nzrange(A1,i), nzrange(A2,i)
@@ -2346,27 +2350,30 @@ function ==(A1::AbstractSparseMatrixCSC, A2::AbstractSparseMatrixCSC)
         while j1 <= last(nz1) && j2 <= last(nz2)
             r1, r2 = rowvals(A1)[j1], rowvals(A2)[j2]
             if r1 == r2
-                nonzeros(A1)[j1] != nonzeros(A2)[j2] && return false
+                eq(nonzeros(A1)[j1], nonzeros(A2)[j2]) || return false
                 j1 += 1
                 j2 += 1
             elseif r1 < r2
-                !iszero(nonzeros(A1)[j1]) && return false
+                _iszero_under(eq, nonzeros(A1)[j1]) || return false
                 j1 += 1
             else # r1 > r2
-                !iszero(nonzeros(A2)[j2]) && return false
+                _iszero_under(eq, nonzeros(A2)[j2]) || return false
                 j2 += 1
             end
         end
         # finish off any left-overs:
         for j = j1:last(nz1)
-            !iszero(nonzeros(A1)[j]) && return false
+            _iszero_under(eq, nonzeros(A1)[j]) || return false
         end
         for j = j2:last(nz2)
-            !iszero(nonzeros(A2)[j]) && return false
+            _iszero_under(eq, nonzeros(A2)[j]) || return false
         end
     end
     return true
 end
+
+==(A1::AbstractSparseMatrixCSC, A2::AbstractSparseMatrixCSC) = _iseq(==, A1, A2)
+Base.isequal(A1::AbstractSparseMatrixCSC, A2::AbstractSparseMatrixCSC) = _iseq(isequal, A1, A2)
 
 ## Explicit efficient comparisons with transposed arrays
 

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -965,42 +965,57 @@ end
 
 ## Explicit efficient comparisons with vectors
 
-function ==(A::AbstractCompressedVector,
-            B::AbstractCompressedVector)
+# Is `x` equal to the implicit zero of a sparse array under the predicate `eq`?
+# Uses `zero(x)` rather than `zero(eltype(...))` so that non-numeric element types such
+# as `Any` still work as long as the stored values themselves are numbers.
+_iszero_under(eq::F, x) where {F} = eq(x, zero(x))
+
+# Compare two compressed vectors by walking their stored entries only. `eq` is the
+# elementwise predicate (`==` or `isequal`); stored entries without a counterpart are
+# compared against the implicit zero of the other vector so that e.g. `isequal(-0.0, 0.0)`
+# and `isequal(NaN, NaN)` behave as they do for dense arrays.
+function _iseq(eq::F, A::AbstractCompressedVector, B::AbstractCompressedVector) where {F}
     # Different sizes are always different
     size(A) ≠ size(B) && return false
     # Compare nonzero elements
     i, j = 1, 1
     @inbounds while i <= nnz(A) && j <= nnz(B)
         if nonzeroinds(A)[i] == nonzeroinds(B)[j]
-            nonzeros(A)[i] == nonzeros(B)[j] || return false
+            eq(nonzeros(A)[i], nonzeros(B)[j]) || return false
             i += 1
             j += 1
         elseif nonzeroinds(A)[i] <= nonzeroinds(B)[j]
-            iszero(nonzeros(A)[i]) || return false
+            _iszero_under(eq, nonzeros(A)[i]) || return false
             i += 1
         else # nonzeroinds(A)[i] >= nonzeroinds(B)[j]
-            iszero(nonzeros(B)[j]) || return false
+            _iszero_under(eq, nonzeros(B)[j]) || return false
             j += 1
         end
     end
 
     @inbounds for k in i:nnz(A)
-        iszero(nonzeros(A)[k]) || return false
+        _iszero_under(eq, nonzeros(A)[k]) || return false
     end
 
     @inbounds for k in j:nnz(B)
-        iszero(nonzeros(B)[k]) || return false
+        _iszero_under(eq, nonzeros(B)[k]) || return false
     end
 
     return true
 end
 
+==(A::AbstractCompressedVector, B::AbstractCompressedVector) = _iseq(==, A, B)
+Base.isequal(A::AbstractCompressedVector, B::AbstractCompressedVector) = _iseq(isequal, A, B)
+
 ==(A::Transpose{<:Any,<:AbstractCompressedVector},
     B::Transpose{<:Any,<:AbstractCompressedVector}) = transpose(A) == transpose(B)
+Base.isequal(A::Transpose{<:Any,<:AbstractCompressedVector},
+    B::Transpose{<:Any,<:AbstractCompressedVector}) = isequal(transpose(A), transpose(B))
 
 ==(A::Adjoint{<:Any,<:AbstractCompressedVector},
     B::Adjoint{<:Any,<:AbstractCompressedVector}) = adjoint(A) == adjoint(B)
+Base.isequal(A::Adjoint{<:Any,<:AbstractCompressedVector},
+    B::Adjoint{<:Any,<:AbstractCompressedVector}) = isequal(adjoint(A), adjoint(B))
 
 ### getindex
 

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -50,6 +50,30 @@ end
     end
 end
 
+@testset "isequal walks stored entries only (issue #561)" begin
+    n = 10^5
+    A = spzeros(n, n); A[1, 1] = 1
+    B = spzeros(n, n); B[1, 1] = 1
+    @test isequal(A, B) && A == B
+    @test @elapsed(isequal(A, B)) < 0.1
+    B[n, n] = 2
+    @test !isequal(A, B) && A != B
+    @test !isequal(spzeros(2, 3), spzeros(3, 2))
+    # isequal semantics for NaN and signed zeros must match dense arrays
+    X = sparse([1, 2, 3], [1, 1, 2], [NaN, -0.0, 2.0], 3, 3)
+    for Y in (sparse([1, 2, 3], [1, 1, 2], [NaN, -0.0, 2.0], 3, 3),
+              sparse([1, 3], [1, 2], [NaN, 2.0], 3, 3),
+              sparse([1, 2, 3], [1, 1, 2], [NaN, 0.0, 2.0], 3, 3),
+              sparse([1, 2, 3, 3], [1, 1, 2, 3], [NaN, -0.0, 2.0, 0.0], 3, 3),
+              sparse([1, 2, 3], [1, 1, 2], [1.0, -0.0, 2.0], 3, 3),
+              sparse([2, 2, 3], [1, 2, 2], [NaN, -0.0, 2.0], 3, 3),
+              sparse([1, 2, 3], [1, 1, 2], [NaN, -0.0, 2], 3, 3))
+        @test isequal(X, Y) == isequal(Matrix(X), Matrix(Y))
+        @test isequal(Y, X) == isequal(Matrix(Y), Matrix(X))
+        @test (X == Y) == (Matrix(X) == Matrix(Y))
+    end
+end
+
 @testset "iszero specialization for SparseMatrixCSC" begin
     @test !iszero(sparse(I, 3, 3))                  # test failure
     @test iszero(spzeros(3, 3))                     # test success with no stored entries

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -356,6 +356,32 @@ end
     @test SparseArrays.dropstored!(x, 5) == SparseVector(10, [7, 9], [7.0, 9.0])
 end
 
+@testset "isequal walks stored entries only (issue #561)" begin
+    n = 10^9
+    v1 = spzeros(n); v1[1] = 1
+    v2 = spzeros(n); v2[1] = 1
+    @test isequal(v1, v2) && v1 == v2
+    @test @elapsed(isequal(v1, v2)) < 0.1
+    v2[n] = 2
+    @test !isequal(v1, v2) && v1 != v2
+    @test isequal(v1', v1') && isequal(transpose(v1), transpose(v1))
+    @test !isequal(v1', v2') && !isequal(transpose(v1), transpose(v2))
+    # isequal semantics for NaN and signed zeros must match dense arrays
+    x = sparsevec([1, 3, 5], [NaN, -0.0, 2.0], 6)
+    for y in (sparsevec([1, 3, 5], [NaN, -0.0, 2.0], 6),   # identical
+              sparsevec([1, 5], [NaN, 2.0], 6),            # -0.0 stored vs implicit 0.0
+              sparsevec([1, 3, 5], [NaN, 0.0, 2.0], 6),    # -0.0 vs stored 0.0
+              sparsevec([1, 2, 5], [NaN, 0.0, 2.0], 6),    # explicit stored zero
+              sparsevec([1, 3, 5], [1.0, -0.0, 2.0], 6),   # NaN vs number
+              sparsevec([2, 3, 5], [NaN, -0.0, 2.0], 6),   # NaN vs implicit zero
+              sparsevec([1, 3, 5], [NaN, -0.0, 2], 6))     # different eltype
+        @test isequal(x, y) == isequal(Vector(x), Vector(y))
+        @test isequal(y, x) == isequal(Vector(y), Vector(x))
+        @test (x == y) == (Vector(x) == Vector(y))
+    end
+    @test !isequal(spzeros(3), spzeros(4))
+end
+
 @testset "findall and findnz" begin
     @test findall(!iszero, spv_x1) == findall(!iszero, x1_full)
     @test findall(spv_x1 .> 1) == findall(x1_full .> 1)


### PR DESCRIPTION
`isequal` on `SparseVector` and `SparseMatrixCSC` fell back to the generic `AbstractArray` method, which visits every element. The example from #561 (two length-10^9 vectors with one stored entry each) took ~1.5s; it now takes microseconds.

Changes:
- Refactor the existing sparse `==` for compressed vectors and CSC matrices into an `_iseq(eq, A, B)` helper parameterized on the elementwise predicate.
- Define `isequal` for `AbstractCompressedVector`, `AbstractSparseMatrixCSC`, and the `Adjoint`/`Transpose` vector wrappers (mirroring the existing `==` methods) on top of that helper.
- Unmatched stored entries are compared with the predicate against `zero(x)`, so `isequal` keeps its dense-array semantics: `isequal(NaN, NaN)` is true and `isequal(-0.0, 0.0)` is false, including a stored `-0.0` against an implicit zero. Using `zero(x)` rather than `zero(eltype(A))` keeps non-numeric element types such as `Any`/`Number` working.
- Tests cross-check `isequal` and `==` against the dense results for NaN, signed zeros, stored zeros, and mixed element types, plus a timing guard on the issue's example.

`Test.detect_ambiguities(SparseArrays)` remains empty.

Fixes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzN6CtuVBJWDVc88ShNYso