### PR TITLE
CI: drop macOS Intel job, limit coverage and forced bounds checks to one job

### DIFF
--- a/.github/workflows/Whitespace.yml
+++ b/.github/workflows/Whitespace.yml
@@ -8,6 +8,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   whitespace:
     name: Check whitespace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           # Only one job runs with coverage instrumentation and forced bounds checking
           # (`--check-bounds=yes`). Both invalidate precompiled code, and the test suite
           # is 95%+ JIT time, so they multiply the wall time of every job they are on.
+          # The other jobs use `--check-bounds=auto` (Julia's default, matching the
+          # precompiled code); `no` would break the tests that expect a `BoundsError`.
           - os: ubuntu-latest
             julia-arch: x64
             coverage: true
@@ -48,7 +50,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           coverage: ${{ matrix.coverage == true }}
-          check_bounds: ${{ matrix.coverage == true && 'yes' || 'no' }}
+          check_bounds: ${{ matrix.coverage == true && 'yes' || 'auto' }}
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.coverage == true
       - uses: codecov/codecov-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
           - os: macOS-latest
             julia-arch: aarch64
             julia-version: 'nightly'
-          - os: macOS-15-intel
+          # Only one job runs with coverage instrumentation and forced bounds checking
+          # (`--check-bounds=yes`). Both invalidate precompiled code, and the test suite
+          # is 95%+ JIT time, so they multiply the wall time of every job they are on.
+          - os: ubuntu-latest
             julia-arch: x64
-            julia-version: 'nightly'
+            coverage: true
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -42,8 +45,13 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: ${{ matrix.coverage == true }}
+          check_bounds: ${{ matrix.coverage == true && 'yes' || 'no' }}
       - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.coverage == true
       - uses: codecov/codecov-action@v7
+        if: matrix.coverage == true
         with:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -78,6 +86,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: 'nightly'
+      - uses: julia-actions/cache@v3
       - name: Generate docs
         run: |
           julia --project --color=yes -e 'using Pkg; Pkg.activate("docs"); Pkg.develop(PackageSpec(path = pwd()))'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,20 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
+    name: test (${{ matrix.os }}, ${{ matrix.julia-arch }}, ${{ matrix.julia-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        julia-version:
-          - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest
         julia-arch:
           - x64
           - x86
+        julia-version:
+          - 'nightly'
         include:
           - os: macOS-latest
             julia-arch: aarch64
@@ -56,6 +57,7 @@ jobs:
           file: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
   aqua-test:
+    name: aqua-test (${{ matrix.os }}, ${{ matrix.julia-arch }}, ${{ matrix.julia-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
@@ -63,12 +65,12 @@ jobs:
       contents: read
     strategy:
       matrix:
-        julia-version:
-          - 'nightly'
         os:
           - ubuntu-latest
         julia-arch:
           - x64
+        julia-version:
+          - 'nightly'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
Cuts CI wall time from ~22 min to an estimated 6-8 min per run without dropping test coverage. Based on per-job timings from recent runs on `main` and local measurements on nightly.

**Drop the `macOS-15-intel` job.** It took ~22 min in every sampled run, against 7-11 min for all other jobs, so it was the sole critical path. It duplicates the x64 coverage the ubuntu job already provides, on a runner about 2.7x slower.

**Coverage and forced bounds checking on one job only.** `julia-actions/julia-runtest` defaults to `coverage: true` and `check_bounds: yes`, and the workflow passed neither option, so all six jobs ran with both. Both invalidate precompiled code, and the test files are 94-99% JIT time (measured with `Base.cumulative_compile_time_ns`), so they multiply the whole step:

| file | default | `--check-bounds=yes` |
|---|---|---|
| `sparsevector.jl` | 25 s | 107 s |
| `linalg.jl` | 85 s | 136 s |
| `higherorderfns.jl` | 44 s | 73 s |

The ubuntu x64 job keeps both, so the package's `@inbounds` use is still exercised under bounds checking and codecov still gets its upload. The other jobs run with `check_bounds: auto` (Julia's default, which matches the precompiled code) and skip the coverage upload, which was five redundant uploads of the same suite. `no` was tried first and is wrong on both counts: tests that expect a `BoundsError` fail and two workers segfaulted on macOS, and it forces recompilation just like `yes` because precompiled code is only reused when the flag matches (`sparsematrix_ops.jl`: 22 s under `auto`, 41 s under `no`).

**Small items.** The docs job now uses `julia-actions/cache`, and the whitespace workflow gets the same cancel-in-progress concurrency group as CI.

Follow-ups in separate PRs: splitting the two longest test files across runner workers, reducing type-loop breadth in `cholmod.jl` and `linalg.jl`, and shrinking the timing-guard tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgBHUw9Hp7YW5ub29B4R5y

