### PR TITLE
Initialize SPQR output pointers and free sibling outputs if wrapping one fails

### DIFF
--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -158,6 +158,13 @@ end
 _default_tol(A::AbstractSparseMatrixCSC) =
     20*sum(size(A))*eps()*maximum(norm(view(A, :, i)) for i in axes(A, 2))
 
+# Return the pointer held by `r` and clear `r`, transferring ownership to the caller.
+function _take!(r::Ref{Ptr{T}}) where T
+    p = r[]
+    r[] = C_NULL
+    return p
+end
+
 """
     qr(A::SparseMatrixCSC; tol=_default_tol(A), ordering=ORDERING_DEFAULT) -> QRSparse
 
@@ -208,13 +215,6 @@ Column permutation:
 
 [^ACM933]: Foster, L. V., & Davis, T. A. (2013). Algorithm 933: Reliable Calculation of Numerical Rank, Null Space Bases, Pseudoinverse Solutions, and Basic Solutions Using SuitesparseQR. ACM Trans. Math. Softw., 40(1). [doi:10.1145/2513109.2513116](https://doi.org/10.1145/2513109.2513116)
 """
-# Return the pointer held by `r` and clear `r`, transferring ownership to the caller.
-function _take!(r::Ref{Ptr{T}}) where T
-    p = r[]
-    r[] = C_NULL
-    return p
-end
-
 function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Ti<:CHOLMOD.ITypes, Tv<:Union{Float64, ComplexF64}}
     # Initialize all output pointers to NULL so that the frees below never
     # see garbage if SPQR returns without writing one of them.

--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -208,11 +208,20 @@ Column permutation:
 
 [^ACM933]: Foster, L. V., & Davis, T. A. (2013). Algorithm 933: Reliable Calculation of Numerical Rank, Null Space Bases, Pseudoinverse Solutions, and Basic Solutions Using SuitesparseQR. ACM Trans. Math. Softw., 40(1). [doi:10.1145/2513109.2513116](https://doi.org/10.1145/2513109.2513116)
 """
+# Return the pointer held by `r` and clear `r`, transferring ownership to the caller.
+function _take!(r::Ref{Ptr{T}}) where T
+    p = r[]
+    r[] = C_NULL
+    return p
+end
+
 function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Ti<:CHOLMOD.ITypes, Tv<:Union{Float64, ComplexF64}}
-    R     = Ref{Ptr{CHOLMOD.cholmod_sparse}}()
-    E     = Ref{Ptr{Ti}}()
-    H     = Ref{Ptr{CHOLMOD.cholmod_sparse}}()
-    HPinv = Ref{Ptr{Ti}}()
+    # Initialize all output pointers to NULL so that the frees below never
+    # see garbage if SPQR returns without writing one of them.
+    R     = Ref{Ptr{CHOLMOD.cholmod_sparse}}(C_NULL)
+    E     = Ref{Ptr{Ti}}(C_NULL)
+    H     = Ref{Ptr{CHOLMOD.cholmod_sparse}}(C_NULL)
+    HPinv = Ref{Ptr{Ti}}(C_NULL)
     HTau  = Ref{Ptr{CHOLMOD.cholmod_dense}}(C_NULL)
 
     # SPQR doesn't accept symmetric matrices so we explicitly set the stype
@@ -220,9 +229,22 @@ function LinearAlgebra.qr(A::SparseMatrixCSC{Tv, Ti}; tol=_default_tol(A), order
         C_NULL, C_NULL, C_NULL, C_NULL,
         R, E, H, HPinv, HTau)
 
-    R_ = SparseMatrixCSC{Tv, Ti}(Sparse{Tv, Ti}(R[]))
-    factors = SparseMatrixCSC{Tv, Ti}(Sparse{Tv, Ti}(H[]))
-    τ = vec(Array{Tv}(CHOLMOD.Dense{Tv}(HTau[])))
+    # Wrap the C-allocated outputs. Each wrapper constructor frees its own
+    # pointer if it throws (or owns it via a finalizer once constructed), but
+    # the siblings that have not been wrapped yet would leak, so hand each
+    # pointer over by clearing its Ref first and free whatever is still held
+    # in a Ref before rethrowing.
+    local R_, factors, τ
+    try
+        R_ = SparseMatrixCSC{Tv, Ti}(Sparse{Tv, Ti}(_take!(R)))
+        factors = SparseMatrixCSC{Tv, Ti}(Sparse{Tv, Ti}(_take!(H)))
+        τ = vec(Array{Tv}(CHOLMOD.Dense{Tv}(_take!(HTau))))
+    catch
+        R[] != C_NULL && free!(R[], Ti)
+        H[] != C_NULL && free!(H[], Ti)
+        HTau[] != C_NULL && free!(HTau[])
+        rethrow()
+    end
     R = SparseMatrixCSC{Tv, Ti}(min(size(A)...),
                                 size(R_, 2),
                                 getcolptr(R_),


### PR DESCRIPTION
## Problem

`SuiteSparseQR_C`/`SuiteSparseQR_i_C` return several C-allocated outputs through `Ref{Ptr}` arguments: `R`, `E`, `H`, `HPinv`, `HTau`.

1. In `qr` (src/solvers/spqr.jl), the Refs `R`, `E`, `H`, `HPinv` were created uninitialized (`Ref{Ptr{...}}()`); only `HTau` was initialized to `C_NULL`. If SPQR ever returned without writing one of them, `_qr!` would pass a garbage pointer to `cholmod_(l_)free` for `E`/`HPinv`, and `qr` would hand garbage to the wrapper constructors.
2. `qr` wrapped the remaining outputs one at a time: `Sparse{Tv,Ti}(R[])`, then `Sparse{Tv,Ti}(H[])`, then `CHOLMOD.Dense{Tv}(HTau[])`. Each wrapper's inner constructor frees *its own* pointer if it throws on an itype/xtype/dtype mismatch (or on a NULL pointer), but nothing freed the siblings that had not been wrapped yet.

## Fix

- Initialize all five output Refs to `C_NULL`.
- Wrap `R`, `H`, `HTau` inside a `try`/`catch`. Each pointer is taken out of its Ref (and the Ref cleared) as it is handed to its wrapper, so the wrapper exclusively owns it from that point; on an exception, any pointer still held in a Ref is freed with `CHOLMOD.free!` (the `(Ptr{cholmod_sparse}, Ti)` and `Ptr{cholmod_dense}` variants, already imported into `SPQR`) before rethrowing. Clearing the Ref before wrapping avoids a double free, since a throwing wrapper constructor has already freed its pointer.

The existing frees for `E` and `HPinv` in `_qr!` were reviewed and left as is: they skip NULL, use the right element counts (`n` and `m`), and pick `cholmod_l_free` vs `cholmod_free` by `Ti`.

In practice SPQR returns objects with matching itype/xtype/dtype, so this is defensive hygiene rather than a fix for an observed failure. No behavior change on the success path.

## Tests

No new tests: `test/spqr.jl` already runs `qr` for `Int32`/`Int64` index types with `Float64`/`ComplexF64` element types (the `"element type of A"` testset), which exercises the rewritten wrapping path.

- `julia +nightly --project=. ... include("test/spqr.jl")`: 191/191 pass
- `detect_ambiguities(SparseArrays; recursive=true)` is empty
- `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165HDwaDQ5gFi8dfiWdj7Bu
