### PR TITLE
Null the pointer in `free!` on CHOLMOD wrapper objects to prevent double free

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1231,12 +1231,36 @@ function change_stype!(A::Sparse, i::Integer)
     return A
 end
 
-free!(A::Dense)  = free!(pointer(A))
-free!(A::Sparse{<:Any, Ti}) where Ti = free!(pointer(A), Ti)
+# The object-level `free!` methods release the CHOLMOD memory and null the
+# wrapper's pointer so that a subsequent `free!` (in particular the finalizer
+# registered in the inner constructor) is a no-op instead of a double free.
+# They return `true` if memory was released and `false` if there was nothing
+# to release (the pointer was already null).
+function free!(A::Dense)
+    p = getfield(A, :ptr)
+    p == C_NULL && return false
+    setfield!(A, :ptr, Ptr{cholmod_dense}(C_NULL))
+    return free!(p)
+end
+function free!(A::Sparse{<:Any, Ti}) where Ti
+    p = getfield(A, :ptr)
+    p == C_NULL && return false
+    setfield!(A, :ptr, Ptr{cholmod_sparse}(C_NULL))
+    return free!(p, Ti)
+end
 function free!(F::Factor{<:Any, Ti}) where Ti
-    free!(getfield(F, :Y)[])
-    free!(getfield(F, :E)[])
-    free!(pointer(F), Ti)
+    # Release the Y/E scratch buffers used by `solve!` and null the handles so
+    # that a later `ldiv!` allocates fresh ones instead of reusing freed memory.
+    Y = getfield(F, :Y)
+    E = getfield(F, :E)
+    y, e = Y[], E[]
+    Y[] = E[] = Ptr{cholmod_dense_struct}(C_NULL)
+    y == C_NULL || free!(y)
+    e == C_NULL || free!(e)
+    p = getfield(F, :ptr)
+    p == C_NULL && return false
+    setfield!(F, :ptr, Ptr{cholmod_factor}(C_NULL))
+    return free!(p, Ti)
 end
 
 nnz(F::Factor) = nnz(Sparse(F))

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -265,6 +265,38 @@ end
     p = Ti == Int64 ? cholmod_l_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD.xdtyp(Tv), getcommon(Ti)) :
         cholmod_allocate_sparse(1, 1, 1, true, true, 0, CHOLMOD.xdtyp(Tv), getcommon(Ti))
     @test CHOLMOD.free!(p, Ti)
+
+    # Object-level free! must null the wrapper's pointer so that a second
+    # free! (and the finalizer) is a no-op rather than a double free.
+    D = CHOLMOD.Dense(rand(Tv, 3))
+    @test CHOLMOD.free!(D)
+    @test getfield(D, :ptr) == C_NULL
+    @test_throws ArgumentError pointer(D)
+    @test !CHOLMOD.free!(D)
+
+    S = CHOLMOD.Sparse(convert(SparseMatrixCSC{Tv,Ti}, sparse(I, 3, 3)))
+    @test CHOLMOD.free!(S)
+    @test getfield(S, :ptr) == C_NULL
+    @test_throws ArgumentError pointer(S)
+    @test !CHOLMOD.free!(S)
+
+    # A Factor that has been used in ldiv! owns Y/E scratch buffers; free! must
+    # release them and null the handles as well as the factor pointer.
+    A = convert(SparseMatrixCSC{Tv,Ti}, sparse(Tv[4 1 0; 1 4 1; 0 1 4]))
+    F = cholesky(A)
+    b = fill(Tv(1), 3)
+    ldiv!(similar(b), F, b)
+    # cholmod_solve2 always allocates Y; E is only allocated when needed.
+    @test getfield(F, :Y)[] != C_NULL
+    @test CHOLMOD.free!(F)
+    @test getfield(F, :ptr) == C_NULL
+    @test getfield(F, :Y)[] == C_NULL
+    @test getfield(F, :E)[] == C_NULL
+    @test_throws ArgumentError pointer(F)
+    @test !CHOLMOD.free!(F)
+
+    D = S = F = nothing
+    GC.gc()
 end
 
 @testset "Check common is still in default state" begin


### PR DESCRIPTION
## Bug

The object-level `free!(::Dense)`, `free!(::Sparse)` and `free!(::Factor)` methods in `src/solvers/cholmod.jl` passed a temporary `Ref(pointer(x))` to `cholmod_(l_)free_*`. CHOLMOD nulls the temporary, but the wrapper's `ptr` field kept its stale address, so the finalizer registered in the inner constructor freed the same block a second time:

```julia
D = CHOLMOD.Dense(rand(3)); CHOLMOD.free!(D)   # process exit aborts with SIGABRT
```

For `Factor`, `free!` also released the Y/E scratch buffers used by `solve!` but left the `Ref`s dangling, so a later `ldiv!` would hand CHOLMOD freed handles.

## Fix

- The object-level `free!` methods now read `getfield(x, :ptr)` (so they never throw on a null pointer), return `false` as a no-op if the pointer is already null, and otherwise null the `ptr` field before releasing the memory and return the C result. Calling `free!` twice, or letting the finalizer run after an explicit `free!`, is now safe.
- `free!(::Factor)` nulls the Y/E handles before freeing them, so a subsequent `ldiv!` allocates fresh buffers.
- `pointer(x)` on a freed object throws the existing `ArgumentError` from `unsafe_convert`.
- The raw-pointer `free!(::Ptr, ...)` methods are unchanged for direct callers (`spqr.jl` imports `free!` but does not use it).

## Tests

Extended the `test free! $Ti` testset in `test/cholmod.jl`: `free!` twice on a `Dense`, `Sparse`, and a `Factor` that has been through `ldiv!` (so Y is allocated); checks that `ptr` and the Y/E refs are null afterwards, that `pointer(x)` throws `ArgumentError`, that the second `free!` returns `false`, and that `GC.gc()` afterwards does not crash.

Ran on Julia nightly: `test/cholmod.jl` (all pass), `test/spqr.jl` (191/191), `detect_ambiguities(SparseArrays; recursive=true)` is empty, and the original repro now exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165HDwaDQ5gFi8dfiWdj7Bu
