### PR TITLE
Make codecov status checks informational only

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,8 +3,10 @@ coverage:
     patch:
       default:
         only_pulls: true # Only show the `codecov/patch` commit status on pull requests.
+        informational: true # Never fail the check; coverage is reported but not enforced.
     project:
       default:
         only_pulls: true # Only show the `codecov/project` commit status on pull requests.
+        informational: true # Never fail the check; coverage is reported but not enforced.
 ignore:
   - "src/solvers/lib/*.jl"


### PR DESCRIPTION
Set `informational: true` on both the `codecov/patch` and `codecov/project` statuses in `.codecov.yml`. With this, the two Codecov checks always pass and never block merging, while coverage is still uploaded by CI and reported on every pull request.

This is the Codecov-documented way to keep the coverage report visible without making it a required gate: https://docs.codecov.com/docs/commit-status#informational

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgBHUw9Hp7YW5ub29B4R5y
