### PR TITLE
Accept strided right-hand sides in CHOLMOD factor component solves

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1858,11 +1858,13 @@ end
 
 SparseVecOrMat{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 
-function (\)(L::FactorComponent, b::Vector)
-    reshape(Matrix(L\Dense(b)), length(b))
+# strided right-hand sides, such as views of dense arrays, are handed to CHOLMOD as they
+# are (issue #496), converted to the eltype of the factor as for `Factor`
+function (\)(L::FactorComponent{T}, b::StridedVector) where {T<:VTypes}
+    reshape(Matrix(L\Dense{T}(b)), length(b))
 end
-function (\)(L::FactorComponent, B::Matrix)
-    Matrix(L\Dense(B))
+function (\)(L::FactorComponent{T}, B::Union{StridedMatrix, Adjoint{<:Any,<:StridedMatrix}, Transpose{<:Any,<:StridedMatrix}}) where {T<:VTypes}
+    Matrix(L\Dense{T}(B))
 end
 function (\)(L::FactorComponent, B::SparseVector)
     sparsevec(L\Sparse(B))
@@ -1873,7 +1875,9 @@ end
 (\)(L::FactorComponent, B::Adjoint{<:Any,<:SparseMatrixCSC}) = L \ copy(B)
 (\)(L::FactorComponent, B::Transpose{<:Any,<:SparseMatrixCSC}) = L \ copy(B)
 
-\(adjL::Adjoint{<:Any,<:FactorComponent}, B::Union{VecOrMat,SparseVecOrMat}) = (L = parent(adjL); adjoint(L)\B)
+const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
+                                 Adjoint{<:Any,<:SparseMatrixCSC}, Transpose{<:Any,<:SparseMatrixCSC}}
+\(adjL::Adjoint{<:Any,<:FactorComponent}, B::FactorComponentRHS) = (L = parent(adjL); adjoint(L)\B)
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
 # Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -148,6 +148,28 @@ Random.seed!(123)
     @test size(chmal) == size(A)
     @test size(chmal, 1) == size(A, 1)
 
+    @testset "factor component solves with views (#496)" begin
+        F = cholesky(A)
+        B = Matrix{Tv}(hcat(b, 2b, 3b))
+        Bt = Matrix(transpose(B[:, 2:3]))
+        for sym in (:L, :U, :PtL, :UP)
+            C = getproperty(F, sym)
+            ref = C \ Vector(b)
+            @test C \ view(B, :, 1) ≈ ref
+            @test C \ view(B, :, 2) ≈ 2ref
+            @test C \ view(B, 1:n, 1) ≈ ref
+            @test C \ view(B, :, 2:3) ≈ hcat(2ref, 3ref)
+            @test C \ Bt' ≈ hcat(2ref, 3ref)
+            @test C \ transpose(Bt) ≈ hcat(2ref, 3ref)
+            @test C' \ view(B, :, 1) ≈ C' \ Vector(b)
+            @test C' \ view(B, :, 2:3) ≈ C' \ B[:, 2:3]
+        end
+        # the discourse example: a column of a dense workspace matrix
+        W = zeros(Tv, n, 2); W[:, 1] .= b
+        y = F.PtL \ view(W, :, 1)
+        @test F.PtL' \ y ≈ F \ b
+    end
+
     @testset "eltype" begin
         @test eltype(Dense(fill(Tv(1.), 3))) == Tv
         @test eltype(A) == Tv


### PR DESCRIPTION
Fixes #496.

`F.PtL \ b` and the other `CHOLMOD.FactorComponent` solves only had methods for `Vector` and `Matrix` right-hand sides, so a view of a dense array (the column of a workspace matrix in the issue's ArnoldiMethod example) fell through to the generic `AbstractMatrix` fallback and failed with a `CanonicalIndexError`, while `F \ view` already worked.

The component solves now take any strided vector or matrix, including adjoints and transposes, converted to the eltype of the factor as the `Factor` solves already do, and the adjoint of a component (`F.PtL'`) accepts the same right-hand sides as the component itself.

Tests solve with `L`, `U`, `PtL`, `UP` and their adjoints against column, range and block views, adjoint and transposed matrices, and reproduce the issue's two-step `PtL` solve against `F \ b`, for both index types and eltypes of the CHOLMOD demo matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6EdE4F3CCGE3vxr8gQYKf
