### PR TITLE
Add promote_rule for SparseMatrixCSC and SparseVector

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -23,7 +23,7 @@ import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
 
 import Base: adjoint, argmin, argmax, Array, broadcast, circshift!, complex, Complex,
     conj, conj!, convert, copy, copy!, copyto!, count, diff, findall, findmax, findmin, findnext, findprev,
-    float, getindex, imag, inv, kron, kron!, length, map, maximum, minimum, permute!, real,
+    float, getindex, imag, inv, kron, kron!, length, map, maximum, minimum, permute!, promote_rule, real,
     rot180, rotl90, rotr90, setindex!, show, similar, size, sum, transpose,
     vcat, hcat, hvcat, cat, vec, reverse, reverse!
 

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -981,6 +981,15 @@ Array(S::AbstractSparseMatrixCSC) = Matrix(S)
 
 convert(T::Type{<:AbstractSparseMatrixCSC}, m::AbstractMatrix) = m isa T ? m : T(m)
 
+# mirror Base's Array rule: promote the eltype only if at least one container wouldn't
+# change, otherwise join the container types (see Base.el_same)
+function promote_rule(::Type{SparseMatrixCSC{Tv1,Ti1}}, ::Type{SparseMatrixCSC{Tv2,Ti2}}) where {Tv1,Ti1,Tv2,Ti2}
+    Ti = promote_type(Ti1, Ti2)
+    return Base.el_same(promote_type(Tv1, Tv2), SparseMatrixCSC{Tv1,Ti}, SparseMatrixCSC{Tv2,Ti})
+end
+promote_rule(::Type{Matrix{Tv1}}, ::Type{<:SparseMatrixCSC{Tv2}}) where {Tv1,Tv2} =
+    Base.el_same(promote_type(Tv1, Tv2), Matrix{Tv1}, Matrix{Tv2})
+
 convert(T::Type{<:Diagonal},       m::AbstractSparseMatrixCSC) = m isa T ? m :
     isdiag(m) ? T(m) : throw(ArgumentError("matrix cannot be represented as Diagonal"))
 convert(T::Type{<:SymTridiagonal}, m::AbstractSparseMatrixCSC) = m isa T ? m :

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -579,6 +579,13 @@ convert(T::Type{<:SparseVector}, m::AbstractVector) = m isa T ? m : T(m)
 convert(T::Type{<:SparseVector}, m::AbstractSparseMatrixCSC) = T(m)
 convert(T::Type{<:AbstractSparseMatrixCSC}, v::AbstractCompressedVector) = T(v)
 
+function promote_rule(::Type{SparseVector{Tv1,Ti1}}, ::Type{SparseVector{Tv2,Ti2}}) where {Tv1,Ti1,Tv2,Ti2}
+    Ti = promote_type(Ti1, Ti2)
+    return Base.el_same(promote_type(Tv1, Tv2), SparseVector{Tv1,Ti}, SparseVector{Tv2,Ti})
+end
+promote_rule(::Type{Vector{Tv1}}, ::Type{<:SparseVector{Tv2}}) where {Tv1,Tv2} =
+    Base.el_same(promote_type(Tv1, Tv2), Vector{Tv1}, Vector{Tv2})
+
 ### copying
 function prep_sparsevec_copy_dest!(A::AbstractCompressedVector, lB, nnzB)
     lA = length(A)

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -37,6 +37,14 @@ end
     @test SparseMatrixCSC{eltype(a)}(Array(a)) == a
     @test Array(SparseMatrixCSC{eltype(a), Int8}(a)) == Array(a)
     @test collect(a) == a
+    # issue #54
+    b = SparseMatrixCSC{ComplexF64,Int32}(a)
+    @test promote_type(typeof(a), typeof(b)) === SparseMatrixCSC{ComplexF64,Int}
+    @test promote_type(typeof(a), Matrix{ComplexF64}) === Matrix{ComplexF64}
+    @test promote_type(Matrix{Int}, typeof(a)) === Matrix{Float64}
+    @test promote_type(SparseMatrixCSC{Int8,Int}, SparseMatrixCSC{Int16,Int}) === SparseMatrixCSC{Int16,Int}
+    @test promote(a, b) == (a, b)
+    @test eltype([a, b]) === SparseMatrixCSC{ComplexF64,Int}
 end
 
 @testset "sparse matrix construction" begin

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -60,6 +60,12 @@ end
         @test Array(x) == xf
         @test Vector(x) == xf
         @test collect(x) == xf
+        # issue #54
+        y = SparseVector{ComplexF64,Int32}(x)
+        @test promote_type(typeof(x), typeof(y)) === SparseVector{ComplexF64,Int}
+        @test promote_type(Vector{Int}, typeof(x)) === Vector{Float64}
+        @test promote(x, y) == (x, y)
+        @test eltype([x, y]) === SparseVector{ComplexF64,Int}
     end
 end
 @testset "show" begin


### PR DESCRIPTION
Fixes #54.

`promote_type(SparseMatrixCSC{Float64,Int}, SparseMatrixCSC{ComplexF64,Int})` currently returns `SparseMatrixCSC{Tv,Int64} where Tv`, and `promote(A, B)` on such a pair throws, because no `promote_rule` is defined for sparse types and the generic `AbstractArray` fallback typejoins.

This adds rules for `SparseMatrixCSC` and `SparseVector` that mirror the Base `Array` rule via `Base.el_same`: the eltype is promoted only if at least one container would be unchanged, otherwise the container types are joined. Index types are always promoted, as Base does for the second parameter of `StepRange`. Sparse against dense `Matrix`/`Vector` promotes to the dense type, following the `Bidiagonal` precedent in LinearAlgebra. Rules are deliberately restricted to `Matrix`/`Vector` rather than `AbstractMatrix` so as not to interfere with structured LinearAlgebra types.

```julia
julia> promote_type(SparseMatrixCSC{Float64,Int}, SparseMatrixCSC{ComplexF64,Int32})
SparseMatrixCSC{ComplexF64, Int64}

julia> promote_type(SparseMatrixCSC{Float64,Int}, Matrix{ComplexF64})
Matrix{ComplexF64}
```

`test/ambiguous.jl` unbound-parameter and piracy counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVrQHidozk7z3U9hTp6o33