### PR TITLE
Convert concatenation inputs directly to sparse types

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1144,6 +1144,21 @@ function SparseMatrixCSC{Tv,Ti}(A::Sparse{Tv, Ti}) where {Tv, Ti<:ITypes}
 end
 SparseMatrixCSC(A::Sparse{Tv, Ti}) where {Tv, Ti} = SparseMatrixCSC{Tv, Ti}(A)
 
+# Wrap the CHOLMOD buffer as a strided `Array` so that the fast `StridedMatrix`
+# constructor is used, instead of reading every entry through the slow
+# bounds-checked `getindex` on `Dense`.
+SparseMatrixCSC(D::Dense{Tv}) where {Tv} = SparseMatrixCSC{Tv, Int}(D)
+SparseMatrixCSC{Tv}(D::Dense) where {Tv} = SparseMatrixCSC{Tv, Int}(D)
+function SparseMatrixCSC{Tv, Ti}(D::Dense{Td}) where {Tv, Ti, Td}
+    s = unsafe_load(pointer(D))
+    nrow, ncol, d = Int(s.nrow), Int(s.ncol), Int(s.d)
+    GC.@preserve D begin
+        buf = unsafe_wrap(Array, Ptr{Td}(s.x), (d, ncol); own = false)
+        M = d == nrow ? buf : view(buf, 1:nrow, :)
+        return SparseMatrixCSC{Tv, Ti}(M)
+    end
+end
+
 function Symmetric{Tv,SparseMatrixCSC{Tv,Ti}}(A::Sparse{Tv, Ti}) where {Tv<:VRealTypes, Ti<:ITypes}
     s = unsafe_load(typedpointer(A))
     issymmetric(A) || throw(ArgumentError("matrix is not symmetric"))
@@ -1205,7 +1220,7 @@ function sparse(F::Factor)
     A
 end
 
-sparse(D::Dense) = sparse(Sparse(D))
+sparse(D::Dense) = SparseMatrixCSC(D)
 
 function sparse(FC::FactorComponent{Tv,:L}) where Tv
     F = Factor(FC)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -1271,8 +1271,8 @@ end
 _sparse(x::Number) = sparsevec([1], [x], 1)
 _sparse(A) = _makesparse(A)
 _makesparse(x::Number) = x
-_makesparse(x::AbstractVector) = convert(SparseVector, issparse(x) ? x : sparse(x))::SparseVector
-_makesparse(x::AbstractMatrix) = convert(SparseMatrixCSC, issparse(x) ? x : sparse(x))::SparseMatrixCSC
+_makesparse(x::AbstractVector) = convert(SparseVector, x)::SparseVector
+_makesparse(x::AbstractMatrix) = convert(SparseMatrixCSC, x)::SparseMatrixCSC
 anysparse() = false
 anysparse(X) = X isa AbstractArray && issparse(X)
 anysparse(X, Xs...) = anysparse(X) || anysparse(Xs...)

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -439,9 +439,23 @@ end
     @test CHOLMOD.norm_dense(bDense, 2) ≈ norm(b)
     @test CHOLMOD.check_dense(bDense)
 
+    # Conversion of Dense to SparseMatrixCSC (used by sparse concatenation)
+    S = sparse(A)
+    @test SparseMatrixCSC(ADense) isa SparseMatrixCSC{elty, Int}
+    @test SparseMatrixCSC(ADense) == S
+    @test SparseMatrixCSC{elty}(ADense) == S
+    @test SparseMatrixCSC{elty, Int32}(ADense) isa SparseMatrixCSC{elty, Int32}
+    @test SparseMatrixCSC{elty, Int32}(ADense) == S
+    @test convert(SparseMatrixCSC, ADense) == S
+    @test sparse(ADense) == S
+    @test hcat(S, ADense) isa SparseMatrixCSC
+    @test hcat(S, ADense) == [A A]
+    @test vcat(ADense, S) == [A; A]
+
     AA = CHOLMOD.eye(3, Tv)
     unsafe_store!(convert(Ptr{Csize_t}, pointer(AA)), 2, 1) # change size, but not stride, of Dense
     @test convert(Matrix, AA) == Matrix(I, 2, 3)
+    @test SparseMatrixCSC(AA) == sparse(I, 2, 3) # stride differs from nrow
 end
 
 @testset "Low level interface" begin

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -439,23 +439,14 @@ end
     @test CHOLMOD.norm_dense(bDense, 2) ≈ norm(b)
     @test CHOLMOD.check_dense(bDense)
 
-    # Conversion of Dense to SparseMatrixCSC (used by sparse concatenation)
     S = sparse(A)
-    @test SparseMatrixCSC(ADense) isa SparseMatrixCSC{elty, Int}
-    @test SparseMatrixCSC(ADense) == S
-    @test SparseMatrixCSC{elty}(ADense) == S
-    @test SparseMatrixCSC{elty, Int32}(ADense) isa SparseMatrixCSC{elty, Int32}
-    @test SparseMatrixCSC{elty, Int32}(ADense) == S
-    @test convert(SparseMatrixCSC, ADense) == S
-    @test sparse(ADense) == S
-    @test hcat(S, ADense) isa SparseMatrixCSC
-    @test hcat(S, ADense) == [A A]
-    @test vcat(ADense, S) == [A; A]
+    @test SparseMatrixCSC(ADense)::SparseMatrixCSC{elty, Int} == S
+    @test SparseMatrixCSC{elty}(ADense)::SparseMatrixCSC{elty, Int} == S
+    @test SparseMatrixCSC{elty, Int32}(ADense)::SparseMatrixCSC{elty, Int32} == S
 
     AA = CHOLMOD.eye(3, Tv)
     unsafe_store!(convert(Ptr{Csize_t}, pointer(AA)), 2, 1) # change size, but not stride, of Dense
     @test convert(Matrix, AA) == Matrix(I, 2, 3)
-    @test SparseMatrixCSC(AA) == sparse(I, 2, 3) # stride differs from nrow
 end
 
 @testset "Low level interface" begin


### PR DESCRIPTION
Related to #419.

When sparse concatenation has been selected, convert inputs directly to the destination `SparseVector` or `SparseMatrixCSC`. This leaves `issparse` responsible only for selecting sparse output, and avoids treating it as a guarantee about `sparse(A)`.

Coded up by Codex and Claude.