### PR TITLE
Keep broadcasts over views of dense arrays sparse

### DIFF
--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -95,6 +95,7 @@ is_supported_sparse_broadcast(::AbstractSparseArray, rest...) = is_supported_spa
 is_supported_sparse_broadcast(::StructuredMatrix, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(::Array, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(t::Union{Transpose, Adjoint}, rest...) = is_supported_sparse_broadcast(t.parent, rest...)
+is_supported_sparse_broadcast(v::SubArray, rest...) = is_supported_sparse_broadcast(parent(v), rest...)
 is_supported_sparse_broadcast(x, rest...) = axes(x) === () && is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(x::Ref, rest...) = is_supported_sparse_broadcast(rest...)
 

--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -94,7 +94,7 @@ is_supported_sparse_broadcast(::AbstractArray, rest...) = false
 is_supported_sparse_broadcast(::AbstractSparseArray, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(::StructuredMatrix, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(::Array, rest...) = is_supported_sparse_broadcast(rest...)
-is_supported_sparse_broadcast(t::Union{Transpose, Adjoint}, rest...) = is_supported_sparse_broadcast(t.parent, rest...)
+is_supported_sparse_broadcast(t::Union{Transpose, Adjoint}, rest...) = is_supported_sparse_broadcast(parent(t), rest...)
 is_supported_sparse_broadcast(v::SubArray, rest...) = is_supported_sparse_broadcast(parent(v), rest...)
 is_supported_sparse_broadcast(x, rest...) = axes(x) === () && is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(x::Ref, rest...) = is_supported_sparse_broadcast(rest...)

--- a/test/higherorderfns.jl
+++ b/test/higherorderfns.jl
@@ -435,6 +435,34 @@ end
     @test A .+ ntuple(identity, N) isa Matrix
 end
 
+@testset "broadcast[!] over views of dense and sparse arrays (#508)" begin
+    N, p = 10, 0.4
+    V = sprand(N, p)
+    A = sprand(N, N, p)
+    Z = copy(A)
+    C = rand(N)
+    M = rand(N, N)
+    # views of dense arrays should not force a dense result
+    for X in (view(M, :, :), view(M, 1:N, 1:N), view(M, collect(1:N), :), view(M, :, :)')
+        fX = Array(X)
+        @test broadcast(+, A, X)::SparseMatrixCSC == sparse(broadcast(+, Array(A), fX))
+        @test broadcast(*, A, X)::SparseMatrixCSC == sparse(broadcast(*, Array(A), fX))
+        @test broadcast!(*, Z, A, X) == sparse(broadcast(*, Array(A), fX))
+        # the structural zeros of A must be preserved by a zero-preserving op
+        @test nnz(broadcast(*, A, X)) <= nnz(A)
+    end
+    for x in (view(C, :), view(C, 1:N), view(C, collect(1:N)))
+        @test broadcast(*, V, x)::SparseVector == sparse(broadcast(*, Array(V), Array(x)))
+        @test nnz(broadcast(*, V, x)) <= nnz(V)
+    end
+    # views of sparse arrays likewise
+    S = sprand(N, 2N, p)
+    @test broadcast(*, A, view(S, :, 1:N))::SparseMatrixCSC ==
+        sparse(broadcast(*, Array(A), Array(S[:, 1:N])))
+    # a view of an unsupported array still diverts to generic dense broadcast
+    @test broadcast(*, A, view(PermutedDimsArray(M, (2, 1)), :, :)) isa Matrix
+end
+
 @testset "map[!] over combinations of sparse and structured matrices" begin
     N, p = 10, 0.4
     A = sprand(N, N, p)


### PR DESCRIPTION
Fixes #508.

Broadcasting a sparse array against a dense `Matrix` stays sparse, but doing
the same against a *view* of that matrix silently produced a dense result:

```julia
julia> A = sprand(5, 5, 0.3); B = rand(5, 5);

julia> typeof(A .* B)
SparseMatrixCSC{Float64, Int64}

julia> typeof(A .* view(B, :, :))
Matrix{Float64}
```

The cause is `is_supported_sparse_broadcast`, which whitelists `Array` but
not `SubArray`. A view therefore answered `false`, and `copy(::Broadcasted{PromoteToSparse})`
diverted the whole expression to the generic dense path — losing both the
sparse result type and the structural zeros of `A`.

This recurses through `SubArray` to its parent, exactly as `Transpose`/`Adjoint`
are already handled one line above, so a view is supported whenever the array
it views is. That covers non-strided views (`view(B, [1,3,5], :)`) as well as
strided ones, and picks up views of *sparse* arrays at the same time. Arrays
that were unsupported before still divert to the dense fallback.

Tests cover dense views, adjoints of views, sparse views, `broadcast!`, and
that a zero-preserving op no longer fills in structural zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8HenXTVrASo1sBZVGhpDQ