### PR TITLE
Use the `parent()` accessor instead of the `.parent` field

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -37,9 +37,9 @@ end
 
 @inline _fix_size(A::Matrix, nrow, ncol) = _FixedSizeMatrix{'N'}(A.ref, nrow, ncol)
 @inline _fix_size(A::Transpose{<:Any,<:Matrix}, nrow, ncol) =
-    _FixedSizeMatrix{'T'}(A.parent.ref, nrow, ncol)
+    _FixedSizeMatrix{'T'}(parent(A).ref, nrow, ncol)
 @inline _fix_size(A::Adjoint{<:Any,<:Matrix}, nrow, ncol) =
-    _FixedSizeMatrix{'C'}(A.parent.ref, nrow, ncol)
+    _FixedSizeMatrix{'C'}(parent(A).ref, nrow, ncol)
 
 const tilebufsize = 10800  # Approximately 32k/3
 
@@ -2355,7 +2355,7 @@ end
 for (xformtype, xformop) in ((:Adjoint, :adjoint), (:Transpose, :transpose))
     @eval begin
         function \(xformA::($xformtype){<:Any,<:AbstractSparseMatrixCSC}, B::AbstractVecOrMat)
-            A = xformA.parent
+            A = parent(xformA)
             require_one_based_indexing(A, B)
             m, n = size(A)
             if m == n

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1891,9 +1891,9 @@ end
 (\)(L::Factor, B::SparseVector) = sparsevec(spsolve(CHOLMOD_A, L, Sparse(B)))
 
 # the eltype restriction is necessary for disambiguation with the B::StridedMatrix below
