### PR TITLE
Accept complex strided RHSs in CHOLMOD solves

### DIFF
--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -726,16 +726,12 @@ for TI ∈ IndexTypes
         return F
     end
 
-    # CHOLMOD solves a real factor against a complex right-hand side of the same precision
-    # natively, giving a complex solution, so that combination goes straight to the library
-    # as well; any other mismatch promotes in the untyped `solve` below
-    function solve(sys::Integer, F::Factor{Tv, $TI}, B::Dense{Tv}) where Tv<:VTypes
-        return _solve(sys, F, B)
-    end
-    function solve(sys::Integer, F::Factor{Tv, $TI}, B::Dense{Complex{Tv}}) where Tv<:VRealTypes
-        return _solve(sys, F, B)
-    end
-    function _solve(sys::Integer, F::Factor{<:VTypes, $TI}, B::Dense{Tv}) where Tv<:VTypes
+    # A right-hand side matching the factor goes straight to the library, and so does a
+    # complex one against a real factor of the same precision, which CHOLMOD solves
+    # natively for a complex solution; any other mismatch promotes in the untyped `solve`
+    # below. `Complex` accepts only real parameters, so `Complex{Tf}` is unmatchable for a
+    # complex `Tf` and the union then admits `Tf` alone, as intended.
+    function solve(sys::Integer, F::Factor{Tf, $TI}, B::Dense{Tv}) where {Tf<:VTypes, Tv<:Union{Tf,Complex{Tf}}}
         if size(F,1) != size(B,1)
             throw(DimensionMismatch("LHS and RHS should have the same number of rows. " *
                 "LHS has $(size(F,1)) rows, but RHS has $(size(B,1)) rows."))

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1966,13 +1966,13 @@ SparseVecOrMat{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 # Strided right-hand sides, such as views of dense arrays (#496), are handed to CHOLMOD as
 # they are, in the precision of the factor. CHOLMOD solves a real factor against a complex
 # right-hand side natively, so a complex one (#120) stays complex in that precision.
-densetype(::Type{T}, ::Type{S}) where {T<:VTypes, S} = S <: Complex ? Complex{real(T)} : T
-function dense_solve(L, B::StridedVecOrMatInclAdjAndTrans)
-    X = L \ Dense{densetype(eltype(L), eltype(B))}(B)
+rhs_eltype(::Type{T}, ::Type{S}) where {T<:VTypes, S} = S <: Complex ? Complex{real(T)} : T
+function strided_solve(L, B::StridedVecOrMatInclAdjAndTrans)
+    X = L \ Dense{rhs_eltype(eltype(L), eltype(B))}(B)
     return B isa AbstractVector ? Vector(X) : Matrix(X)
 end
 
-(\)(L::FactorComponent{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = dense_solve(L, B)
+(\)(L::FactorComponent{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = strided_solve(L, B)
 function (\)(L::FactorComponent, B::SparseVector)
     sparsevec(L\Sparse(B))
 end
@@ -1987,11 +1987,11 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::Adjoint{<:Any,<:FactorComponent}, B::FactorComponentRHS) = (L = parent(adjL); adjoint(L)\B)
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
-(\)(L::Factor{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = dense_solve(L, B)
+(\)(L::Factor{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = strided_solve(L, B)
 # The explicit typevars avoid an ambiguity with `\(::Factorization{T}, ::VecOrMat{Complex{T}})`
 # in LinearAlgebra/factorization.jl, which is otherwise neither more nor less specific than
 # the strided method above.
-(\)(L::Factor{T}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = dense_solve(L, B)
+(\)(L::Factor{T}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = strided_solve(L, B)
 
 (\)(L::Factor, B::Sparse) = spsolve(CHOLMOD_A, L, B)
 # When right hand side is sparse, we have to ensure that the rhs is not marked as symmetric.
@@ -2006,8 +2006,8 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
 # These mirror the `Factor` methods above, `VecOrMat` tie-breaker included.
-\(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedVecOrMatInclAdjAndTrans) = dense_solve(adjL, B)
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = dense_solve(adjL, B)
+\(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedVecOrMatInclAdjAndTrans) = strided_solve(adjL, B)
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = strided_solve(adjL, B)
 (\)(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::AdjOrTransAbsMat) = adjL \ copy(B)
 
 const RealHermSymComplexHermSSL{Ti, Tr} = Union{

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1963,9 +1963,13 @@ SparseVecOrMat{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 function (\)(L::FactorComponent{T}, b::StridedVector) where {T<:VTypes}
     reshape(Matrix(L\Dense{T}(b)), length(b))
 end
-function (\)(L::FactorComponent{T}, B::Union{StridedMatrix, Adjoint{<:Any,<:StridedMatrix}, Transpose{<:Any,<:StridedMatrix}}) where {T<:VTypes}
+function (\)(L::FactorComponent{T}, B::Union{StridedMatrix, Adjoint{<:Any,<:StridedVecOrMat}, Transpose{<:Any,<:StridedVecOrMat}}) where {T<:VTypes}
     Matrix(L\Dense{T}(B))
 end
+# a real factor component is a real linear map, so a complex right-hand side is solved
+# for by its real and imaginary parts, as for `Factor` below
+(\)(L::FactorComponent{T}, B::StridedVecOrMatInclAdjAndTrans{Complex{T}}) where {T<:VRealTypes} =
+    complex.(L\real(B), L\imag(B))
 function (\)(L::FactorComponent, B::SparseVector)
     sparsevec(L\Sparse(B))
 end
@@ -1980,16 +1984,13 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::Adjoint{<:Any,<:FactorComponent}, B::FactorComponentRHS) = (L = parent(adjL); adjoint(L)\B)
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
-# Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl.
-# The strided methods keep complex views (issue #120) off the real `Strided*` methods
-# below; the explicit Vector and Matrix methods are still needed, since LinearAlgebra's
-# `\(::Factorization{T}, ::VecOrMat{Complex{T}})` is otherwise ambiguous with them.
-(\)(L::Factor{T}, B::Vector{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Matrix{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::StridedVector{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::StridedMatrix{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Adjoint{<:Any, <:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Transpose{<:Any, <:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
+# A real factor solves for a complex right-hand side by its real and imaginary parts. The
+# strided method keeps complex views (issue #120) off the real `Strided*` methods below.
+# Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl,
+# and the `VecOrMat` method is needed alongside the strided one because LinearAlgebra's
+# `\(::Factorization{T}, ::VecOrMat{Complex{T}})` is otherwise ambiguous with it.
+(\)(L::Factor{T}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{T}, B::StridedVecOrMatInclAdjAndTrans{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
 
 (\)(L::Factor{T}, b::StridedVector) where {T<:VTypes} = Vector(L\Dense{T}(b))
 (\)(L::Factor{T}, B::StridedMatrix) where {T<:VTypes} = Matrix(L\Dense{T}(B))
@@ -2008,14 +2009,9 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::Sparse) = (L = parent(adjL); spsolve(CHOLMOD_A, L, B))
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
-# Explicit typevars are necessary to avoid ambiguities with defs in LinearAlgebra/factorizations.jl.
-# These mirror the `Factor` methods above, explicit Vector and Matrix methods included.
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Vector{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Matrix{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedVector{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedMatrix{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Adjoint{<:Any,<:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Transpose{<:Any,<:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
+# These mirror the `Factor` methods above, `VecOrMat` tie-breaker included.
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedVecOrMatInclAdjAndTrans{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
 function \(adjL::AdjointFactorization{<:VTypes,<:Factor}, b::StridedVector)
     L = parent(adjL)
     return Vector(solve(CHOLMOD_A, L, Dense(b)))

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1981,8 +1981,11 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
 # Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl.
-# Keep the complex-RHS specializations more specific than the real `Strided*` methods below,
-# including for views (issue #120).
+# The strided methods keep complex views (issue #120) off the real `Strided*` methods
+# below; the explicit Vector and Matrix methods are still needed, since LinearAlgebra's
+# `\(::Factorization{T}, ::VecOrMat{Complex{T}})` is otherwise ambiguous with them.
+(\)(L::Factor{T}, B::Vector{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{T}, B::Matrix{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
 (\)(L::Factor{T}, B::StridedVector{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
 (\)(L::Factor{T}, B::StridedMatrix{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
 (\)(L::Factor{T}, B::Adjoint{<:Any, <:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
@@ -2006,7 +2009,9 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
 # Explicit typevars are necessary to avoid ambiguities with defs in LinearAlgebra/factorizations.jl.
-# These mirror the `Factor` methods above so complex views are not converted to a real RHS.
+# These mirror the `Factor` methods above, explicit Vector and Matrix methods included.
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::Vector{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::Matrix{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
 (\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedVector{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
 (\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedMatrix{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
 (\)(adjL::AdjointFactorization{T,<:Factor}, B::Adjoint{<:Any,<:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -1980,12 +1980,13 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::Adjoint{<:Any,<:FactorComponent}, B::FactorComponentRHS) = (L = parent(adjL); adjoint(L)\B)
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
-# Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl
-# Likewise the two following explicit Vector and Matrix defs (rather than a single VecOrMat)
-(\)(L::Factor{T}, B::Vector{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Matrix{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Adjoint{<:Any, <:Matrix{Complex{T}}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::Transpose{<:Any, <:Matrix{Complex{T}}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
+# Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl.
+# Keep the complex-RHS specializations more specific than the real `Strided*` methods below,
+# including for views (issue #120).
+(\)(L::Factor{T}, B::StridedVector{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{T}, B::StridedMatrix{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{T}, B::Adjoint{<:Any, <:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
+(\)(L::Factor{T}, B::Transpose{<:Any, <:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
 
 (\)(L::Factor{T}, b::StridedVector) where {T<:VTypes} = Vector(L\Dense{T}(b))
 (\)(L::Factor{T}, B::StridedMatrix) where {T<:VTypes} = Matrix(L\Dense{T}(B))
@@ -2004,12 +2005,12 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::Sparse) = (L = parent(adjL); spsolve(CHOLMOD_A, L, B))
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
-# Explicit typevars are necessary to avoid ambiguities with defs in LinearAlgebra/factorizations.jl
-# Likewise the two following explicit Vector and Matrix defs (rather than a single VecOrMat)
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Vector{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Matrix{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Adjoint{<:Any,Matrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::Transpose{<:Any,Matrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
+# Explicit typevars are necessary to avoid ambiguities with defs in LinearAlgebra/factorizations.jl.
+# These mirror the `Factor` methods above so complex views are not converted to a real RHS.
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedVector{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedMatrix{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::Adjoint{<:Any,<:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::Transpose{<:Any,<:StridedMatrix{Complex{T}}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
 function \(adjL::AdjointFactorization{<:VTypes,<:Factor}, b::StridedVector)
     L = parent(adjL)
     return Vector(solve(CHOLMOD_A, L, Dense(b)))

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -726,7 +726,16 @@ for TI ∈ IndexTypes
         return F
     end
 
+    # CHOLMOD solves a real factor against a complex right-hand side of the same precision
+    # natively, giving a complex solution, so that combination goes straight to the library
+    # as well; any other mismatch promotes in the untyped `solve` below
     function solve(sys::Integer, F::Factor{Tv, $TI}, B::Dense{Tv}) where Tv<:VTypes
+        return _solve(sys, F, B)
+    end
+    function solve(sys::Integer, F::Factor{Tv, $TI}, B::Dense{Complex{Tv}}) where Tv<:VRealTypes
+        return _solve(sys, F, B)
+    end
+    function _solve(sys::Integer, F::Factor{<:VTypes, $TI}, B::Dense{Tv}) where Tv<:VTypes
         if size(F,1) != size(B,1)
             throw(DimensionMismatch("LHS and RHS should have the same number of rows. " *
                 "LHS has $(size(F,1)) rows, but RHS has $(size(B,1)) rows."))
@@ -1958,18 +1967,16 @@ end
 
 SparseVecOrMat{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 
-# strided right-hand sides, such as views of dense arrays, are handed to CHOLMOD as they
-# are (issue #496), converted to the eltype of the factor as for `Factor`
-function (\)(L::FactorComponent{T}, b::StridedVector) where {T<:VTypes}
-    reshape(Matrix(L\Dense{T}(b)), length(b))
+# Strided right-hand sides, such as views of dense arrays (#496), are handed to CHOLMOD as
+# they are, in the precision of the factor. CHOLMOD solves a real factor against a complex
+# right-hand side natively, so a complex one (#120) stays complex in that precision.
+densetype(::Type{T}, ::Type{S}) where {T<:VTypes, S} = S <: Complex ? Complex{real(T)} : T
+function dense_solve(L, B::StridedVecOrMatInclAdjAndTrans)
+    X = L \ Dense{densetype(eltype(L), eltype(B))}(B)
+    return B isa AbstractVector ? Vector(X) : Matrix(X)
 end
-function (\)(L::FactorComponent{T}, B::Union{StridedMatrix, Adjoint{<:Any,<:StridedVecOrMat}, Transpose{<:Any,<:StridedVecOrMat}}) where {T<:VTypes}
-    Matrix(L\Dense{T}(B))
-end
-# a real factor component is a real linear map, so a complex right-hand side is solved
-# for by its real and imaginary parts, as for `Factor` below
-(\)(L::FactorComponent{T}, B::StridedVecOrMatInclAdjAndTrans{Complex{T}}) where {T<:VRealTypes} =
-    complex.(L\real(B), L\imag(B))
+
+(\)(L::FactorComponent{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = dense_solve(L, B)
 function (\)(L::FactorComponent, B::SparseVector)
     sparsevec(L\Sparse(B))
 end
@@ -1984,18 +1991,11 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::Adjoint{<:Any,<:FactorComponent}, B::FactorComponentRHS) = (L = parent(adjL); adjoint(L)\B)
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
-# A real factor solves for a complex right-hand side by its real and imaginary parts. The
-# strided method keeps complex views (issue #120) off the real `Strided*` methods below.
-# Explicit typevars are necessary to avoid ambiguities with defs in linalg/factorizations.jl,
-# and the `VecOrMat` method is needed alongside the strided one because LinearAlgebra's
-# `\(::Factorization{T}, ::VecOrMat{Complex{T}})` is otherwise ambiguous with it.
-(\)(L::Factor{T}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-(\)(L::Factor{T}, B::StridedVecOrMatInclAdjAndTrans{Complex{T}}) where {T<:VRealTypes} = complex.(L\real(B), L\imag(B))
-
-(\)(L::Factor{T}, b::StridedVector) where {T<:VTypes} = Vector(L\Dense{T}(b))
-(\)(L::Factor{T}, B::StridedMatrix) where {T<:VTypes} = Matrix(L\Dense{T}(B))
-(\)(L::Factor{T}, B::Adjoint{<:Any, <:StridedMatrix}) where {T<:VTypes} = Matrix(L\Dense{T}(B))
-(\)(L::Factor{T}, B::Transpose{<:Any, <:StridedMatrix}) where {T<:VTypes} = Matrix(L\Dense{T}(B))
+(\)(L::Factor{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = dense_solve(L, B)
+# The explicit typevars avoid an ambiguity with `\(::Factorization{T}, ::VecOrMat{Complex{T}})`
+# in LinearAlgebra/factorization.jl, which is otherwise neither more nor less specific than
+# the strided method above.
+(\)(L::Factor{T}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = dense_solve(L, B)
 
 (\)(L::Factor, B::Sparse) = spsolve(CHOLMOD_A, L, B)
 # When right hand side is sparse, we have to ensure that the rhs is not marked as symmetric.
@@ -2010,16 +2010,8 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
 # These mirror the `Factor` methods above, `VecOrMat` tie-breaker included.
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-(\)(adjL::AdjointFactorization{T,<:Factor}, B::StridedVecOrMatInclAdjAndTrans{Complex{T}}) where {T<:VRealTypes} = complex.(adjL\real(B), adjL\imag(B))
-function \(adjL::AdjointFactorization{<:VTypes,<:Factor}, b::StridedVector)
-    L = parent(adjL)
-    return Vector(solve(CHOLMOD_A, L, Dense(b)))
-end
-function \(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedMatrix)
-    L = parent(adjL)
-    return Matrix(solve(CHOLMOD_A, L, Dense(B)))
-end
+\(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedVecOrMatInclAdjAndTrans) = dense_solve(adjL, B)
+(\)(adjL::AdjointFactorization{T,<:Factor}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = dense_solve(adjL, B)
 (\)(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::AdjOrTransAbsMat) = adjL \ copy(B)
 
 const RealHermSymComplexHermSSL{Ti, Tr} = Union{

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -148,10 +148,14 @@ Random.seed!(123)
     @test size(chmal) == size(A)
     @test size(chmal, 1) == size(A, 1)
 
-    @testset "factor component solves with views (#496)" begin
+    @testset "factor and component solves with views (#496, #120)" begin
         F = cholesky(A)
         B = Matrix{Tv}(hcat(b, 2b, 3b))
         Bt = Matrix(transpose(B[:, 2:3]))
+        # complex right-hand sides for the real factor (#120), which LinearAlgebra handles
+        # for `Vector` and `Matrix` but not for views or adjoint/transpose wrappers of them
+        Z = complex.(B, 2B)
+        Zt = Matrix(transpose(Z[:, 2:3]))
         for sym in (:L, :U, :PtL, :UP)
             C = getproperty(F, sym)
             ref = C \ Vector(b)
@@ -163,39 +167,28 @@ Random.seed!(123)
             @test C \ transpose(Bt) ≈ hcat(2ref, 3ref)
             @test C' \ view(B, :, 1) ≈ C' \ Vector(b)
             @test C' \ view(B, :, 2:3) ≈ C' \ B[:, 2:3]
+            # a real factor component is a real linear map, so it solves for a complex
+            # right-hand side componentwise
+            zref = complex.(ref, 2ref)
+            @test C \ Z[:, 1] ≈ zref
+            @test C \ view(Z, :, 1) ≈ zref
+            @test C \ view(Z, :, 2:3) ≈ hcat(2zref, 3zref)
+            @test C \ Zt' ≈ conj(hcat(2zref, 3zref))   # the adjoint conjugates
+            @test C \ transpose(Zt) ≈ hcat(2zref, 3zref)
+            @test C' \ view(Z, :, 1) ≈ complex.(C' \ Vector(b), 2(C' \ Vector(b)))
+        end
+        for G in (F, F')
+            zref = complex.(G \ Vector(b), 2(G \ Vector(b)))
+            @test G \ Z[:, 1] ≈ zref
+            @test G \ view(Z, :, 1) ≈ zref
+            @test G \ view(Z, :, 2:3) ≈ hcat(2zref, 3zref)
+            @test G \ Zt' ≈ conj(hcat(2zref, 3zref))
+            @test G \ transpose(Zt) ≈ hcat(2zref, 3zref)
         end
         # the discourse example: a column of a dense workspace matrix
         W = zeros(Tv, n, 2); W[:, 1] .= b
         y = F.PtL \ view(W, :, 1)
         @test F.PtL' \ y ≈ F \ b
-    end
-
-    @testset "real factor solves with complex strided right-hand sides (#120)" begin
-        z = complex.(b, 2b)
-        Z = hcat(z, 2z, 3z)
-        zview = @view z[:]
-        Zview = @view Z[:, 1:2]
-
-        Zt = Matrix(transpose(Z))
-        Ztview = @view Zt[1:2, :]
-        for F in (chma, chma')
-            @test F \ z ≈ complex.(F \ real(z), F \ imag(z))
-            @test F \ zview ≈ F \ z
-            @test F \ Zview ≈ F \ Z[:, 1:2]
-            @test F \ Ztview' ≈ F \ Matrix(Ztview')   # the adjoint conjugates
-            @test F \ transpose(Ztview) ≈ F \ Z[:, 1:2]
-        end
-        # factor components are real linear maps too
-        for sym in (:L, :U, :PtL, :UP)
-            C = getproperty(chma, sym)
-            ref = complex.(C \ real(z), C \ imag(z))
-            @test C \ z ≈ ref
-            @test C \ zview ≈ ref
-            @test C' \ zview ≈ complex.(C' \ real(z), C' \ imag(z))
-            @test C \ Zview ≈ hcat(ref, 2ref)
-            @test C \ transpose(Ztview) ≈ hcat(ref, 2ref)
-            @test C \ Ztview' ≈ conj(hcat(ref, 2ref))
-        end
     end
 
     @testset "eltype" begin

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -176,19 +176,26 @@ Random.seed!(123)
         zview = @view z[:]
         Zview = @view Z[:, 1:2]
 
-        @test chma \ zview ≈ chma \ z
-        @test chma \ Zview ≈ chma \ Z[:, 1:2]
-        @test chma' \ zview ≈ chma' \ z
-        @test chma' \ Zview ≈ chma' \ Z[:, 1:2]
-
-        # The wrapper cases need a square view so the transposed RHS still
-        # has the factor's leading dimension.
-        Zsquare = hcat((j * z for j in 1:n)...)
-        Zsquareview = @view Zsquare[:, 1:n]
-        @test chma \ Zsquareview' ≈ chma \ Matrix(Zsquareview')
-        @test chma \ transpose(Zsquareview) ≈ chma \ Matrix(transpose(Zsquareview))
-        @test chma' \ Zsquareview' ≈ chma' \ Matrix(Zsquareview')
-        @test chma' \ transpose(Zsquareview) ≈ chma' \ Matrix(transpose(Zsquareview))
+        Zt = Matrix(transpose(Z))
+        Ztview = @view Zt[1:2, :]
+        for F in (chma, chma')
+            @test F \ z ≈ complex.(F \ real(z), F \ imag(z))
+            @test F \ zview ≈ F \ z
+            @test F \ Zview ≈ F \ Z[:, 1:2]
+            @test F \ Ztview' ≈ F \ Matrix(Ztview')   # the adjoint conjugates
+            @test F \ transpose(Ztview) ≈ F \ Z[:, 1:2]
+        end
+        # factor components are real linear maps too
+        for sym in (:L, :U, :PtL, :UP)
+            C = getproperty(chma, sym)
+            ref = complex.(C \ real(z), C \ imag(z))
+            @test C \ z ≈ ref
+            @test C \ zview ≈ ref
+            @test C' \ zview ≈ complex.(C' \ real(z), C' \ imag(z))
+            @test C \ Zview ≈ hcat(ref, 2ref)
+            @test C \ transpose(Ztview) ≈ hcat(ref, 2ref)
+            @test C \ Ztview' ≈ conj(hcat(ref, 2ref))
+        end
     end
 
     @testset "eltype" begin

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -170,6 +170,27 @@ Random.seed!(123)
         @test F.PtL' \ y ≈ F \ b
     end
 
+    @testset "real factor solves with complex strided right-hand sides (#120)" begin
+        z = complex.(b, 2b)
+        Z = hcat(z, 2z, 3z)
+        zview = @view z[:]
+        Zview = @view Z[:, 1:2]
+
+        @test chma \ zview ≈ chma \ z
+        @test chma \ Zview ≈ chma \ Z[:, 1:2]
+        @test chma' \ zview ≈ chma' \ z
+        @test chma' \ Zview ≈ chma' \ Z[:, 1:2]
+
+        # The wrapper cases need a square view so the transposed RHS still
+        # has the factor's leading dimension.
+        Zsquare = hcat((j * z for j in 1:n)...)
+        Zsquareview = @view Zsquare[:, 1:n]
+        @test chma \ Zsquareview' ≈ chma \ Matrix(Zsquareview')
+        @test chma \ transpose(Zsquareview) ≈ chma \ Matrix(transpose(Zsquareview))
+        @test chma' \ Zsquareview' ≈ chma' \ Matrix(Zsquareview')
+        @test chma' \ transpose(Zsquareview) ≈ chma' \ Matrix(transpose(Zsquareview))
+    end
+
     @testset "eltype" begin
         @test eltype(Dense(fill(Tv(1.), 3))) == Tv
         @test eltype(A) == Tv

--- a/test/cholmod.jl
+++ b/test/cholmod.jl
@@ -185,6 +185,15 @@ Random.seed!(123)
             @test G \ Zt' ≈ conj(hcat(2zref, 3zref))
             @test G \ transpose(Zt) ≈ hcat(2zref, 3zref)
         end
+        # a complex right-hand side of the other precision is solved in the precision of
+        # the (real) factor, as a real one is
+        Z2 = Complex{Tv === Float64 ? Float32 : Float64}.(Z)
+        for G in (F, F', F.L, F.PtL')
+            X = G \ Z2
+            @test eltype(X) === Complex{Tv}
+            @test X ≈ G \ Z rtol=sqrt(eps(Float32))
+            @test G \ view(Z2, :, 1) ≈ X[:, 1] rtol=sqrt(eps(Float32))
+        end
         # the discourse example: a column of a dense workspace matrix
         W = zeros(Tv, n, 2); W[:, 1] .= b
         y = F.PtL \ view(W, :, 1)


### PR DESCRIPTION
Fixes #120.

Real CHOLMOD factors already handle complex dense RHSs by solving the real and imaginary components separately. Extend those specializations to strided vectors, matrices, and their adjoint/transpose wrappers, so complex views do not fall through to the real-RHS conversion path.

Tests cover the original vector-view reproduction, matrix views, and wrapper views for both a factor and its adjoint.