### PR TITLE
Clarify what `sparse(F.LD)` returns in the `ldlt` docstring

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1682,11 +1682,24 @@ To include the effects of permutation, it is typically preferable to extract
 "combined" factors like `PtL = F.PtL` (the equivalent of
 `P'*L`) and `LtP = F.UP` (the equivalent of `L'*P`).
 The complete list of supported factors is `:L, :PtL, :D, :UP, :U, :LD, :DU, :PtLD, :DUP`.
-The permutation vector is available as `F.p`, defined such that `L*D*L' == A[p, p]`,
+Each one acts as the matrix its name spells out, so that for instance `F.PtL \\ b`
+solves with `P'*L` and `F.LD \\ b` solves with the product `L*D`.
+The permutation vector is available as `F.p`, defined such that `L*D*L' == A[p, p]`.
 
-The `LD` component can be materialized as a sparse matrix using `sparse(F.LD)`,
-Other components cannot be materialized directly, but can be reconstructed from
-`sparse(F.LD)` and `F.p` if needed.
+Of these, only `LD` can be materialized, with `sparse(F.LD)`. Beware that the
+matrix it returns is *not* the product `L*D`: it is CHOLMOD's packed ``LDL'``
+factor, which stores `L` with its unit diagonal overwritten by the diagonal of
+`D`. Solving with it is therefore not the same as solving with `F.LD`. Unpack it
+as
+
+```julia
+LD = sparse(F.LD)
+D = Diagonal(diag(LD))   # equivalently, Diagonal(diag(F))
+L = tril(LD, -1) + I     # unit lower triangular
+```
+
+after which `L*D*L' == A[F.p, F.p]`. The remaining components cannot be
+materialized directly, but can be reconstructed from `L`, `D` and `F.p`.
 
 Unlike the related Cholesky factorization, the ``LDL'`` factorization does not
 require `A` to be positive definite. However, it still requires all leading


### PR DESCRIPTION
Fixes #725.

`F.LD` means two different matrices depending on how you use it:

| Use | What it is |
| --- | --- |
| `F.LD \ b` | solves with the **product** `L*D` (`cholmod_solve` with `CHOLMOD_LD`) |
| `sparse(F.LD)` | CHOLMOD's **packed** `LDL'` factor — `L` with its unit diagonal overwritten by `diag(D)` |

so `F.LD \ b` and `sparse(F.LD) \ b` are different operations:

```
sparse(F.LD)           recovered L            recovered D
 7.0    0    0    0     1.0    0    0    0     7.0
 0.29  3.43  0    0     0.29  1.0   0    0          3.43
 0     0.29 4.71  0     0     0.29 1.0   0               4.71
 0.14 -0.08 0.23 5.58   0.14 -0.08 0.23 1.0                   5.58

L*D*L' == A[p,p]              : true
sparse(F.LD) == L*D           : false
F.LD \ b == (L*D) \ b         : true
F.LD \ b == sparse(F.LD) \ b  : false
```

The docstring said only that "the `LD` component can be materialized as a
sparse matrix using `sparse(F.LD)`", mentioning neither the packed layout nor
the divergence from `F.LD \ b`. Sitting next to `F.PtL` = `P'*L` and `F.UP` =
`L'*P`, which really are products, `LD` reads as `L*D`.

The internals already rely on the packed convention: `sparse(::Factor)` calls
`getLd!` on `sparse(F.LD)`, which reads `d` off the diagonal and writes `1`
back into it to recover `L`.

This documents both meanings and replaces the vague "can be reconstructed from
`sparse(F.LD)` and `F.p` if needed" with the actual recipe. The snippet is
verified on a 200×200 problem: `diag(LD) == diag(F)`, `L` comes back as a
`SparseMatrixCSC`, and `L*D*L' == A[F.p, F.p]`.

Docstring change only — no behavior change. Two alternatives I did not take:

- **Renaming or aliasing the component.** `F.LD` as an operator is consistent
  with `PtL`/`UP`; only `sparse` exposes the packed form, and changing either
  would break code.
- **Making `sparse(F.LD)` return `L*D`.** As the reporter notes, `L` is
  unrecoverable from `L*D` when `D` has a zero diagonal entry, and
  `sparse(::Factor)` depends on the packed layout. The packed form is strictly
  more informative — it just needed documenting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8HenXTVrASo1sBZVGhpDQ