### PR TITLE
Define `nnz` and `indtype` for `ReadOnly`

### DIFF
--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -43,3 +43,8 @@ Base.copy(x::ReadOnly) = ReadOnly(copy(parent(x)))
     parent(x) == parent(y)
 
 Base.dataids(::ReadOnly) = tuple()
+
+# Forward the sparse array interface to the parent, so that a `ReadOnly` wrapping a
+# sparse array behaves like one. `issparse` already forwards through `parent`.
+nnz(x::ReadOnly) = nnz(parent(x))
+indtype(x::ReadOnly) = indtype(parent(x))

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -1,6 +1,6 @@
 using Test, SparseArrays, LinearAlgebra
 using SparseArrays: AbstractSparseVector, AbstractSparseMatrixCSC, FixedSparseCSC, FixedSparseVector, ReadOnly,
-    getcolptr, rowvals, nonzeros, nonzeroinds, _is_fixed, fixed, move_fixed, fkeep!
+    getcolptr, rowvals, nonzeros, nonzeroinds, _is_fixed, fixed, move_fixed, fkeep!, indtype
 
 @testset "ReadOnly" begin
     v = randn(100)
@@ -35,6 +35,14 @@ end
     @test rowvals(A) !== rowvals(B)
     @test nonzeros(A) == nonzeros(B)
     @test nonzeros(A) === nonzeros(B)
+
+    # a ReadOnly wrapping a sparse array forwards the sparse array interface
+    for X in (A, A[:, 1], SparseMatrixCSC{Float64,Int32}(A))
+        R = ReadOnly(X)
+        @test issparse(R)
+        @test nnz(R) == nnz(X)
+        @test indtype(R) === indtype(X)
+    end
 end
 
 struct_eq(A, B, C...) = struct_eq(A, B) && struct_eq(B, C...)


### PR DESCRIPTION
Fixes #611.

`issparse` already looks through a `ReadOnly` wrapper via `parent`, so
`ReadOnly(A)` for a sparse `A` reports itself as sparse and then throws a
`MethodError` on the rest of the interface:

```julia
julia> R = SparseArrays.ReadOnly(sprandn(12, 11, 0.3));

julia> issparse(R)
true

julia> nnz(R)
ERROR: MethodError: no method matching nnz(::SparseArrays.ReadOnly{Float64, 2, SparseMatrixCSC{Float64, Int64}})
```

This forwards `nnz` and `indtype` to the parent, alongside the `Base`
functions `readonly.jl` already forwards. Wrapping a non-sparse array still
gives a `MethodError`, now reported against the parent type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8HenXTVrASo1sBZVGhpDQ