### PR TITLE
Export AbstractSparseMatrixCSC, getcolptr, indtype

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -29,7 +29,7 @@ import Base: adjoint, argmin, argmax, Array, broadcast, circshift!, complex, Com
 
 using Random: default_rng, AbstractRNG, randsubseq, randsubseq!
 
-export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector, AbstractSparseMatrixCSC
+export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector, AbstractSparseMatrixCSC,
     SparseMatrixCSC, SparseVector, blockdiag, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, getcolptr, sparse, sparsevec, spdiagm,
     sprand, sprandn, spzeros, nnz, indtype, permute, findnz,  fkeep!, ftranspose!,

--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -29,10 +29,10 @@ import Base: adjoint, argmin, argmax, Array, broadcast, circshift!, complex, Com
 
 using Random: default_rng, AbstractRNG, randsubseq, randsubseq!
 
-export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
+export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector, AbstractSparseMatrixCSC
     SparseMatrixCSC, SparseVector, blockdiag, droptol!, dropzeros!, dropzeros,
-    issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm,
-    sprand, sprandn, spzeros, nnz, permute, findnz,  fkeep!, ftranspose!,
+    issparse, nonzeros, nzrange, rowvals, getcolptr, sparse, sparsevec, spdiagm,
+    sprand, sprandn, spzeros, nnz, indtype, permute, findnz,  fkeep!, ftranspose!,
     sparse_hcat, sparse_vcat, sparse_hvcat
 
 public sparse!, spzeros!

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -75,6 +75,11 @@ end
 issparse(A::DenseArray) = false
 issparse(S::AbstractSparseArray) = true
 
+"""
+    indtype(S)
+
+Return the type used to index sparse array entries.
+"""
 indtype(S::AbstractSparseArray{<:Any,Ti}) where {Ti} = Ti
 indtype(T::UpperOrLowerTriangular{<:Any,<:AbstractSparseArray}) = indtype(parent(T))
 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -194,10 +194,11 @@ const SparseMatrixCSCUnion2{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, Spars
 """
         getcolptr(S)
 
-Return the vector of column start indices in an AbstractSparseMatrixCSC pointing
-into [`nonzeros`](@ref) and [`rowvals`](@ref). Any modifications to the returned
-vector will mutate `A` as well. Providing access to the column start indices
-can be useful in preconditioners and sparse direct solvers.
+Return the vector of column start indices in an `AbstractSparseMatrixCSC` pointing
+into [`nonzeros`](@ref) and [`rowvals`](@ref). The returned vector aliases `S`,
+but implementations with fixed sparsity may make it read-only. When it is
+writable, modifications to it mutate `S`. Providing access to the column start
+indices can be useful in preconditioners and sparse direct solvers.
 
 # Examples
 ```jldoctest

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -209,10 +209,10 @@ julia> A = sparse(2I, 3, 3)
 
 julia> getcolptr(A)
 4-element Vector{Int64}:
-1
-2
-3
-4
+ 1
+ 2
+ 3
+ 4
 ```
 """
 getcolptr(S::SorF)     = getfield(S, :colptr)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -191,6 +191,30 @@ const SparseMatrixCSCColumnSubset{Tv,Ti} =
         Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractVector{<:Integer}}
 const SparseMatrixCSCUnion2{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCColumnSubset{Tv,Ti}}
 
+"""
+        getcolptr(S)
+
+Return the vector of column start indices in an AbstractSparseMatrixCSC pointing
+into [`nonzeros`](@ref) and [`rowvals`](@ref). Any modifications to the returned
+vector will mutate `A` as well. Providing access to the column start indices
+can be useful in preconditioners and sparse direct solvers.
+
+# Examples
+```jldoctest
+julia> A = sparse(2I, 3, 3)
+3×3 SparseMatrixCSC{Int64, Int64} with 3 stored entries:
+ 2  ⋅  ⋅
+ ⋅  2  ⋅
+ ⋅  ⋅  2
+
+julia> getcolptr(A)
+4-element Vector{Int64}:
+1
+2
+3
+4
+```
+"""
 getcolptr(S::SorF)     = getfield(S, :colptr)
 getcolptr(S::SparseMatrixCSCView) = view(getcolptr(parent(S)), first(S.indices[2]):(last(S.indices[2]) + 1))
 getcolptr(S::SparseMatrixCSCColumnSubset) = error("getcolptr not well-defined for $(typeof(S))")


### PR DESCRIPTION
AbstractSparseMatrixCSC and getcolptr are heavily used in LinearSolve.jl.

We find uses of getcolptr in Sparspak.jl and Pardiso.jl (and yes, in my package ExtendableSparse.jl)

indtype is a useful complement to eltype which could be extended for subtypes of AbstractSparseArray.SparseMatrixCSC


I intend to replace #395 with this PR. My main concern ist "ExplicitImports sanity" of the package ecosystem.  IMHO #395 was (perceived as) too ambitious, probably because of the word 'interface' in the title. The present PR doesn't care about "interface", but just pragmatically tries to formalize what is current practice.

As for 'indtype', this is a slightly different discussion, we may just make it public, and I would also agree with keeping it internal, in order to prevent delaying of fixing the situation with AbstractSparseMatrixCSC and getcolptr.
