### PR TITLE
Reshape matrix values to the index shape in nonscalar sparse `setindex!`

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -3524,9 +3524,8 @@ function _spsetnz_setindex!(A::AbstractSparseMatrixCSC{Tv}, x::Tv,
 end
 
 # Nonscalar A[I,J] = B: Convert B to a SparseMatrixCSC of the appropriate shape first
-_to_same_csc(::AbstractSparseMatrixCSC{Tv, Ti}, V::AbstractMatrix, I...) where {Tv,Ti} = convert(SparseMatrixCSC{Tv,Ti}, V)
-_to_same_csc(::AbstractSparseMatrixCSC{Tv, Ti}, V::AbstractMatrix, i::Integer, J) where {Tv,Ti} = convert(SparseMatrixCSC{Tv,Ti}, reshape(V, (1, length(J))))
-_to_same_csc(::AbstractSparseMatrixCSC{Tv, Ti}, V::AbstractVector, I...) where {Tv,Ti} = convert(SparseMatrixCSC{Tv,Ti}, reshape(V, map(length, I)))
+# (reshape also fixes a 1×n V assigned to A[:, j], which the shape check allows; see #569)
+_to_same_csc(::AbstractSparseMatrixCSC{Tv, Ti}, V::AbstractVecOrMat, I...) where {Tv,Ti} = convert(SparseMatrixCSC{Tv,Ti}, reshape(V, map(length, I)))
 
 setindex!(A::AbstractSparseMatrixCSC{Tv}, B::AbstractVecOrMat, I::Integer, J::Integer) where {Tv} = _setindex_scalar!(A, B, I, J)
 

--- a/test/sparsematrix_constructors_indexing.jl
+++ b/test/sparsematrix_constructors_indexing.jl
@@ -1340,6 +1340,8 @@ _length_or_count_or_five(x) = length(x)
         @test setindex!(spzeros(5, 5), Array(V), I, J) == setindex!(zeros(5,5), V, I, J)
     end
     @test setindex!(spzeros(5, 5), 1:25, :) == setindex!(zeros(5,5), 1:25, :) == reshape(1:25, 5, 5)
+    # a 1×n matrix value into a column is reshaped rather than silently zeroed, see #569
+    @test setindex!(sparse(1.0I, 5, 5), reshape(1.0:5.0, 1, 5), :, 2) == setindex!(Matrix(1.0I, 5, 5), reshape(1.0:5.0, 1, 5), :, 2)
     @test setindex!(spzeros(5, 5), (25:-1:1).+spzeros(25), :) == setindex!(zeros(5,5), (25:-1:1).+spzeros(25), :) == reshape(25:-1:1, 5, 5)
     for X in (1:20, sparse(1:20), reshape(sparse(1:20), 20, 1), (1:20) .+ spzeros(20, 1), collect(1:20), collect(reshape(1:20, 20, 1)))
         @test setindex!(spzeros(5, 5), X, 6:25) == setindex!(zeros(5,5), 1:20, 6:25)


### PR DESCRIPTION
Fixes #569.

`A[:, j] = V` with `V` a `1×n` `Matrix` succeeded silently and wrote zeros, also dropping the entries already stored in that column. `Base.setindex_shape_check` allows the value's shape to differ from the index lengths by singleton dimensions, the same rule dense arrays use, but `_to_same_csc` converted a matrix value without reshaping, so the column merge read column 1 of a `1×n` sparse matrix.

Matrix values are now reshaped to the index lengths, as the vector method already did. That also covers the separate `(i::Integer, J)` method, which is removed. `reshape` returns the value itself when the shape already matches.

A local sweep compared sparse and dense `setindex!` over colon, range, vector, integer, reversed and logical index pairs against dense, sparse, adjoint and vector values in matching, singleton-transposed, mismatched and 3-d shapes; every case now gives the same result or throws the same error as the dense array. Only the issue's case is added as a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013D8Ek6uCm6yBhicEvSGz35
