### PR TITLE
Document `fkeep!` in the manual

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -241,6 +241,7 @@ SparseArrays.nzrange
 SparseArrays.droptol!
 SparseArrays.dropzeros!
 SparseArrays.dropzeros
+SparseArrays.fkeep!
 SparseArrays.permute
 permute!{Tv, Ti, Tp <: Integer, Tq <: Integer}(::SparseMatrixCSC{Tv,Ti}, ::SparseMatrixCSC{Tv,Ti}, ::AbstractArray{Tp,1}, ::AbstractArray{Tq,1})
 SparseArrays.halfperm!


### PR DESCRIPTION
`fkeep!` is exported and has a docstring, but it was the only one of the 30 exports missing from the `@docs` blocks in `docs/src/index.md`, so it rendered nowhere. Added next to `dropzeros`, which is built on it.

Verified with a local docs build: it now renders on the API page.

This slipped through because `docs/make.jl` sets `warnonly = [:missing_docs, ...]`. I tried removing that so the check is enforced, but the build then fails on 59 docstrings that are on internal functions (`_checkargs_*_permute!`, `_distributevals_halfperm!`, CHOLMOD internals, `FixedSparseVector`, `ReadOnly`, ...) and are not listed in the manual. Making that check strict needs a separate decision on which of those should be documented as public and which should become plain comments, so this PR leaves it as is.

Note also that `test/sparsevector.jl` has a `@test_deprecated` on `fkeep!`, but that only covers the old `fkeep!(x, f)` argument order; the function itself is current, so documenting it is the right resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgBHUw9Hp7YW5ub29B4R5y
