### PR TITLE
Add fast `sort!`/`sort` for `SparseMatrixCSC`

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1777,6 +1777,64 @@ function permute(A::AbstractSparseMatrixCSC{Tv,Ti}, p::AbstractVector{<:Integer}
     unchecked_noalias_permute!(X, A, p, q, C)
 end
 
+## Sorting
+
+#sorting TODO: integrate with `Base.Sort.IEEEFloatOptimization`'s partitioning by zero
+searchsortedfirst_discard_keywords(v::AbstractVector, x; lt=isless, by=identity,
+    rev::Union{Bool,Nothing}=nothing, order::Base.Order.Ordering=Forward, kws...) =
+        searchsortedfirst(v, x, Base.Order.ord(lt,by,rev,order))
+
+"""
+Sort the stored entries of each column of `A` in place, rewriting the row indices so that
+the values sorting before `zero(eltype(A))` end up at the top of their column and the
+remaining values at the bottom, with the structural zeros in between. `nnz(A)` and the
+column pointers are left untouched.
+"""
+function _sortcolumns!(A::AbstractSparseMatrixCSC; kws...)
+    require_one_based_indexing(A)
+    rows = rowvals(A)
+    vals = nonzeros(A)
+    m = size(A, 1)
+    z = zero(eltype(A))
+    for j in axes(A, 2)
+        r = nzrange(A, j)
+        isempty(r) && continue
+        col = view(vals, r)
+        sort!(col; kws...)
+        # `i-1` stored values sort before the structural zeros and `length(r)-i+1` after
+        i = searchsortedfirst_discard_keywords(col, z; kws...)
+        k = first(r)
+        @inbounds for t in 1:i-1
+            rows[k] = t
+            k += 1
+        end
+        @inbounds for t in (m - length(r) + i):m
+            rows[k] = t
+            k += 1
+        end
+    end
+    return A
+end
+
+function Base.sort!(A::AbstractSparseMatrixCSC; dims::Integer, kws...)
+    if dims == 1
+        _sortcolumns!(A; kws...)
+    elseif dims == 2
+        # the rows of `A` are the columns of `transpose(A)`, which is cheap to form and
+        # cheap to transpose back once its columns are sorted
+        At = ftranspose(A, identity)
+        _sortcolumns!(At; kws...)
+        transpose!(A, At)
+    else
+        throw(ArgumentError(lazy"dimension out of range, got dims = $dims, expected 1 or 2"))
+    end
+    return A
+end
+
+# the generic `Base.sort` for matrices goes through `permutedims`/`reshape` and does not
+# return a `SparseMatrixCSC` for `dims = 1`
+Base.sort(A::AbstractSparseMatrixCSC; kws...) = sort!(copy(A); kws...)
+
 ## fkeep! and children tril!, triu!, droptol!, dropzeros[!]
 
 function _fkeep!(f::F, A::AbstractSparseMatrixCSC) where F<:Function

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2272,10 +2272,8 @@ function _densifystarttolastnz!(x::SparseVector)
     x
 end
 
-#sorting TODO: integrate with `Base.Sort.IEEEFloatOptimization`'s partitioning by zero
-searchsortedfirst_discard_keywords(v::AbstractVector, x; lt=isless, by=identity,
-    rev::Union{Bool,Nothing}=nothing, order::Base.Order.Ordering=Forward, kws...) =
-        searchsortedfirst(v,x,Base.Order.ord(lt,by,rev,order))
+# `searchsortedfirst_discard_keywords` is defined alongside the sparse matrix sorting
+# methods in sparsematrix.jl
 function sort!(x::AbstractCompressedVector; kws...)
     nz = nonzeros(x)
     sort!(nz; kws...)

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -759,4 +759,59 @@ end
     @test isdiag(S)
 end
 
+@testset "sort/sort! of a sparse matrix" begin
+    # `sort` of a dense 0-dimension-along-`dims` matrix errors in Base, so those sizes are
+    # compared against the input itself rather than against a dense reference
+    @testset "size = ($m, $n), density = $d" for (m, n) in ((6, 5), (1, 1), (0, 3), (3, 0),
+                                                            (1, 9), (9, 1), (20, 13)),
+                                                 d in (0.0, 0.05, 0.3, 1.0)
+        A = sprand(m, n, d)
+        M = Matrix(A)
+        for dims in (1, 2), kws in ((;), (; rev=true), (; by=abs), (; by=x -> -x),
+                                    (; lt=(x, y) -> isless(y, x)),
+                                    (; alg=Base.DEFAULT_STABLE))
+            expected = (m == 0 || n == 0) ? M : sort(M; dims, kws...)
+            B = copy(A)
+            @test sort!(B; dims, kws...) === B
+            @test B isa SparseMatrixCSC
+            @test Matrix(B) == expected
+            # sorting only moves the stored entries around
+            @test nnz(B) == nnz(A)
+            S = sort(A; dims, kws...)
+            @test S isa SparseMatrixCSC
+            @test Matrix(S) == expected
+            @test A == sparse(M) # `sort` leaves its argument alone
+        end
+    end
+
+    @testset "index type $Ti" for Ti in (Int32, Int64)
+        A = SparseMatrixCSC{Float64,Ti}(sprand(11, 7, 0.4))
+        for dims in (1, 2)
+            @test sort(A; dims) isa SparseMatrixCSC{Float64,Ti}
+            @test Matrix(sort(A; dims)) == sort(Matrix(A); dims)
+        end
+    end
+
+    @testset "keyword arguments" begin
+        A = sprand(50, 50, 0.1)
+        # `scratch` is forwarded to the underlying `sort!` and ignored by the search for
+        # where the structural zeros belong (see #335)
+        @test Matrix(sort!(copy(A); dims=1, scratch=Vector{Float64}(undef, 50))) ==
+            sort(Matrix(A); dims=1)
+        @test_throws MethodError sort!(copy(A); dims=1, banana=:blue)
+        @test_throws ArgumentError sort!(copy(A); dims=3)
+        @test_throws ArgumentError sort!(copy(A); dims=0)
+        @test_throws UndefKeywordError sort!(copy(A))
+    end
+
+    @testset "stored zeros" begin
+        # column 1 stores an explicit zero next to structural zeros
+        A = SparseMatrixCSC(4, 2, [1, 3, 4], [1, 3, 2], [0.0, -1.0, 2.0])
+        for dims in (1, 2)
+            @test Matrix(sort(A; dims)) == sort(Matrix(A); dims)
+            @test nnz(sort(A; dims)) == nnz(A)
+        end
+    end
+end
+
 end # module

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -804,6 +804,44 @@ end
         @test_throws UndefKeywordError sort!(copy(A))
     end
 
+    @testset "empty and zero-size matrices" begin
+        # `Base.sort` on a zero-size *dense* matrix throws `ArgumentError: step cannot be
+        # zero`, so there is no dense reference to compare against here; the sparse methods
+        # just return the (empty) matrix unchanged
+        @testset "size = ($m, $n)" for (m, n) in ((0, 3), (3, 0), (0, 0))
+            A = spzeros(m, n)
+            for dims in (1, 2)
+                B = copy(A)
+                @test sort!(B; dims) === B
+                @test size(B) == (m, n)
+                @test nnz(B) == 0
+                @test B == A
+                S = sort(A; dims)
+                @test S isa SparseMatrixCSC{Float64,Int}
+                @test size(S) == (m, n)
+                @test nnz(S) == 0
+            end
+        end
+
+        # structurally empty, but not zero-size: here dense does give a reference
+        @testset "all structural zeros, size = ($m, $n)" for (m, n) in ((1, 1), (5, 4))
+            A = spzeros(m, n)
+            for dims in (1, 2)
+                B = sort!(copy(A); dims)
+                @test Matrix(B) == sort(Matrix(A); dims)
+                @test nnz(B) == 0
+                @test getcolptr(B) == getcolptr(A)
+            end
+        end
+
+        # a single column/row that is entirely structural next to a populated one
+        A = SparseMatrixCSC(4, 3, [1, 1, 5, 5], [1, 2, 3, 4], [1.0, -2.0, 0.0, 3.0])
+        for dims in (1, 2)
+            @test Matrix(sort(A; dims)) == sort(Matrix(A); dims)
+            @test nnz(sort(A; dims)) == nnz(A)
+        end
+    end
+
     @testset "stored zeros" begin
         # column 1 stores an explicit zero next to structural zeros
         A = SparseMatrixCSC(4, 2, [1, 3, 4], [1, 3, 2], [0.0, -1.0, 2.0])


### PR DESCRIPTION
Fixes #302 (the matrix half; #303 already covered vectors).

### The problem

There is no `sort!` method for `SparseMatrixCSC`, so `sort!(A; dims)` falls back to the generic `AbstractArray` path, which reads and writes slices through `getindex`/`setindex!`. That densifies the structure and is much slower than sorting the equivalent dense matrix — the benchmark from the issue:

```
dense          747.921 μs (3 allocations: 1.66 KiB)
sparse k=.03   3.763 ms (12 allocations: 249.07 KiB)
sparse k=.003  923.806 μs (14 allocations: 62.23 KiB)
dense          766.291 μs (4 allocations: 3.25 KiB)
sparse k=.03   976.657 μs (812 allocations: 196.37 KiB)
sparse k=.003  375.270 μs (808 allocations: 104.07 KiB)
```

### The fix

Sorting a column only permutes its stored entries. Under any ordering, all the structural zeros compare equal, so they stay contiguous: the stored values that sort before `zero(eltype(A))` end up at the top of the column, the rest at the bottom, and the zeros fill the gap. A column can therefore be sorted in place by sorting its stored values and rewriting its row indices — exactly the trick `sort!` already uses for sparse vectors in #303.

`dims = 1` does that directly. `dims = 2` sorts the columns of a transposed copy and transposes the result back, so it stays `O(nnz + m + n)` and reuses the existing `halfperm!` machinery.

Same benchmark after:

```
dense          751.151 μs (3 allocations: 1.66 KiB)
sparse k=.03   12.780 μs (2 allocations: 1.62 KiB)
sparse k=.003  1.511 μs (2 allocations: 1.62 KiB)
dense          763.242 μs (4 allocations: 3.25 KiB)
sparse k=.03   19.071 μs (10 allocations: 20.02 KiB)
sparse k=.003  4.110 μs (8 allocations: 4.62 KiB)
```

That is 294x / 612x for `dims = 1` and 51x / 91x for `dims = 2`, and sparse is now well ahead of dense rather than behind it.

### Two behaviour changes worth calling out

- `nnz` is preserved instead of growing. The old path stored the zeros it wrote into the slices, so `sort!` on a sparse matrix used to (partially) densify it, the same way the vector case did before #303.
- `sort(A; dims = 1)` now returns a `SparseMatrixCSC`. The generic fallback went through `A[:]`/`reshape` and returned a `Base.ReshapedArray{Float64, 2, SparseVector{Float64, Int64}, Tuple{}}`. `dims = 2` already returned a `SparseMatrixCSC` via `permutedims`.

`searchsortedfirst_discard_keywords` moved from `sparsevector.jl` to `sparsematrix.jl` (which is included first) since both sorting implementations use it; it is unchanged otherwise.

### Tests

Added a `sort/sort!` testset in `test/sparsematrix_ops.jl` covering both dims against dense references across sizes (including empty and single row/column), densities, and keyword combinations (`rev`, `by`, `lt`, `alg`, `scratch`), plus index-type preservation, `nnz` preservation, explicitly stored zeros, and the error paths for a bad or missing `dims`. `Aqua` reports the same ambiguity/piracy/unbound counts as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PddHRZV2UXjpTPRkoQoM8j
