### PR TITLE
Fall back to generic broadcast in `copyto!` for unsupported promoted arguments

### DIFF
--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -1186,7 +1186,11 @@ end
 
 @inline function copyto!(dest::SparseVecOrMat, bc::Broadcasted{PromoteToSparse})
     bcf = flatten(bc)
-    broadcast!(bcf.f, dest, map(_sparsifystructured, bcf.args)...)
+    if is_supported_sparse_broadcast(bcf.args...)
+        broadcast!(bcf.f, dest, map(_sparsifystructured, bcf.args)...)
+    else # e.g. a Tuple argument: re-promoting would recurse, so opt out like `copy` does
+        copyto!(dest, convert(Broadcasted{Broadcast.DefaultArrayStyle{length(axes(bc))}}, bc))
+    end
 end
 
 _sparsifystructured(M::AbstractMatrix) = SparseMatrixCSC(M)

--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -1188,8 +1188,8 @@ end
     bcf = flatten(bc)
     if is_supported_sparse_broadcast(bcf.args...)
         broadcast!(bcf.f, dest, map(_sparsifystructured, bcf.args)...)
-    else # e.g. a Tuple argument: re-promoting would recurse, so opt out like `copy` does
-        copyto!(dest, convert(Broadcasted{Broadcast.DefaultArrayStyle{length(axes(bc))}}, bc))
+    else # e.g. a Tuple argument: re-promoting would recurse; `copy` handles the fallback
+        copyto!(dest, copy(bc))
     end
 end
 

--- a/test/higherorderfns.jl
+++ b/test/higherorderfns.jl
@@ -681,6 +681,9 @@ end
     @test ((1:5) .+ A) .* 2 == 2:2:10
     @test 2 .* ((1:5) .+ A) == 2:2:10
     @test 2 .* (A .+ (1:5)) == 2:2:10
+    # in-place with an unsupported (Tuple) argument used to recurse, see #573
+    B = sparsevec([2], [3.0], 5)
+    @test (B .= .*(B, A .+ 1, (2,))) == [0, 6, 0, 0, 0]
 
     # lu(zeros(5,5)) throw SingularException, see #42343
     @test_throws SingularException Diagonal(spzeros(5)) \ view(rand(10), 1:5)


### PR DESCRIPTION
Fixes #573.

`v1 .= .*(v1, v2, (1,))` overflowed the stack. With three or more arguments the broadcast style resolves to `PromoteToSparse`, and `copyto!(dest::SparseVecOrMat, ::Broadcasted{PromoteToSparse})` sparsified the arguments and called `broadcast!` unconditionally. Since a Tuple cannot be sparsified, the same style was computed again and the call recursed. The two-argument form never hit this because it resolves to the default array style directly.

`copyto!` now checks `is_supported_sparse_broadcast` on the flattened arguments and, when it fails, materializes the result with `copy(bc)` and copies it into the destination. `copy` for this style already knows how to fall back to the generic elementwise path, so `copyto!` reuses that rather than duplicating the style conversion.

A local sweep over in-place products of sparse vectors and matrices with Tuple, `Ref`, range, dense array and scalar arguments in each position matched the dense result and kept the destination type; only the issue's case is added as a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuTWiPAcAtfHFG1JjbVTyZ