-\(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::Dense) = (L = adjL.parent; solve(CHOLMOD_A, L, B))
-\(adjL::AdjointFactorization{<:Any,<:Factor}, B::Sparse) = (L = adjL.parent; spsolve(CHOLMOD_A, L, B))
-\(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = adjL.parent; \(adjoint(L), Sparse(B)))
+\(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::Dense) = (L = parent(adjL); solve(CHOLMOD_A, L, B))
+\(adjL::AdjointFactorization{<:Any,<:Factor}, B::Sparse) = (L = parent(adjL); spsolve(CHOLMOD_A, L, B))
+\(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
 # Explicit typevars are necessary to avoid ambiguities with defs in LinearAlgebra/factorizations.jl
 # Likewise the two following explicit Vector and Matrix defs (rather than a single VecOrMat)
@@ -1902,11 +1902,11 @@ end
 (\)(adjL::AdjointFactorization{T,<:Factor}, B::Adjoint{<:Any,Matrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
 (\)(adjL::AdjointFactorization{T,<:Factor}, B::Transpose{<:Any,Matrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
 function \(adjL::AdjointFactorization{<:VTypes,<:Factor}, b::StridedVector)
-    L = adjL.parent
+    L = parent(adjL)
     return Vector(solve(CHOLMOD_A, L, Dense(b)))
 end
 function \(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedMatrix)
-    L = adjL.parent
+    L = parent(adjL)
     return Matrix(solve(CHOLMOD_A, L, Dense(B)))
 end
 (\)(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::AdjOrTransAbsMat) = adjL \ copy(B)

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -258,7 +258,7 @@ workspace_W_size(S::Union{UmfpackLU{<:AbstractFloat}, AbstractSparseMatrixCSC{<:
 workspace_W_size(S::Union{UmfpackLU{<:Complex}, AbstractSparseMatrixCSC{<:Complex}}, refinement::Bool) = refinement ? 10 * size(S, 2) : 4 * size(S, 2)
 
 const ATLU = Union{TransposeFactorization{<:Any, <:UmfpackLU}, AdjointFactorization{<:Any, <:UmfpackLU}}
-has_refinement(F::ATLU) = has_refinement(F.parent)
+has_refinement(F::ATLU) = has_refinement(parent(F))
 has_refinement(F::UmfpackLU) = has_refinement(F.control)
 has_refinement(control::AbstractVector) = control[JL_UMFPACK_IRSTEP] > 0
 
@@ -272,7 +272,7 @@ end
 UmfpackWS(F::UmfpackLU{Tv, Ti}, refinement::Bool=has_refinement(F)) where {Tv, Ti} = UmfpackWS(
         Vector{Ti}(undef, size(F, 2)),
         Vector{Float64}(undef, workspace_W_size(F, refinement)))
-UmfpackWS(F::ATLU, refinement::Bool=has_refinement(F)) = UmfpackWS(F.parent, refinement)
+UmfpackWS(F::ATLU, refinement::Bool=has_refinement(F)) = UmfpackWS(parent(F), refinement)
 
 # Not using similar helps if the actual needed size has changed as it would need to be resized again
 """
@@ -946,15 +946,15 @@ ldiv!(adjlu::AdjointFactorization{Float64,<:UmfpackLU{Float64}}, B::StridedVecOr
 ldiv!(X::StridedVecOrMat{T}, lu::UmfpackLU{T}, B::StridedVecOrMat{T}) where {T<:UMFVTypes} =
     _Aq_ldiv_B!(X, lu, B, UMFPACK_A)
 ldiv!(X::StridedVecOrMat{T}, translu::TransposeFactorization{T,<:UmfpackLU{T}}, B::StridedVecOrMat{T}) where {T<:UMFVTypes} =
-    (lu = translu.parent; _Aq_ldiv_B!(X, lu, B, UMFPACK_Aat))
+    (lu = parent(translu); _Aq_ldiv_B!(X, lu, B, UMFPACK_Aat))
 ldiv!(X::StridedVecOrMat{T}, adjlu::AdjointFactorization{T,<:UmfpackLU{T}}, B::StridedVecOrMat{T}) where {T<:UMFVTypes} =
-    (lu = adjlu.parent; _Aq_ldiv_B!(X, lu, B, UMFPACK_At))
+    (lu = parent(adjlu); _Aq_ldiv_B!(X, lu, B, UMFPACK_At))
 ldiv!(X::StridedVecOrMat{Tb}, lu::UmfpackLU{Float64}, B::StridedVecOrMat{Tb}) where {Tb<:Complex} =
     _Aq_ldiv_B!(X, lu, B, UMFPACK_A)
 ldiv!(X::StridedVecOrMat{Tb}, translu::TransposeFactorization{Float64,<:UmfpackLU{Float64}}, B::StridedVecOrMat{Tb}) where {Tb<:Complex} =
-    (lu = translu.parent; _Aq_ldiv_B!(X, lu, B, UMFPACK_Aat))
+    (lu = parent(translu); _Aq_ldiv_B!(X, lu, B, UMFPACK_Aat))
 ldiv!(X::StridedVecOrMat{Tb}, adjlu::AdjointFactorization{Float64,<:UmfpackLU{Float64}}, B::StridedVecOrMat{Tb}) where {Tb<:Complex} =
-    (lu = adjlu.parent; _Aq_ldiv_B!(X, lu, B, UMFPACK_At))
+    (lu = parent(adjlu); _Aq_ldiv_B!(X, lu, B, UMFPACK_At))
 
 function _Aq_ldiv_B!(X::StridedVecOrMat, lu::UmfpackLU, B::StridedVecOrMat, transposeoptype)
     if size(X, 2) != size(B, 2)

--- a/src/sparseconvert.jl
+++ b/src/sparseconvert.jl
@@ -119,7 +119,7 @@ _sparsem(A::SparseMatrixCSCSymmHerm) = _sparsem(A.uplo == 'U' ? nzrangeup : nzra
 _sparsem(A::UpperTriangular{T,<:AbstractSparseMatrix}) where T = triu(A.data)
 _sparsem(A::LowerTriangular{T,<:AbstractSparseMatrix}) where T = tril(A.data)
 # view of sparse matrix
-_sparsem(S::SubArray{<:Any,2,<:AbstractSparseMatrixCSC}) = getindex(S.parent,S.indices...)
+_sparsem(S::SubArray{<:Any,2,<:AbstractSparseMatrixCSC}) = getindex(parent(S),S.indices...)
 
 # 4 cases: (Symmetric|Hermitian) variants (:U|:L)
 function _sparsem(fnzrange::Function, sA::SparseMatrixCSCSymmHerm{Tv}) where {Tv}
@@ -219,7 +219,7 @@ end
 # 8 cases: (Transpose|Adjoint){Tv,[Unit](Upper|Lower)Triangular}
 function _sparsem(taA::AdjOrTrans{Tv,<:AbstractTriangularSparse}) where {Tv}
 
-    sA = taA.parent
+    sA = parent(taA)
     A = sA.data
     rowval = rowvals(A)
     nzval = nonzeros(A)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -254,7 +254,7 @@ julia> nonzeros(A)
 ```
 """
 nonzeros(S::SorF) = getfield(S, :nzval)
-nonzeros(S::SparseMatrixCSCColumnSubset)  = nonzeros(S.parent)
+nonzeros(S::SparseMatrixCSCColumnSubset)  = nonzeros(parent(S))
 nonzeros(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
 nonzeros(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
 
@@ -282,7 +282,7 @@ julia> rowvals(A)
 ```
 """
 rowvals(S::SorF) = getfield(S, :rowval)
-rowvals(S::SparseMatrixCSCColumnSubset) = rowvals(S.parent)
+rowvals(S::SparseMatrixCSCColumnSubset) = rowvals(parent(S))
 rowvals(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
 rowvals(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
 
@@ -309,7 +309,7 @@ of sparse array `A`. In conjunction with [`nonzeros`](@ref) and
     Adding or removing nonzero elements to the matrix may invalidate the `nzrange`, one should not mutate the matrix while iterating.
 """
 Base.@propagate_inbounds nzrange(S::AbstractSparseMatrixCSC, col::Integer) = getcolptr(S)[col]:(getcolptr(S)[col+1]-1)
-Base.@propagate_inbounds nzrange(S::SparseMatrixCSCColumnSubset, col::Integer) = nzrange(S.parent, S.indices[2][col])
+Base.@propagate_inbounds nzrange(S::SparseMatrixCSCColumnSubset, col::Integer) = nzrange(parent(S), S.indices[2][col])
 nzrange(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangeup(S.data, i)
 nzrange(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangelo(S.data, i)
 
@@ -380,7 +380,7 @@ end
 function Base.show(io::IO, _S::AbstractSparseMatrixCSCInclAdjointAndTranspose)
     _checkbuffers(_S)
     # can't use `findnz`, because that expects all values not to be #undef
-    S = _S isa Adjoint || _S isa Transpose ? _S.parent : _S
+    S = _S isa Adjoint || _S isa Transpose ? parent(_S) : _S
     I = rowvals(S)
     K = nonzeros(S)
     m, n = size(S)
@@ -1472,9 +1472,9 @@ end
 adjoint(A::AbstractSparseMatrixCSC) = Adjoint(A)
 transpose(A::AbstractSparseMatrixCSC) = Transpose(A)
 Base.copy(A::Adjoint{<:Any,<:AbstractSparseMatrixCSC}) =
-    ftranspose(A.parent, x -> adjoint(copy(x)), eltype(A))
+    ftranspose(parent(A), x -> adjoint(copy(x)), eltype(A))
 Base.copy(A::Transpose{<:Any,<:AbstractSparseMatrixCSC}) =
-    ftranspose(A.parent, x -> transpose(copy(x)), eltype(A))
+    ftranspose(parent(A), x -> transpose(copy(x)), eltype(A))
 function Base.permutedims(A::AbstractSparseMatrixCSC, (a,b))
     (a, b) == (2, 1) && return ftranspose(A, identity)
     (a, b) == (1, 2) && return copy(A)
@@ -3280,7 +3280,7 @@ function _insert!(v::Vector, pos::Integer, item, nz::Integer)
 end
 
 function Base.fill!(V::SubArray{Tv, <:Any, <:AbstractSparseMatrixCSC{Tv}, <:Tuple{Vararg{Union{Integer, AbstractVector{<:Integer}},2}}}, x) where Tv
-    A = V.parent
+    A = parent(V)
     I, J = V.indices
     if isempty(I) || isempty(J); return A; end
     # lt=≤ to check for strict sorting

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -117,7 +117,7 @@ function nnz(x::SparseColumnView)
     rowidx, colidx = parentindices(x)
     return length(@inbounds nzrange(parent(x), colidx))
 end
-nnz(x::SparseVectorView) = nnz(x.parent)
+nnz(x::SparseVectorView) = nnz(parent(x))
 nnz(x::SparseVectorPartialView) = length(nonzeroinds(x))
 
 """
@@ -684,9 +684,9 @@ function getindex(x::AbstractSparseMatrixCSC, I::AbstractUnitRange, j::Integer)
 end
 
 getindex(M::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, i::Integer, ::Colon) =
-    map!(wrapperop(M), M.parent[:,i])
+    map!(wrapperop(M), parent(M)[:,i])
 getindex(M::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, i::AbstractVector, ::Colon) =
-    copy(wrapperop(M)(M.parent[:,i]))
+    copy(wrapperop(M)(parent(M)[:,i]))
 
 # In the general case, we piggy back upon SparseMatrixCSC's optimized solution
 @inline getindex(A::AbstractSparseMatrixCSC, I::AbstractVector, J::Integer) =
@@ -854,7 +854,7 @@ function getindex(A::AbstractSparseMatrixCSC{Tv,Ti}, I::AbstractVector) where {T
     return @if_move_fixed A SparseVector(n, rowvalB, nzvalB)
 end
 
-Base.copy(a::SubArray{<:Any,<:Any,<:Union{SparseVector, AbstractSparseMatrixCSC}}) = a.parent[a.indices...]
+Base.copy(a::SubArray{<:Any,<:Any,<:Union{SparseVector, AbstractSparseMatrixCSC}}) = parent(a)[a.indices...]
 
 function findall(x::SparseVectorUnion)
     return findall(identity, x)
@@ -2114,7 +2114,7 @@ function *(A::AbstractSparseMatrixCSC, x::AbstractSparseVector)
 end
 
 *(xA::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, x::AbstractSparseVector) =
-    _At_or_Ac_mul_B((a,b) -> wrapperop(xA)(a) * b, xA.parent, x, promote_op(matprod, eltype(xA), eltype(x)))
+    _At_or_Ac_mul_B((a,b) -> wrapperop(xA)(a) * b, parent(xA), x, promote_op(matprod, eltype(xA), eltype(x)))
 
 function _At_or_Ac_mul_B(tfun::Function, A::AbstractSparseMatrixCSC{TvA,TiA}, x::AbstractSparseVector{TvX,TiX},
                          Tv = promote_op(matprod, TvA, TvX)) where {TvA,TiA,TvX,TiX}

--- a/test/simplesmatrix.jl
+++ b/test/simplesmatrix.jl
@@ -11,34 +11,34 @@ Base.:*(a::SimpleSMatrix{N,O}, b::SimpleSMatrix{O,M}) where {N,O,M} =
     SimpleSMatrix{N,M}(a.m * b.m)
 
 Base.:*(a::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix{O,N}}, b::SimpleSMatrix{O,M}) where {N,O,M} =
-    SimpleSMatrix{N,M}(adjoint(a.parent.m) * b.m)
+    SimpleSMatrix{N,M}(adjoint(parent(a).m) * b.m)
 
 Base.:*(a::SimpleSMatrix{N,O}, b::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix{M,O}}) where {N,O,M} =
-    SimpleSMatrix{N,M}(a.m * adjoint(b.parent.m))
+    SimpleSMatrix{N,M}(a.m * adjoint(parent(b).m))
 
 Base.:+(a::SimpleSMatrix{N,M}, b::SimpleSMatrix{N,M}) where {N,M} =
     SimpleSMatrix{N,M}(a.m + b.m)
 
 Base.:+(a::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix{M,N}}, b::SimpleSMatrix{N,M}) where {N,M} =
-    SimpleSMatrix{N,M}(adjoint(a.parent.m) + b.m)
+    SimpleSMatrix{N,M}(adjoint(parent(a).m) + b.m)
 
 Base.:+(a::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix}, b::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix}) =
     (a' + b')'
 
 Base.:+(a::SimpleSMatrix{N,M}, b::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix{M,N}}) where {N,M} =
-    SimpleSMatrix{N,M}(a.m + adjoint(b.parent.m))
+    SimpleSMatrix{N,M}(a.m + adjoint(parent(b).m))
 
 Base.:-(a::SimpleSMatrix{N,M}, b::SimpleSMatrix{N,M}) where {N,M} =
     SimpleSMatrix{N,M}(a.m - b.m)
 
 Base.:-(a::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix{M,N}}, b::SimpleSMatrix{N,M}) where {N,M} =
-    SimpleSMatrix{N,M}(adjoint(a.parent.m) - b.m)
+    SimpleSMatrix{N,M}(adjoint(parent(a).m) - b.m)
 
 Base.:-(a::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix}, b::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix}) =
     (a' - b')'
 
 Base.:-(a::SimpleSMatrix{N,M}, b::LinearAlgebra.Adjoint{<:Any, <:SimpleSMatrix{M,N}}) where {N,M} =
-    SimpleSMatrix{N,M}(a.m - adjoint(b.parent.m))
+    SimpleSMatrix{N,M}(a.m - adjoint(parent(b).m))
 
 Base.size(a::SimpleSMatrix{N,M}) where {N,M} = (N, M)
 


### PR DESCRIPTION
Follow-up to #772, which switched one `t.parent` to `parent(t)` in `higherorderfns.jl`. This does the same for the remaining 28 field accesses in `src/` and the 6 in `test/simplesmatrix.jl`.

Every wrapper the package unwraps this way defines `Base.parent`: `SubArray`, `Adjoint`, `Transpose`, `AdjointFactorization` and `TransposeFactorization`. Going through the accessor is the supported interface and would keep working if a wrapper ever renamed its field. The one `.parent` left in `src/` is the `getfield(x, :parent)` that implements `parent` for `ReadOnly`.

Mechanical rename, no behaviour change. `sparsevector`, `sparsematrix_ops`, `sparsematrix_constructors_indexing`, `linalg`, `linalg_solvers`, `cholmod` and `umfpack` test files pass on nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BA2YkbzRZcTbTrc3S8odn