### PR TITLE
Trim redundant sparse test cases

### DIFF
--- a/test/cholmod_ops.jl
+++ b/test/cholmod_ops.jl
@@ -685,7 +685,7 @@ end
     @test issparse(F \ Bts')
 end
 
-@testset "getindex with unsorted or unpacked buffers (#758), Ti = $Ti" for Ti ∈ itypes
+@testset "getindex with unsorted or unpacked buffers (#758), Ti = $Ti" begin
     # the product of two matrices with sorted row indices need not be sorted
     A = sparse(Ti[2, 1, 2], Ti[1, 2, 2], Tv[1, 2, 3])
     S = CHOLMOD.Sparse(A)

--- a/test/linalg_products.jl
+++ b/test/linalg_products.jl
@@ -99,7 +99,7 @@ end
         S = _sparse_test_matrix(n, T1)
         MS = Matrix(S)
         for T2 in (Int, Float64, ComplexF32)
-            for TM in (LowerTriangular, UnitLowerTriangular, UpperTriangular, UnitLowerTriangular)
+            for TM in (LowerTriangular, UnitLowerTriangular, UpperTriangular, UnitUpperTriangular)
                 T = _triangular_test_matrix(n, TM, T2)
                 MT = Matrix(T)
                 @test isa(T * S, DenseMatrix)

--- a/test/sparsematrix_ops.jl
+++ b/test/sparsematrix_ops.jl
@@ -664,8 +664,10 @@ Base.isequal(x::Counting, y::Counting) = (stepcounter(); isequal(x.elt, y.elt))
 end
 
 @testset "Comparisons to adjoints are efficient" for
-    A in Any[sparse(1*I(10000)), sprandn(10000, 10000, 0.00001), sprandn(ComplexF64, 100, 100, 0.9)],
-    B in Any[sparse(1*I(10000)), sprandn(10000, 10000, 0.00001), sprandn(ComplexF64, 100, 100, 0.9)]
+    # The counting guard below distinguishes stored-entry traversal from the generic
+    # length(A) fallback, so these do not need to be large matrices.
+    A in Any[sparse(1*I(100)), sprandn(100, 100, 0.1), sprandn(ComplexF64, 100, 100, 0.9)],
+    B in Any[sparse(1*I(100)), sprandn(100, 100, 0.1), sprandn(ComplexF64, 100, 100, 0.9)]
     if size(A) == size(B)
         A = Counting.(A)
         B = Counting.(B)

--- a/test/umfpack.jl
+++ b/test/umfpack.jl
@@ -532,12 +532,10 @@ end
 end
 
 
-for Ti in Base.uniontypes(UMFPACK.UMFITypes)
-    A = I + sprandn(100, 100, 0.01)
-    Af = lu(A)
-    UMFPACK.umfpack_report_numeric(Af, 0)
-    UMFPACK.umfpack_report_symbolic(Af, 0)
-end
+A = I + sprandn(100, 100, 0.01)
+Af = lu(A)
+UMFPACK.umfpack_report_numeric(Af, 0)
+UMFPACK.umfpack_report_symbolic(Af, 0)
 
 end # Base.USE_GPL_LIBS
 


### PR DESCRIPTION
This removes redundant test work while preserving coverage:

- avoid repeating the CHOLMOD unsorted/unpacked-buffer test for each outer index type
- replace a duplicate `UnitLowerTriangular` case with `UnitUpperTriangular`
- remove an unused UMFPACK index-type loop
- use small matrices for the operation-counted adjoint-comparison guard

The sort test grid is intentionally untouched.

PR made by Codex