### PR TITLE
Document issparse guarantees

### DIFF
--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -50,9 +50,11 @@ Returns `true` if `S` is sparse or wraps a sparse array, and `false` otherwise.
 `issparse` is a classification predicate. A `true` result does not guarantee
 support for a particular `SparseArrays` operation (such as `nnz`, `nonzeros`,
 or `findnz`), a particular sparse storage format, or that `sparse(S)` is an
-identity or efficient operation. Code requiring a particular sparse interface
-should dispatch on the relevant abstract type or operation instead of branching
-on `issparse`.
+identity or efficient operation. Likewise, `false` means that `S` is not recognized
+as sparse by `SparseArrays`, not that it is dense: an array type that does not
+subtype `AbstractSparseArray` or wrap one yields `false` regardless of its storage.
+Code requiring a particular sparse interface should dispatch on the relevant
+abstract type or operation instead of branching on `issparse`.
 
 # Examples
 ```jldoctest

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -45,7 +45,14 @@ abstract type AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv
 """
     issparse(S)
 
-Returns `true` if `S` is sparse, and `false` otherwise.
+Returns `true` if `S` is sparse or wraps a sparse array, and `false` otherwise.
+
+`issparse` is a classification predicate. A `true` result does not guarantee
+support for a particular `SparseArrays` operation (such as `nnz`, `nonzeros`,
+or `findnz`), a particular sparse storage format, or that `sparse(S)` is an
+identity or efficient operation. Code requiring a particular sparse interface
+should dispatch on the relevant abstract type or operation instead of branching
+on `issparse`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Closes #419.

Clarify that `issparse` classifies sparse storage/wrappers, rather than establishing an API, storage-format, identity, or performance contract.

Coded up by Codex.