### PR TITLE
CI: run threads tests on Windows in GitHub Actions

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,6 @@
 
 using Test, LinearAlgebra, SparseArrays
 
-include("util/gha.jl")
-
 testfiles = ["allowscalar.jl", "fixed.jl", "higherorderfns.jl",
              "sparsematrix_constructors_indexing.jl", "sparsematrix_ops.jl",
              "sparsevector.jl", "issues.jl"]
@@ -11,11 +9,7 @@ testfiles = ["allowscalar.jl", "fixed.jl", "higherorderfns.jl",
 if Base.USE_GPL_LIBS
     append!(testfiles, ["cholmod.jl", "cholmod_ops.jl", "umfpack.jl", "spqr.jl",
                         "linalg.jl", "linalg_products.jl", "linalg_solvers.jl"])
-    if Sys.iswindows() && is_github_actions_ci()
-        @warn "Skipping `threads` tests on Windows on GitHub Actions CI"
-    else
-        push!(testfiles, "threads_suite.jl")
-    end
+    push!(testfiles, "threads_suite.jl")
 end
 
 # ParallelTestRunner comes from the Pkg.test target; Julia base CI runs this

--- a/test/util/gha.jl
+++ b/test/util/gha.jl
@@ -1,6 +1,0 @@
-function is_github_actions_ci()
-    is_ci  = parse(Bool, get(ENV, "CI",             "false"))
-    is_gha = parse(Bool, get(ENV, "GITHUB_ACTIONS", "false"))
-
-    return is_ci && is_gha
-end


### PR DESCRIPTION
Ref #531

#530 skipped the SuiteSparse `threads` tests on Windows under GitHub Actions on the assumption that Windows Buildkite CI would still run them. This repo no longer has Buildkite CI, so Windows threading has had no coverage since then.

This PR removes the skip and the `test/util/gha.jl` helper so the Windows x64 and x86 jobs run `threads_suite.jl` again. The point is to find out whether the original failure still reproduces on current Julia nightly, now that the test layout has changed (#658, #739) and ParallelTestRunner already runs every test file in a subprocess with piped stdio on all platforms.

- If Windows CI is green, this can be merged and #531 closed.
- If it still fails, the next thing to try is changing `threads_suite.jl` to capture the spawned child's output (e.g. `read(cmd, String)`) rather than passing the parent's `stdout`/`stderr` handles through the pipeline, which was the suspected trigger in the #529 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZMj3bpBSV7WxFnUPUb1mU
