### PR TITLE
Rationalize the dispatch type aliases

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -38,8 +38,6 @@ export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
 
 public sparse!, spzeros!
 
-const LinAlgLeftQs = Union{HessenbergQ,QRCompactWYQ,QRPackedQ}
-
 # helper function needed in sparsematrix, sparsevector and higherorderfns
 # `iszero` and `!iszero` don't guarantee to return a boolean but we need one that does
 # to remove the handle the structure of the array.

--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -12,7 +12,7 @@ using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, AdjointFactorization, TransposeFactorization, matprod,
     AbstractQ, AdjointQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ, MulAddMul,
     UpperOrLowerTriangular, UnitUpperOrUnitLowerTriangular, UpperOrUnitUpperTriangular,
-    LowerOrUnitLowerTriangular, HermOrSym, @stable_muladdmul, isbanded
+    LowerOrUnitLowerTriangular, HermOrSym, BiTriSym, BandedMatrix, @stable_muladdmul, isbanded
 
 
 import Base: +, -, *, \, /, ==, zero

--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -11,7 +11,8 @@ using Base.Order: Forward
 using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, AdjointFactorization, TransposeFactorization, matprod,
     AbstractQ, AdjointQ, HessenbergQ, QRCompactWYQ, QRPackedQ, LQPackedQ, MulAddMul,
-    UpperOrLowerTriangular, UnitUpperOrUnitLowerTriangular, @stable_muladdmul, isbanded
+    UpperOrLowerTriangular, UnitUpperOrUnitLowerTriangular, UpperOrUnitUpperTriangular,
+    LowerOrUnitLowerTriangular, HermOrSym, @stable_muladdmul, isbanded
 
 
 import Base: +, -, *, \, /, ==, zero

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -81,6 +81,8 @@ const SparseMatrixCSCSymmHerm{Tv,Ti} = HermOrSym{Tv,<:SparseMatrixCSCOrView{Tv,T
 
 # LinearAlgebra's BiTriSym (Bidiagonal/Tridiagonal/SymTridiagonal) and BandedMatrix (those
 # plus Diagonal) are imported for the banded special matrices.
+# LinearAlgebra's Q types that multiply sparse arrays via densification
+const LinAlgLeftQs = Union{HessenbergQ,QRCompactWYQ,QRPackedQ}
 
 # Former names of the above, not used here but relied on by downstream packages together
 # with SparseMatrixCSCView, SparseColumnView and SparseVectorView. May be deprecated in a

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -79,16 +79,14 @@ const SparseTriangular{Tv,Ti} = UpperOrLowerTriangular{Tv,<:SparseMatrixCSCOrVie
 const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCOrView{Tv,Ti}, SparseTriangular{Tv,Ti}}
 const SparseMatrixCSCSymmHerm{Tv,Ti} = HermOrSym{Tv,<:SparseMatrixCSCOrView{Tv,Ti}}
 
-# LinearAlgebra's banded special matrices; Diagonal is often handled separately
-const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
-const DiagBiTriSym = Union{Diagonal,BiTriSym}
+# LinearAlgebra's BiTriSym (Bidiagonal/Tridiagonal/SymTridiagonal) and BandedMatrix (those
+# plus Diagonal) are imported for the banded special matrices.
 
 # Former names of the above, not used here but relied on by downstream packages together
 # with SparseMatrixCSCView, SparseColumnView and SparseVectorView. May be deprecated in a
 # future release.
 const SparseMatrixCSCUnion{Tv,Ti} = SparseMatrixCSCOrView{Tv,Ti}
 const SparseVectorUnion{Tv,Ti} = SparseVectorOrView{Tv,Ti}
-const AdjOrTransSparseVectorUnion{Tv,Ti} = AdjOrTransSparseVectorOrView{Tv,Ti}
 
 """
     issparse(S)

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -40,6 +40,8 @@ Supertype for matrix with compressed sparse column (CSC).
 abstract type AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti} end
 
 # ---- Type aliases used for dispatch across files ----
+# Alias names use the Sparse family name and accept the abstract tier of the type they
+# are built on; an alias restricted to the concrete types says so in its name.
 # (Aliases for solver scalar types live with the solvers.)
 
 const AbstractSparseVecOrMat = Union{AbstractSparseVector,AbstractSparseMatrix}
@@ -70,8 +72,7 @@ const AdjOrTransSparseVectorOrView{Tv,Ti} = AdjOrTrans{Tv, <:SparseVectorOrView{
 const SparseVectorPartialView{Tv,Ti} = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},<:Tuple{AbstractUnitRange},false}
 
 # `X` or an `Adjoint`/`Transpose` of `X`, named after LinearAlgebra's StridedMaybeAdjOrTransMat
-const AbstractSparseMatrixCSCMaybeAdjOrTrans = Union{AbstractSparseMatrixCSC, AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}}
-const AbstractSparseVecOrMatMaybeAdjOrTrans = Union{AbstractSparseVecOrMat, AdjOrTrans{<:Any,<:AbstractSparseVecOrMat}}
+const SparseMatrixCSCMaybeAdjOrTrans = Union{AbstractSparseMatrixCSC, AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}}
 const SparseVecOrMatMaybeAdjOrTrans = Union{SparseVecOrMat, AdjOrTrans{<:Any,<:SparseVecOrMat}}
 
 # LinearAlgebra wrappers around CSC storage

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -41,6 +41,9 @@ abstract type AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv
 
 # ---- Type aliases used for dispatch across files ----
 # (Aliases for solver scalar types live with the solvers.)
+# SparseMatrixCSCView, SparseMatrixCSCUnion, SparseColumnView, SparseVectorView,
+# SparseVectorUnion and AdjOrTransSparseVectorUnion are not exported but are used by
+# downstream packages, so their names and definitions should stay stable.
 
 const AbstractSparseVecOrMat = Union{AbstractSparseVector,AbstractSparseMatrix}
 # types exposing compressed storage via nonzeros, rowvals/nonzeroinds and nzrange

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -32,8 +32,6 @@ of type `Tv` and index type `Ti`. Alias for `AbstractSparseArray{Tv,Ti,2}`.
 """
 const AbstractSparseMatrix{Tv,Ti} = AbstractSparseArray{Tv,Ti,2}
 
-const AbstractSparseVecOrMat = Union{AbstractSparseVector,AbstractSparseMatrix}
-
 """
     AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
 
@@ -41,6 +39,49 @@ Supertype for matrix with compressed sparse column (CSC).
 """
 abstract type AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti} end
 
+# ---- Type aliases used for dispatch across files ----
+# (Aliases for solver scalar types live with the solvers.)
+
+const AbstractSparseVecOrMat = Union{AbstractSparseVector,AbstractSparseMatrix}
+# types exposing compressed storage via nonzeros, rowvals/nonzeroinds and nzrange
+const SparseVecOrMat = Union{AbstractCompressedVector,AbstractSparseMatrixCSC}
+
+# Views of an AbstractSparseMatrixCSC taking all rows and a unit range of columns. getcolptr
+# is an offset view into the parent's colptr, so kernels written against
+# getcolptr/getrowval/getnzval work unchanged.
+const SparseMatrixCSCView{Tv,Ti} =
+    SubArray{Tv,2,<:AbstractSparseMatrixCSC{Tv,Ti},
+        Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractUnitRange{<:Integer}}
+const SparseMatrixCSCUnion{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
+# Views taking all rows and an arbitrary column subset (a superset of SparseMatrixCSCView):
+# nzrange/getrowval/getnzval work, getcolptr does not.
+const SparseMatrixCSCColumnSubset{Tv,Ti} =
+    SubArray{Tv,2,<:AbstractSparseMatrixCSC{Tv,Ti},
+        Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractVector{<:Integer}}
+const SparseMatrixCSCOrColumnSubset{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCColumnSubset{Tv,Ti}}
+
+# Whole-column views of sparse matrices and whole views of sparse vectors share the
+# sparse vector interface.
+const SparseColumnView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
+const SparseVectorView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}}},false}
+const SparseVectorUnion{Tv,Ti} = Union{AbstractCompressedVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
+const AdjOrTransSparseVectorUnion{Tv,Ti} = AdjOrTrans{Tv, <:SparseVectorUnion{Tv,Ti}}
+# view of a unit range of a sparse vector's indices
+const SparseVectorPartialView{Tv,Ti} = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},<:Tuple{AbstractUnitRange},false}
+
+# `X` or an `Adjoint`/`Transpose` of `X`, named after LinearAlgebra's StridedMaybeAdjOrTransMat
+const AbstractSparseMatrixCSCMaybeAdjOrTrans = Union{AbstractSparseMatrixCSC, AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}}
+const AbstractSparseVecOrMatMaybeAdjOrTrans = Union{AbstractSparseVecOrMat, AdjOrTrans{<:Any,<:AbstractSparseVecOrMat}}
+const SparseVecOrMatMaybeAdjOrTrans = Union{SparseVecOrMat, AdjOrTrans{<:Any,<:SparseVecOrMat}}
+
+# LinearAlgebra wrappers around CSC storage
+const SparseTriangular{Tv,Ti} = UpperOrLowerTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
+const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti}, SparseTriangular{Tv,Ti}}
+const SparseMatrixCSCSymmHerm{Tv,Ti} = HermOrSym{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
+
+# LinearAlgebra's banded special matrices; Diagonal is often handled separately
+const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
+const DiagBiTriSym = Union{Diagonal,BiTriSym}
 
 """
     issparse(S)
@@ -85,7 +126,7 @@ issparse(A::DenseArray) = false
 issparse(S::AbstractSparseArray) = true
 
 indtype(S::AbstractSparseArray{<:Any,Ti}) where {Ti} = Ti
-indtype(T::UpperOrLowerTriangular{<:Any,<:AbstractSparseArray}) = indtype(parent(T))
+indtype(T::UpperOrLowerTriangular{<:Any,<:Union{AbstractSparseArray,SparseMatrixCSCColumnSubset}}) = indtype(parent(T))
 
 # The following two methods should be overloaded by concrete types to avoid
 # allocating the I = findall(...)

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -41,9 +41,6 @@ abstract type AbstractSparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv
 
 # ---- Type aliases used for dispatch across files ----
 # (Aliases for solver scalar types live with the solvers.)
-# SparseMatrixCSCView, SparseMatrixCSCUnion, SparseColumnView, SparseVectorView,
-# SparseVectorUnion and AdjOrTransSparseVectorUnion are not exported but are used by
-# downstream packages, so their names and definitions should stay stable.
 
 const AbstractSparseVecOrMat = Union{AbstractSparseVector,AbstractSparseMatrix}
 # types exposing compressed storage via nonzeros, rowvals/nonzeroinds and nzrange
@@ -55,7 +52,7 @@ const SparseVecOrMat = Union{AbstractCompressedVector,AbstractSparseMatrixCSC}
 const SparseMatrixCSCView{Tv,Ti} =
     SubArray{Tv,2,<:AbstractSparseMatrixCSC{Tv,Ti},
         Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractUnitRange{<:Integer}}
-const SparseMatrixCSCUnion{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
+const SparseMatrixCSCOrView{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
 # Views taking all rows and an arbitrary column subset (a superset of SparseMatrixCSCView):
 # nzrange/getrowval/getnzval work, getcolptr does not.
 const SparseMatrixCSCColumnSubset{Tv,Ti} =
@@ -67,8 +64,8 @@ const SparseMatrixCSCOrColumnSubset{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti
 # sparse vector interface.
 const SparseColumnView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
 const SparseVectorView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}}},false}
-const SparseVectorUnion{Tv,Ti} = Union{AbstractCompressedVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
-const AdjOrTransSparseVectorUnion{Tv,Ti} = AdjOrTrans{Tv, <:SparseVectorUnion{Tv,Ti}}
+const SparseVectorOrView{Tv,Ti} = Union{AbstractCompressedVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
+const AdjOrTransSparseVectorOrView{Tv,Ti} = AdjOrTrans{Tv, <:SparseVectorOrView{Tv,Ti}}
 # view of a unit range of a sparse vector's indices
 const SparseVectorPartialView{Tv,Ti} = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},<:Tuple{AbstractUnitRange},false}
 
@@ -78,13 +75,20 @@ const AbstractSparseVecOrMatMaybeAdjOrTrans = Union{AbstractSparseVecOrMat, AdjO
 const SparseVecOrMatMaybeAdjOrTrans = Union{SparseVecOrMat, AdjOrTrans{<:Any,<:SparseVecOrMat}}
 
 # LinearAlgebra wrappers around CSC storage
-const SparseTriangular{Tv,Ti} = UpperOrLowerTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
-const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti}, SparseTriangular{Tv,Ti}}
-const SparseMatrixCSCSymmHerm{Tv,Ti} = HermOrSym{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
+const SparseTriangular{Tv,Ti} = UpperOrLowerTriangular{Tv,<:SparseMatrixCSCOrView{Tv,Ti}}
+const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCOrView{Tv,Ti}, SparseTriangular{Tv,Ti}}
+const SparseMatrixCSCSymmHerm{Tv,Ti} = HermOrSym{Tv,<:SparseMatrixCSCOrView{Tv,Ti}}
 
 # LinearAlgebra's banded special matrices; Diagonal is often handled separately
 const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
 const DiagBiTriSym = Union{Diagonal,BiTriSym}
+
+# Former names of the above, not used here but relied on by downstream packages together
+# with SparseMatrixCSCView, SparseColumnView and SparseVectorView. May be deprecated in a
+# future release.
+const SparseMatrixCSCUnion{Tv,Ti} = SparseMatrixCSCOrView{Tv,Ti}
+const SparseVectorUnion{Tv,Ti} = SparseVectorOrView{Tv,Ti}
+const AdjOrTransSparseVectorUnion{Tv,Ti} = AdjOrTransSparseVectorOrView{Tv,Ti}
 
 """
     issparse(S)

--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -11,12 +11,13 @@ using Base: front, tail, to_shape
 using ..SparseArrays: SparseVector, SparseMatrixCSC, FixedSparseCSC, SparseMatrixCSCView,
                       AbstractCompressedVector, AbstractSparseVector, AbstractSparseMatrixCSC,
                       AbstractSparseMatrix, AbstractSparseArray,
-                      SparseVectorOrView, AdjOrTransSparseVectorOrView, SparseVecOrMat, DiagBiTriSym,
+                      SparseVectorOrView, AdjOrTransSparseVectorOrView, SparseVecOrMat,
                       indtype, fixed, move_fixed, nnz, nzrange, spzeros,
                       nonzeroinds, nonzeros, rowvals, getcolptr, widelength,
                       _iszero, _isnotzero, _is_fixed, @if_move_fixed
 using Base.Broadcast: BroadcastStyle, Broadcasted, flatten
 using LinearAlgebra
+using LinearAlgebra: AdjOrTrans, BandedMatrix
 
 # This module is organized as follows:
 # (0) Define BroadcastStyle rules and convenience types for dispatch
@@ -69,16 +70,15 @@ PromoteToSparse(::Val{1}) = PromoteToSparse()
 PromoteToSparse(::Val{2}) = PromoteToSparse()
 PromoteToSparse(::Val{N}) where N = Broadcast.DefaultArrayStyle{N}()
 
-Broadcast.BroadcastStyle(::Type{<:Adjoint{T,<:Union{AbstractCompressedVector,AbstractSparseMatrixCSC}} where T}) = PromoteToSparse()
-Broadcast.BroadcastStyle(::Type{<:Transpose{T,<:Union{AbstractCompressedVector,AbstractSparseMatrixCSC}} where T}) = PromoteToSparse()
+Broadcast.BroadcastStyle(::Type{<:AdjOrTrans{<:Any,<:SparseVecOrMat}}) = PromoteToSparse()
 
 Broadcast.BroadcastStyle(s::SPVM, ::Broadcast.AbstractArrayStyle{0}) = s
 Broadcast.BroadcastStyle(s::SPVM, ::Broadcast.DefaultArrayStyle{0}) = s
 Broadcast.BroadcastStyle(::SPVM, ::Broadcast.DefaultArrayStyle{1}) = PromoteToSparse()
 Broadcast.BroadcastStyle(::SPVM, ::Broadcast.DefaultArrayStyle{2}) = PromoteToSparse()
 
-Broadcast.BroadcastStyle(::SPVM, ::LinearAlgebra.StructuredMatrixStyle{<:DiagBiTriSym}) = PromoteToSparse()
-Broadcast.BroadcastStyle(::PromoteToSparse, ::LinearAlgebra.StructuredMatrixStyle{<:DiagBiTriSym}) = PromoteToSparse()
+Broadcast.BroadcastStyle(::SPVM, ::LinearAlgebra.StructuredMatrixStyle{<:BandedMatrix}) = PromoteToSparse()
+Broadcast.BroadcastStyle(::PromoteToSparse, ::LinearAlgebra.StructuredMatrixStyle{<:BandedMatrix}) = PromoteToSparse()
 
 Broadcast.BroadcastStyle(::PromoteToSparse, ::SPVM) = PromoteToSparse()
 Broadcast.BroadcastStyle(::PromoteToSparse, ::Broadcast.Style{Tuple}) = Broadcast.DefaultArrayStyle{2}()
@@ -89,7 +89,7 @@ Broadcast.BroadcastStyle(::PromoteToSparse, ::Broadcast.Style{Tuple}) = Broadcas
 is_supported_sparse_broadcast() = true
 is_supported_sparse_broadcast(::AbstractArray, rest...) = false
 is_supported_sparse_broadcast(::AbstractSparseArray, rest...) = is_supported_sparse_broadcast(rest...)
-is_supported_sparse_broadcast(::DiagBiTriSym, rest...) = is_supported_sparse_broadcast(rest...)
+is_supported_sparse_broadcast(::BandedMatrix, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(::Array, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(t::Union{Transpose, Adjoint}, rest...) = is_supported_sparse_broadcast(parent(t), rest...)
 is_supported_sparse_broadcast(v::SubArray, rest...) = is_supported_sparse_broadcast(parent(v), rest...)

--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -11,7 +11,7 @@ using Base: front, tail, to_shape
 using ..SparseArrays: SparseVector, SparseMatrixCSC, FixedSparseCSC, SparseMatrixCSCView,
                       AbstractCompressedVector, AbstractSparseVector, AbstractSparseMatrixCSC,
                       AbstractSparseMatrix, AbstractSparseArray,
-                      SparseVectorOrView, AdjOrTransSparseVectorOrView, SparseVecOrMat,
+                      SparseVectorOrView, AdjOrTransSparseVectorOrView, SparseVecOrMat, SparseMatrixCSCOrView,
                       indtype, fixed, move_fixed, nnz, nzrange, spzeros,
                       nonzeroinds, nonzeros, rowvals, getcolptr, widelength,
                       _iszero, _isnotzero, _is_fixed, @if_move_fixed
@@ -44,7 +44,7 @@ struct SparseVecStyle <: Broadcast.AbstractArrayStyle{1} end
 struct SparseMatStyle <: Broadcast.AbstractArrayStyle{2} end
 Broadcast.BroadcastStyle(::Type{<:AbstractCompressedVector}) = SparseVecStyle()
 Broadcast.BroadcastStyle(::Type{<:AbstractSparseMatrixCSC}) = SparseMatStyle()
-const SPVM = Union{SparseVecStyle,SparseMatStyle}
+const SparseVecOrMatStyle = Union{SparseVecStyle,SparseMatStyle}
 
 # SparseVecStyle handles 0-1 dimensions, SparseMatStyle 0-2 dimensions.
 # SparseVecStyle promotes to SparseMatStyle for 2 dimensions.
@@ -72,15 +72,15 @@ PromoteToSparse(::Val{N}) where N = Broadcast.DefaultArrayStyle{N}()
 
 Broadcast.BroadcastStyle(::Type{<:AdjOrTrans{<:Any,<:SparseVecOrMat}}) = PromoteToSparse()
 
-Broadcast.BroadcastStyle(s::SPVM, ::Broadcast.AbstractArrayStyle{0}) = s
-Broadcast.BroadcastStyle(s::SPVM, ::Broadcast.DefaultArrayStyle{0}) = s
-Broadcast.BroadcastStyle(::SPVM, ::Broadcast.DefaultArrayStyle{1}) = PromoteToSparse()
-Broadcast.BroadcastStyle(::SPVM, ::Broadcast.DefaultArrayStyle{2}) = PromoteToSparse()
+Broadcast.BroadcastStyle(s::SparseVecOrMatStyle, ::Broadcast.AbstractArrayStyle{0}) = s
+Broadcast.BroadcastStyle(s::SparseVecOrMatStyle, ::Broadcast.DefaultArrayStyle{0}) = s
+Broadcast.BroadcastStyle(::SparseVecOrMatStyle, ::Broadcast.DefaultArrayStyle{1}) = PromoteToSparse()
+Broadcast.BroadcastStyle(::SparseVecOrMatStyle, ::Broadcast.DefaultArrayStyle{2}) = PromoteToSparse()
 
-Broadcast.BroadcastStyle(::SPVM, ::LinearAlgebra.StructuredMatrixStyle{<:BandedMatrix}) = PromoteToSparse()
+Broadcast.BroadcastStyle(::SparseVecOrMatStyle, ::LinearAlgebra.StructuredMatrixStyle{<:BandedMatrix}) = PromoteToSparse()
 Broadcast.BroadcastStyle(::PromoteToSparse, ::LinearAlgebra.StructuredMatrixStyle{<:BandedMatrix}) = PromoteToSparse()
 
-Broadcast.BroadcastStyle(::PromoteToSparse, ::SPVM) = PromoteToSparse()
+Broadcast.BroadcastStyle(::PromoteToSparse, ::SparseVecOrMatStyle) = PromoteToSparse()
 Broadcast.BroadcastStyle(::PromoteToSparse, ::Broadcast.Style{Tuple}) = Broadcast.DefaultArrayStyle{2}()
 
 # FIXME: currently sparse broadcasts are only well-tested on known array types, while any AbstractArray
@@ -102,7 +102,7 @@ can_skip_sparsification(::typeof(*), ::SparseVectorOrView, ::AdjOrTransSparseVec
 # Dispatch on broadcast operations by number of arguments
 const Broadcasted0{Style<:Union{Nothing,BroadcastStyle},Axes,F} =
     Broadcasted{Style,Axes,F,Tuple{}}
-const SpBroadcasted1{Style<:SPVM,Axes,F,Args<:Tuple{SparseVecOrMat}} =
+const SpBroadcasted1{Style<:SparseVecOrMatStyle,Axes,F,Args<:Tuple{SparseVecOrMat}} =
     Broadcasted{Style,Axes,F,Args}
 
 # (1) The definitions below provide a common interface to sparse vectors and matrices
@@ -157,11 +157,12 @@ _checkbuffers(S::AbstractCompressedVector) = (@assert length(storedvals(S)) == l
 # (2) map[!] entry points
 map(f::Tf, A::AbstractCompressedVector) where {Tf} = _noshapecheck_map(f, A)
 map(f::Tf, A::AbstractSparseMatrixCSC) where {Tf} = _noshapecheck_map(f, A)
-map(f::Tf, A::AbstractSparseMatrixCSC, Bs::Vararg{SparseMatrixCSC,N}) where {Tf,N} =
+# more specific than both the SparseVecOrMat and the SparseOrStructuredMatrix methods
+map(f::Tf, A::AbstractSparseMatrixCSC, Bs::Vararg{AbstractSparseMatrixCSC,N}) where {Tf,N} =
     (_checksameshape(A, Bs...); _noshapecheck_map(f, A, Bs...))
 map(f::Tf, A::SparseVecOrMat, Bs::Vararg{SparseVecOrMat,N}) where {Tf,N} =
     (_checksameshape(A, Bs...); _noshapecheck_map(f, A, Bs...))
-map!(f::Tf, C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, Bs::Vararg{SparseMatrixCSC,N}) where {Tf,N} =
+map!(f::Tf, C::AbstractSparseMatrixCSC, A::AbstractSparseMatrixCSC, Bs::Vararg{AbstractSparseMatrixCSC,N}) where {Tf,N} =
     (_checksameshape(C, A, Bs...); _noshapecheck_map!(f, C, _unaliasargs(C, A, Bs...)...))
 map!(f::Tf, C::SparseVecOrMat, A::SparseVecOrMat, Bs::Vararg{SparseVecOrMat,N}) where {Tf,N} =
     (_checksameshape(C, A, Bs...); _noshapecheck_map!(f, C, _unaliasargs(C, A, Bs...)...))
@@ -1061,7 +1062,7 @@ end
 # (10) broadcast over combinations of broadcast scalars and sparse vectors/matrices
 
 # broadcast entry points for combinations of sparse arrays and other (scalar) types
-@inline function copy(bc::Broadcasted{<:SPVM})
+@inline function copy(bc::Broadcasted{<:SparseVecOrMatStyle})
     bcf = flatten(bc)
     return _copy(bcf.f, bcf.args...)
 end
@@ -1081,7 +1082,7 @@ function _shapecheckbc(f, args...)
 end
 
 
-@inline function copyto!(dest::SparseVecOrMat, bc::Broadcasted{<:SPVM})
+@inline function copyto!(dest::SparseVecOrMat, bc::Broadcasted{<:SparseVecOrMatStyle})
     if bc.f === identity && bc isa SpBroadcasted1 && Base.axes(dest) == (A = bc.args[1]; Base.axes(A))
         return copyto!(dest, A)
     end
@@ -1205,7 +1206,7 @@ _sparsifystructured(x) = x
 
 
 # (12) map[!] over combinations of sparse and structured matrices
-const SparseOrStructuredMatrix = Union{FixedSparseCSC,SparseMatrixCSC,SparseMatrixCSCView,LinearAlgebra.StructuredMatrix}
+const SparseOrStructuredMatrix = Union{SparseMatrixCSCOrView,LinearAlgebra.StructuredMatrix}
 map(f::Tf, A::SparseOrStructuredMatrix, Bs::Vararg{SparseOrStructuredMatrix,N}) where {Tf,N} =
     (_checksameshape(A, Bs...); _noshapecheck_map(f, _sparsifystructured(A), map(_sparsifystructured, Bs)...))
 map!(f::Tf, C::AbstractSparseMatrixCSC, A::SparseOrStructuredMatrix, Bs::Vararg{SparseOrStructuredMatrix,N}) where {Tf,N} =

--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -11,7 +11,7 @@ using Base: front, tail, to_shape
 using ..SparseArrays: SparseVector, SparseMatrixCSC, FixedSparseCSC, SparseMatrixCSCView,
                       AbstractCompressedVector, AbstractSparseVector, AbstractSparseMatrixCSC,
                       AbstractSparseMatrix, AbstractSparseArray,
-                      SparseVectorUnion, AdjOrTransSparseVectorUnion,
+                      SparseVectorUnion, AdjOrTransSparseVectorUnion, SparseVecOrMat, DiagBiTriSym,
                       indtype, fixed, move_fixed, nnz, nzrange, spzeros,
                       nonzeroinds, nonzeros, rowvals, getcolptr, widelength,
                       _iszero, _isnotzero, _is_fixed, @if_move_fixed
@@ -37,8 +37,6 @@ using LinearAlgebra
 
 
 # (0) BroadcastStyle rules and convenience types for dispatch
-
-const SparseVecOrMat = Union{AbstractCompressedVector,AbstractSparseMatrixCSC}
 
 # broadcast container type promotion for combinations of sparse arrays and other types
 struct SparseVecStyle <: Broadcast.AbstractArrayStyle{1} end
@@ -71,7 +69,6 @@ PromoteToSparse(::Val{1}) = PromoteToSparse()
 PromoteToSparse(::Val{2}) = PromoteToSparse()
 PromoteToSparse(::Val{N}) where N = Broadcast.DefaultArrayStyle{N}()
 
-const StructuredMatrix = Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}
 Broadcast.BroadcastStyle(::Type{<:Adjoint{T,<:Union{AbstractCompressedVector,AbstractSparseMatrixCSC}} where T}) = PromoteToSparse()
 Broadcast.BroadcastStyle(::Type{<:Transpose{T,<:Union{AbstractCompressedVector,AbstractSparseMatrixCSC}} where T}) = PromoteToSparse()
 
@@ -80,8 +77,8 @@ Broadcast.BroadcastStyle(s::SPVM, ::Broadcast.DefaultArrayStyle{0}) = s
 Broadcast.BroadcastStyle(::SPVM, ::Broadcast.DefaultArrayStyle{1}) = PromoteToSparse()
 Broadcast.BroadcastStyle(::SPVM, ::Broadcast.DefaultArrayStyle{2}) = PromoteToSparse()
 
-Broadcast.BroadcastStyle(::SPVM, ::LinearAlgebra.StructuredMatrixStyle{<:StructuredMatrix}) = PromoteToSparse()
-Broadcast.BroadcastStyle(::PromoteToSparse, ::LinearAlgebra.StructuredMatrixStyle{<:StructuredMatrix}) = PromoteToSparse()
+Broadcast.BroadcastStyle(::SPVM, ::LinearAlgebra.StructuredMatrixStyle{<:DiagBiTriSym}) = PromoteToSparse()
+Broadcast.BroadcastStyle(::PromoteToSparse, ::LinearAlgebra.StructuredMatrixStyle{<:DiagBiTriSym}) = PromoteToSparse()
 
 Broadcast.BroadcastStyle(::PromoteToSparse, ::SPVM) = PromoteToSparse()
 Broadcast.BroadcastStyle(::PromoteToSparse, ::Broadcast.Style{Tuple}) = Broadcast.DefaultArrayStyle{2}()
@@ -92,7 +89,7 @@ Broadcast.BroadcastStyle(::PromoteToSparse, ::Broadcast.Style{Tuple}) = Broadcas
 is_supported_sparse_broadcast() = true
 is_supported_sparse_broadcast(::AbstractArray, rest...) = false
 is_supported_sparse_broadcast(::AbstractSparseArray, rest...) = is_supported_sparse_broadcast(rest...)
-is_supported_sparse_broadcast(::StructuredMatrix, rest...) = is_supported_sparse_broadcast(rest...)
+is_supported_sparse_broadcast(::DiagBiTriSym, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(::Array, rest...) = is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(t::Union{Transpose, Adjoint}, rest...) = is_supported_sparse_broadcast(parent(t), rest...)
 is_supported_sparse_broadcast(v::SubArray, rest...) = is_supported_sparse_broadcast(parent(v), rest...)

--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -11,7 +11,7 @@ using Base: front, tail, to_shape
 using ..SparseArrays: SparseVector, SparseMatrixCSC, FixedSparseCSC, SparseMatrixCSCView,
                       AbstractCompressedVector, AbstractSparseVector, AbstractSparseMatrixCSC,
                       AbstractSparseMatrix, AbstractSparseArray,
-                      SparseVectorUnion, AdjOrTransSparseVectorUnion, SparseVecOrMat, DiagBiTriSym,
+                      SparseVectorOrView, AdjOrTransSparseVectorOrView, SparseVecOrMat, DiagBiTriSym,
                       indtype, fixed, move_fixed, nnz, nzrange, spzeros,
                       nonzeroinds, nonzeros, rowvals, getcolptr, widelength,
                       _iszero, _isnotzero, _is_fixed, @if_move_fixed
@@ -97,7 +97,7 @@ is_supported_sparse_broadcast(x, rest...) = axes(x) === () && is_supported_spars
 is_supported_sparse_broadcast(x::Ref, rest...) = is_supported_sparse_broadcast(rest...)
 
 can_skip_sparsification(f, rest...) = false
-can_skip_sparsification(::typeof(*), ::SparseVectorUnion, ::AdjOrTransSparseVectorUnion) = true
+can_skip_sparsification(::typeof(*), ::SparseVectorOrView, ::AdjOrTransSparseVectorOrView) = true
 
 # Dispatch on broadcast operations by number of arguments
 const Broadcasted0{Style<:Union{Nothing,BroadcastStyle},Axes,F} =
@@ -861,9 +861,9 @@ _finishempty!(C::AbstractCompressedVector) = C
 _finishempty!(C::AbstractSparseMatrixCSC) = (fill!(getcolptr(C), 1); C)
 
 # special case - vector outer product
-_copy(f::typeof(*), x::SparseVectorUnion, y::AdjOrTransSparseVectorUnion) = _outer(x, y)
-@inline _outer(x::SparseVectorUnion, y::Adjoint) = return _outer(conj, x, parent(y))
-@inline _outer(x::SparseVectorUnion, y::Transpose) = return _outer(identity, x, parent(y))
+_copy(f::typeof(*), x::SparseVectorOrView, y::AdjOrTransSparseVectorOrView) = _outer(x, y)
+@inline _outer(x::SparseVectorOrView, y::Adjoint) = return _outer(conj, x, parent(y))
+@inline _outer(x::SparseVectorOrView, y::Transpose) = return _outer(identity, x, parent(y))
 function _outer(trans::Tf, x, y) where Tf
     nx = length(x)
     ny = length(y)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -302,9 +302,12 @@ end
 # Sparse matrix multiplication as described in [Gustavson, 1978]:
 # http://dl.acm.org/citation.cfm?id=355796
 
-*(A::SparseOrTri, B::AbstractSparseVector) = spmatmulv(A, B)
-*(A::SparseOrTri, B::SparseColumnView) = spmatmulv(A, B)
-*(A::SparseOrTri, B::SparseVectorView) = spmatmulv(A, B)
+# spmatmul handles compressed vectors and whole-column/whole-vector views; other
+# AbstractSparseVectors take the generic product. Plain CSC times a compressed vector is
+# defined in sparsevector.jl.
+*(A::SparseTriangular, B::SparseVectorOrView) = spmatmulv(A, B)
+*(A::SparseMatrixCSCView, B::SparseVectorOrView) = spmatmulv(A, B)
+*(A::AbstractSparseMatrixCSC, B::Union{SparseColumnView,SparseVectorView}) = spmatmulv(A, B)
 *(A::SparseMatrixCSCOrView, B::SparseMatrixCSCOrView) = spmatmul(A,B)
 *(A::SparseTriangular, B::SparseMatrixCSCOrView) = spmatmul(A,B)
 *(A::SparseMatrixCSCOrView, B::SparseTriangular) = spmatmul(A,B)
@@ -341,15 +344,19 @@ end
 # depending on expected execution speed the sorting of the result column is
 # done by a quicksort of the row indices or by a full scan of the dense result vector.
 # The last is faster, if more than ≈ 1/32 of the result column is nonzero.
-# TODO: extend to SparseMatrixCSCOrView to allow for SubArrays (view(X, :, r)).
 # Unit triangular wrappers keep their diagonal implicitly, so they are materialized first.
+# The added diagonal may not fit the parent's index type, in which case a wider one is used
+# for the temporary; the result keeps the index type of the operands.
 _explicitdiag(A) = A
-_explicitdiag(A::UnitUpperOrUnitLowerTriangular{<:Any,<:SparseMatrixCSCOrView}) = sparse(A)
+_explicitdiag(A::UnitUpperTriangular{<:Any,<:SparseMatrixCSCOrView}) = sparse(UnitUpperTriangular(_fitsdiag(parent(A))))
+_explicitdiag(A::UnitLowerTriangular{<:Any,<:SparseMatrixCSCOrView}) = sparse(UnitLowerTriangular(_fitsdiag(parent(A))))
+# colptr[end] is one past the stored count
+_fitsdiag(S) = nnz(S) + size(S, 2) < typemax(indtype(S)) ? S : SparseMatrixCSC{eltype(S),Int}(S)
 function spmatmul(A::SparseOrTri, B::Union{SparseOrTri,AbstractCompressedVector,SubArray{<:Any,<:Any,<:AbstractSparseArray}})
-    A = _explicitdiag(A)
-    B = _explicitdiag(B)
     Tv = promote_op(matprod, eltype(A), eltype(B))
     Ti = promote_type(indtype(A), indtype(B))
+    A = _explicitdiag(A)
+    B = _explicitdiag(B)
     mA, nA = size(A)
     nB = size(B, 2)
     mB = size(B, 1)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using LinearAlgebra: AbstractTriangular, UpperOrLowerTriangular,
-    RealHermSymComplexHerm, HermOrSym, checksquare, sym_uplo, wrap
+    RealHermSymComplexHerm, checksquare, sym_uplo, wrap
 using Random: rand!
 
 import LinearAlgebra: _uppercase, _isuppercase
@@ -44,12 +44,13 @@ end
 const tilebufsize = 10800  # Approximately 32k/3
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
-const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
 const DenseMatrixUnion = Union{StridedMatrix, BitMatrix}
 const DenseInputVector = Union{StridedVector, BitVector}
-const DenseViewWrappers{T,S} = Union{AdjOrTrans{T,S}, HermOrSym{T,S}, UpperOrLowerTriangular{T,S}, UpperHessenberg{T,S}}
-const QuasiSparseMatrix = Union{SparseMatrixCSCUnion2, DenseViewWrappers{<:Any,<:SparseMatrixCSCUnion2}}
-const QuasiStridedMatrix = Union{StridedMatrix, DenseViewWrappers{<:Any,<:StridedMatrix}}
+# LinearAlgebra wrappers of a matrix of type MT, and those plus 2-d views (for dot)
+const MatrixWrappers{T,MT} = Union{AdjOrTrans{T,MT}, HermOrSym{T,MT}, UpperOrLowerTriangular{T,MT}, UpperHessenberg{T,MT}}
+const WrapperMatrixTypes{T,MT} = Union{SubArray{T,2,MT}, MatrixWrappers{T,MT}}
+const QuasiSparseMatrix = Union{SparseMatrixCSCOrColumnSubset, MatrixWrappers{<:Any,<:SparseMatrixCSCOrColumnSubset}}
+const QuasiStridedMatrix = Union{StridedMatrix, MatrixWrappers{<:Any,<:StridedMatrix}}
 
 matop_dest(::typeof(*), A::QuasiStridedMatrix, b::AbstractSparseVector) =
     Vector{promote_op(matprod, eltype(A), eltype(b))}(undef, size(A, 1))
@@ -82,11 +83,11 @@ for op ∈ (:+, :-)
     end
 end
 
-mul!(C::StridedMatrix, tA, tB, A::SparseMatrixCSCUnion2, B::DenseMatrixUnion, alpha::Number, beta::Number) =
+mul!(C::StridedMatrix, tA, tB, A::SparseMatrixCSCOrColumnSubset, B::DenseMatrixUnion, alpha::Number, beta::Number) =
     spdensemul!(C, tA, tB, A, B, alpha, beta)
 LinearAlgebra._mul!(C::StridedMatrix, A::QuasiSparseMatrix, B::AbstractTriangular, alpha::Number, beta::Number) =
     spdensemul!(C, LinearAlgebra.wrapper_char(A), LinearAlgebra.wrapper_char(B), LinearAlgebra._unwrap(A), B, alpha, beta)
-mul!(C::StridedVecOrMat, tA, A::SparseMatrixCSCUnion2, B::DenseInputVector, alpha::Number, beta::Number) =
+mul!(C::StridedVecOrMat, tA, A::SparseMatrixCSCOrColumnSubset, B::DenseInputVector, alpha::Number, beta::Number) =
     spdensemul!(C, tA, 'N', A, B, alpha, beta)
 
 Base.@constprop :aggressive function spdensemul!(C, tA, tB, A, B, alpha, beta)
@@ -199,7 +200,7 @@ function _At_or_Ac_mul_B!(tfun::Function, C, A, B, α, β)
     end
 end
 
-Base.@constprop :aggressive function LinearAlgebra.generic_matmatmul_wrapper!(C::StridedMatrix, tA, tB, A::DenseMatrixUnion, B::SparseMatrixCSCUnion2, alpha::Number, beta::Number, ::LinearAlgebra.BlasFlag.SyrkHerkGemm)
+Base.@constprop :aggressive function LinearAlgebra.generic_matmatmul_wrapper!(C::StridedMatrix, tA, tB, A::DenseMatrixUnion, B::SparseMatrixCSCOrColumnSubset, alpha::Number, beta::Number, ::LinearAlgebra.BlasFlag.SyrkHerkGemm)
     transA = tA == 'N' ? identity : tA == 'T' ? transpose : adjoint
     if tB == 'N'
         _spmul!(C, transA(A), B, alpha, beta)
@@ -210,10 +211,10 @@ Base.@constprop :aggressive function LinearAlgebra.generic_matmatmul_wrapper!(C:
     end
     return C
 end
-Base.@constprop :aggressive LinearAlgebra.generic_matmatmul_wrapper!(C::StridedMatrix, tA, tB, A::DenseMatrixUnion, B::SparseMatrixCSCUnion2, alpha::Number, beta::Number, @nospecialize(val)) =
+Base.@constprop :aggressive LinearAlgebra.generic_matmatmul_wrapper!(C::StridedMatrix, tA, tB, A::DenseMatrixUnion, B::SparseMatrixCSCOrColumnSubset, alpha::Number, beta::Number, @nospecialize(val)) =
     LinearAlgebra._generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
 
-function _spmul!(C::StridedMatrix, X::DenseMatrixUnion, A::SparseMatrixCSCUnion2, α::Number, β::Number)
+function _spmul!(C::StridedMatrix, X::DenseMatrixUnion, A::SparseMatrixCSCOrColumnSubset, α::Number, β::Number)
     Aax2 = axes(A, 2)
     Xax1 = axes(X, 1)
     mC, nC, mX, nX, mA, nA = _matmul_size_AB(C, X, A)
@@ -234,7 +235,7 @@ function _spmul!(C::StridedMatrix, X::DenseMatrixUnion, A::SparseMatrixCSCUnion2
         end
     end
 end
-function _spmul!(C::StridedMatrix, X::AdjOrTrans{<:Any,<:DenseMatrixUnion}, A::SparseMatrixCSCUnion2, α::Number, β::Number)
+function _spmul!(C::StridedMatrix, X::AdjOrTrans{<:Any,<:DenseMatrixUnion}, A::SparseMatrixCSCOrColumnSubset, α::Number, β::Number)
     Xax1 = axes(X, 1)
     Cax2 = axes(C, 2)
     mC, nC, mX, nX, mA, nA = _matmul_size_AB(C, X, A)
@@ -260,7 +261,7 @@ function _spmul!(C::StridedMatrix, X::AdjOrTrans{<:Any,<:DenseMatrixUnion}, A::S
     end
 end
 
-function _A_mul_Bt_or_Bc!(tfun::Function, C::StridedMatrix, A::AbstractMatrix, B::SparseMatrixCSCUnion2, α::Number, β::Number)
+function _A_mul_Bt_or_Bc!(tfun::Function, C::StridedMatrix, A::AbstractMatrix, B::SparseMatrixCSCOrColumnSubset, α::Number, β::Number)
     Bax2 = axes(B, 2)
     Aax1 = axes(A, 1)
     mC, nC, mA, nA, mB, nB = _matmul_size_ABt(C, A, B)
@@ -300,9 +301,6 @@ end
 
 # Sparse matrix multiplication as described in [Gustavson, 1978]:
 # http://dl.acm.org/citation.cfm?id=355796
-
-const SparseTriangular{Tv,Ti} = Union{UpperTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}},LowerTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}}
-const SparseOrTri{Tv,Ti} = Union{SparseMatrixCSCUnion{Tv,Ti},SparseTriangular{Tv,Ti}}
 
 *(A::SparseOrTri, B::AbstractSparseVector) = spmatmulv(A, B)
 *(A::SparseOrTri, B::SparseColumnView) = spmatmulv(A, B)
@@ -344,7 +342,12 @@ end
 # done by a quicksort of the row indices or by a full scan of the dense result vector.
 # The last is faster, if more than ≈ 1/32 of the result column is nonzero.
 # TODO: extend to SparseMatrixCSCUnion to allow for SubArrays (view(X, :, r)).
+# Unit triangular wrappers keep their diagonal implicitly, so they are materialized first.
+_explicitdiag(A) = A
+_explicitdiag(A::UnitUpperOrUnitLowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = sparse(A)
 function spmatmul(A::SparseOrTri, B::Union{SparseOrTri,AbstractCompressedVector,SubArray{<:Any,<:Any,<:AbstractSparseArray}})
+    A = _explicitdiag(A)
+    B = _explicitdiag(B)
     Tv = promote_op(matprod, eltype(A), eltype(B))
     Ti = promote_type(indtype(A), indtype(B))
     mA, nA = size(A)
@@ -431,12 +434,10 @@ end
 
 # special cases of same twin Upper/LowerTriangular
 spmatmul1(A, B) = spmatmul(A, B)
-function spmatmul1(A::UpperTriangular, B::UpperTriangular)
-    UpperTriangular(spmatmul(A, B))
-end
-function spmatmul1(A::LowerTriangular, B::LowerTriangular)
-    LowerTriangular(spmatmul(A, B))
-end
+spmatmul1(A::UpperOrUnitUpperTriangular, B::UpperOrUnitUpperTriangular) = UpperTriangular(spmatmul(A, B))
+spmatmul1(A::UnitUpperTriangular, B::UnitUpperTriangular) = UnitUpperTriangular(spmatmul(A, B))
+spmatmul1(A::LowerOrUnitLowerTriangular, B::LowerOrUnitLowerTriangular) = LowerTriangular(spmatmul(A, B))
+spmatmul1(A::UnitLowerTriangular, B::UnitLowerTriangular) = UnitLowerTriangular(spmatmul(A, B))
 # exploit spmatmul for sparse vectors and column views
 function spmatmulv(A, B)
     spmatmul(A, B)[:,1]
@@ -450,8 +451,8 @@ function estimate_mulsize(m::Integer, nnzA::Integer, n::Integer, nnzB::Integer, 
     p >= 1 ? m*k : p > 0 ? Int(ceil(-expm1(log1p(-p) * n)*m*k)) : 0 # (1-(1-p)^n)*m*k
 end
 
-Base.@constprop :aggressive function mul!(C::SparseMatrixCSCUnion2, tA, tB, A::SparseMatrixCSCUnion2,
-                            B::SparseMatrixCSCUnion2, alpha::Number, beta::Number)
+Base.@constprop :aggressive function mul!(C::SparseMatrixCSCOrColumnSubset, tA, tB, A::SparseMatrixCSCOrColumnSubset,
+                            B::SparseMatrixCSCOrColumnSubset, alpha::Number, beta::Number)
     tA_uc, tB_uc = _uppercase(tA), _uppercase(tB)
     Anew, ta = tA_uc in ('S', 'H') ? (wrap(A, tA), oftype(tA, 'N')) : (A, tA)
     Bnew, tb = tB_uc in ('S', 'H') ? (wrap(B, tB), oftype(tB, 'N')) : (B, tB)
@@ -459,7 +460,7 @@ Base.@constprop :aggressive function mul!(C::SparseMatrixCSCUnion2, tA, tB, A::S
 end
 # Sparse-destination counterpart of `LinearAlgebra._generic_matmatmul!` (which this file also
 # calls, qualified, for dense destinations); named distinctly so the two are not confused.
-function _generic_spmatmatmul!(C::SparseMatrixCSCUnion2, tA, tB, A::AbstractVecOrMat,
+function _generic_spmatmatmul!(C::SparseMatrixCSCOrColumnSubset, tA, tB, A::AbstractVecOrMat,
                                 B::AbstractVecOrMat, _add::MulAddMul)
     @assert tA in ('N', 'T', 'C') && tB in ('N', 'T', 'C')
     require_one_based_indexing(C, A, B)
@@ -720,16 +721,6 @@ function dot(x::AbstractSparseVector, A::AbstractSparseMatrixCSC, y::AbstractSpa
     end
     r
 end
-
-const WrapperMatrixTypes{T,MT} = Union{
-    SubArray{T,2,MT},
-    Adjoint{T,MT},
-    Transpose{T,MT},
-    UpperOrLowerTriangular{T,MT},
-    UpperHessenberg{T,MT},
-    Symmetric{T,MT},
-    Hermitian{T,MT},
-}
 
 function dot(A::Union{DenseMatrixUnion,WrapperMatrixTypes{<:Any,<:Union{DenseMatrixUnion,AbstractSparseMatrix}}}, B::AbstractSparseMatrixCSC)
     T = promote_type(eltype(A), eltype(B))
@@ -1917,21 +1908,11 @@ function opnormestinv(A::AbstractSparseMatrixCSC{T}, t::Integer = min(2,maximum(
 end
 
 ## kron
-const _SparseArraysCSC = Union{AbstractCompressedVector, AbstractSparseMatrixCSC}
-const _SparseKronArrays = Union{_SparseArraysCSC, AdjOrTrans{<:Any,<:_SparseArraysCSC}}
-
-const _Symmetric_SparseKronArrays = Symmetric{<:Any,<:_SparseKronArrays}
-const _Hermitian_SparseKronArrays = Hermitian{<:Any,<:_SparseKronArrays}
-const _Triangular_SparseKronArrays = UpperOrLowerTriangular{<:Any,<:_SparseKronArrays}
-const _Annotated_SparseKronArrays = Union{_Triangular_SparseKronArrays, _Symmetric_SparseKronArrays, _Hermitian_SparseKronArrays}
-const _SparseKronGroup = Union{_SparseKronArrays, _Annotated_SparseKronArrays}
-
-const _SpecialArrays = Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}
-const _Symmetric_DenseArrays{T,A<:Matrix} = Symmetric{T,A}
-const _Hermitian_DenseArrays{T,A<:Matrix} = Hermitian{T,A}
-const _Triangular_DenseArrays{T,A<:Matrix} = UpperOrLowerTriangular{<:Any,A} # AbstractTriangular{T,A}
-const _Annotated_DenseArrays = Union{_SpecialArrays, _Triangular_DenseArrays, _Symmetric_DenseArrays, _Hermitian_DenseArrays}
-const _DenseKronGroup = Union{Number, Vector, Matrix, AdjOrTrans{<:Any,<:VecOrMat}, _Annotated_DenseArrays}
+const _SparseKronGroup = Union{SparseVecOrMatMaybeAdjOrTrans,
+                               HermOrSym{<:Any,<:SparseVecOrMatMaybeAdjOrTrans},
+                               UpperOrLowerTriangular{<:Any,<:SparseVecOrMatMaybeAdjOrTrans}}
+const _DenseKronGroup = Union{Number, Vector, Matrix, AdjOrTrans{<:Any,<:VecOrMat}, DiagBiTriSym,
+                              HermOrSym{<:Any,<:Matrix}, UpperOrLowerTriangular{<:Any,<:Matrix}}
 
 @inline function kron!(C::SparseMatrixCSC, A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)
     mA, nA = size(A); mB, nB = size(B)
@@ -1995,7 +1976,7 @@ kron!(C::SparseMatrixCSC, A::_DenseKronGroup, B::_SparseKronGroup) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
 kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_SparseKronGroup) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
-kron!(C::SparseMatrixCSC, A::_SparseVectorUnion, B::_AdjOrTransSparseVectorUnion) =
+kron!(C::SparseMatrixCSC, A::SparseVectorUnion, B::AdjOrTrans{<:Any,<:SparseVectorUnion}) =
     broadcast!(*, C, A, B)
 # disambiguation
 kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::Diagonal) =
@@ -2030,7 +2011,7 @@ kron(A::_SparseKronGroup, B::_SparseKronGroup) =
     kron(convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
 kron(A::_SparseKronGroup, B::_DenseKronGroup) = kron(A, sparse(B))
 kron(A::_DenseKronGroup, B::_SparseKronGroup) = kron(sparse(A), B)
-kron(A::_SparseVectorUnion, B::_AdjOrTransSparseVectorUnion) = A .* B
+kron(A::SparseVectorUnion, B::AdjOrTrans{<:Any,<:SparseVectorUnion}) = A .* B
 # disambiguation
 kron(A::AbstractCompressedVector, B::AdjOrTrans{<:Any,<:AbstractCompressedVector}) = A .* B
 kron(a::Number, b::_SparseKronGroup) = a * b

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -305,15 +305,15 @@ end
 *(A::SparseOrTri, B::AbstractSparseVector) = spmatmulv(A, B)
 *(A::SparseOrTri, B::SparseColumnView) = spmatmulv(A, B)
 *(A::SparseOrTri, B::SparseVectorView) = spmatmulv(A, B)
-*(A::SparseMatrixCSCUnion, B::SparseMatrixCSCUnion) = spmatmul(A,B)
-*(A::SparseTriangular, B::SparseMatrixCSCUnion) = spmatmul(A,B)
-*(A::SparseMatrixCSCUnion, B::SparseTriangular) = spmatmul(A,B)
+*(A::SparseMatrixCSCOrView, B::SparseMatrixCSCOrView) = spmatmul(A,B)
+*(A::SparseTriangular, B::SparseMatrixCSCOrView) = spmatmul(A,B)
+*(A::SparseMatrixCSCOrView, B::SparseTriangular) = spmatmul(A,B)
 *(A::SparseTriangular, B::SparseTriangular) = spmatmul1(A,B)
 *(A::SparseOrTri, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = spmatmul(A, copy(B))
 *(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, B::SparseOrTri) = spmatmul(copy(A), B)
 *(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = spmatmul(copy(A), copy(B))
 
-(*)(Da::Diagonal, A::Union{SparseMatrixCSCUnion, AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}}, Db::Diagonal) = Da * (A * Db)
+(*)(Da::Diagonal, A::Union{SparseMatrixCSCOrView, AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}}, Db::Diagonal) = Da * (A * Db)
 function (*)(Da::Diagonal, A::SparseMatrixCSC, Db::Diagonal)
     (size(Da, 2) == size(A,1) && size(A,2) == size(Db,1)) ||
         throw(DimensionMismatch("incompatible sizes"))
@@ -341,10 +341,10 @@ end
 # depending on expected execution speed the sorting of the result column is
 # done by a quicksort of the row indices or by a full scan of the dense result vector.
 # The last is faster, if more than ≈ 1/32 of the result column is nonzero.
-# TODO: extend to SparseMatrixCSCUnion to allow for SubArrays (view(X, :, r)).
+# TODO: extend to SparseMatrixCSCOrView to allow for SubArrays (view(X, :, r)).
 # Unit triangular wrappers keep their diagonal implicitly, so they are materialized first.
 _explicitdiag(A) = A
-_explicitdiag(A::UnitUpperOrUnitLowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = sparse(A)
+_explicitdiag(A::UnitUpperOrUnitLowerTriangular{<:Any,<:SparseMatrixCSCOrView}) = sparse(A)
 function spmatmul(A::SparseOrTri, B::Union{SparseOrTri,AbstractCompressedVector,SubArray{<:Any,<:Any,<:AbstractSparseArray}})
     A = _explicitdiag(A)
     B = _explicitdiag(B)
@@ -871,7 +871,7 @@ end
 
 ## triangular sparse handling
 ## triangular multiplication
-function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, tfun::Function, A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
+function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, tfun::Function, A::SparseMatrixCSCOrView, B::AbstractVecOrMat)
     require_one_based_indexing(A, C)
     nrowC = size(C, 1)
     ncol = checksquare(A)
@@ -1002,7 +1002,7 @@ function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, tf
     end
     return C
 end
-function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, ::Function, xA::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion}, B::AbstractVecOrMat)
+function LinearAlgebra.generic_trimatmul!(C::StridedVecOrMat, uploc, isunitc, ::Function, xA::AdjOrTrans{<:Any,<:SparseMatrixCSCOrView}, B::AbstractVecOrMat)
     A = parent(xA)
     nrowC = size(C, 1)
     ncol = checksquare(A)
@@ -1082,7 +1082,7 @@ end
 _uconvert_copyto!(c, b, oA) = (c .= Ref(oA) .\ b)
 _uconvert_copyto!(c::AbstractArray{T}, b::AbstractArray{T}, _) where {T} = copyto!(c, b)
 
-function LinearAlgebra.generic_trimatdiv!(C::StridedVecOrMat, uploc, isunitc, tfun::Function, A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
+function LinearAlgebra.generic_trimatdiv!(C::StridedVecOrMat, uploc, isunitc, tfun::Function, A::SparseMatrixCSCOrView, B::AbstractVecOrMat)
     mA, nA = size(A)
     nrowB, ncolB = size(B, 1), size(B, 2)
     if nA != nrowB
@@ -1218,7 +1218,7 @@ function LinearAlgebra.generic_trimatdiv!(C::StridedVecOrMat, uploc, isunitc, tf
     end
     C
 end
-function LinearAlgebra.generic_trimatdiv!(C::StridedVecOrMat, uploc, isunitc, ::Function, xA::AdjOrTrans{<:Any,<:SparseMatrixCSCUnion}, B::AbstractVecOrMat)
+function LinearAlgebra.generic_trimatdiv!(C::StridedVecOrMat, uploc, isunitc, ::Function, xA::AdjOrTrans{<:Any,<:SparseMatrixCSCOrView}, B::AbstractVecOrMat)
     A = parent(xA)
     mA, nA = size(A)
     nrowB, ncolB = size(B, 1), size(B, 2)
@@ -1976,7 +1976,7 @@ kron!(C::SparseMatrixCSC, A::_DenseKronGroup, B::_SparseKronGroup) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
 kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::_SparseKronGroup) =
     kron!(C, convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
-kron!(C::SparseMatrixCSC, A::SparseVectorUnion, B::AdjOrTrans{<:Any,<:SparseVectorUnion}) =
+kron!(C::SparseMatrixCSC, A::SparseVectorOrView, B::AdjOrTrans{<:Any,<:SparseVectorOrView}) =
     broadcast!(*, C, A, B)
 # disambiguation
 kron!(C::SparseMatrixCSC, A::_SparseKronGroup, B::Diagonal) =
@@ -2011,7 +2011,7 @@ kron(A::_SparseKronGroup, B::_SparseKronGroup) =
     kron(convert(SparseMatrixCSC, A), convert(SparseMatrixCSC, B))
 kron(A::_SparseKronGroup, B::_DenseKronGroup) = kron(A, sparse(B))
 kron(A::_DenseKronGroup, B::_SparseKronGroup) = kron(sparse(A), B)
-kron(A::SparseVectorUnion, B::AdjOrTrans{<:Any,<:SparseVectorUnion}) = A .* B
+kron(A::SparseVectorOrView, B::AdjOrTrans{<:Any,<:SparseVectorOrView}) = A .* B
 # disambiguation
 kron(A::AbstractCompressedVector, B::AdjOrTrans{<:Any,<:AbstractCompressedVector}) = A .* B
 kron(a::Number, b::_SparseKronGroup) = a * b

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -48,7 +48,7 @@ const DenseMatrixUnion = Union{StridedMatrix, BitMatrix}
 const DenseInputVector = Union{StridedVector, BitVector}
 # LinearAlgebra wrappers of a matrix of type MT, and those plus 2-d views (for dot)
 const MatrixWrappers{T,MT} = Union{AdjOrTrans{T,MT}, HermOrSym{T,MT}, UpperOrLowerTriangular{T,MT}, UpperHessenberg{T,MT}}
-const WrapperMatrixTypes{T,MT} = Union{SubArray{T,2,MT}, MatrixWrappers{T,MT}}
+const MatrixWrappersOrView{T,MT} = Union{SubArray{T,2,MT}, MatrixWrappers{T,MT}}
 const QuasiSparseMatrix = Union{SparseMatrixCSCOrColumnSubset, MatrixWrappers{<:Any,<:SparseMatrixCSCOrColumnSubset}}
 const QuasiStridedMatrix = Union{StridedMatrix, MatrixWrappers{<:Any,<:StridedMatrix}}
 
@@ -722,7 +722,7 @@ function dot(x::AbstractSparseVector, A::AbstractSparseMatrixCSC, y::AbstractSpa
     r
 end
 
-function dot(A::Union{DenseMatrixUnion,WrapperMatrixTypes{<:Any,<:Union{DenseMatrixUnion,AbstractSparseMatrix}}}, B::AbstractSparseMatrixCSC)
+function dot(A::Union{DenseMatrixUnion,MatrixWrappersOrView{<:Any,<:Union{DenseMatrixUnion,AbstractSparseMatrix}}}, B::AbstractSparseMatrixCSC)
     T = promote_type(eltype(A), eltype(B))
     (m, n) = size(A)
     if (m, n) != size(B)
@@ -744,7 +744,7 @@ function dot(A::Union{DenseMatrixUnion,WrapperMatrixTypes{<:Any,<:Union{DenseMat
     return s
 end
 
-function dot(A::AbstractSparseMatrixCSC, B::Union{DenseMatrixUnion,WrapperMatrixTypes{<:Any,<:Union{DenseMatrixUnion,AbstractSparseMatrix}}})
+function dot(A::AbstractSparseMatrixCSC, B::Union{DenseMatrixUnion,MatrixWrappersOrView{<:Any,<:Union{DenseMatrixUnion,AbstractSparseMatrix}}})
     return conj(dot(B, A))
 end
 
@@ -806,7 +806,7 @@ end
 
 function dot(
     a::AbstractSparseVector,
-    Q::Union{DenseMatrixUnion,WrapperMatrixTypes{<:Any,<:DenseMatrixUnion}},
+    Q::Union{DenseMatrixUnion,MatrixWrappersOrView{<:Any,<:DenseMatrixUnion}},
     b::AbstractSparseVector,
 )
     return _dot_quadratic_form(a, Q, b)
@@ -822,7 +822,7 @@ end
 
 function dot(
     a::AbstractSparseVector,
-    Q::LinearAlgebra.Transpose{<:Real,<:WrapperMatrixTypes{<:Real,<:DenseMatrixUnion}},
+    Q::LinearAlgebra.Transpose{<:Real,<:MatrixWrappersOrView{<:Real,<:DenseMatrixUnion}},
     b::AbstractSparseVector,
 )
     return _dot_quadratic_form(a, Q, b)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1911,7 +1911,7 @@ end
 const _SparseKronGroup = Union{SparseVecOrMatMaybeAdjOrTrans,
                                HermOrSym{<:Any,<:SparseVecOrMatMaybeAdjOrTrans},
                                UpperOrLowerTriangular{<:Any,<:SparseVecOrMatMaybeAdjOrTrans}}
-const _DenseKronGroup = Union{Number, Vector, Matrix, AdjOrTrans{<:Any,<:VecOrMat}, DiagBiTriSym,
+const _DenseKronGroup = Union{Number, Vector, Matrix, AdjOrTrans{<:Any,<:VecOrMat}, BandedMatrix,
                               HermOrSym{<:Any,<:Matrix}, UpperOrLowerTriangular{<:Any,<:Matrix}}
 
 @inline function kron!(C::SparseMatrixCSC, A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -2068,10 +2068,7 @@ const FactorComponentRHS = Union{StridedVecOrMatMaybeAdjOrTrans, SparseVectorOrM
 (\)(adjL::AdjointFactorization{T,<:Factor}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = strided_solve(adjL, B)
 (\)(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::AdjOrTransAbsMat) = adjL \ copy(B)
 
-const RealHermSymComplexHermSSL{Ti, Tr} = Union{
-    Symmetric{Tr, SparseMatrixCSC{Tr, Ti}},
-    Hermitian{Tr, SparseMatrixCSC{Tr, Ti}},
-    Hermitian{Complex{Tr}, SparseMatrixCSC{Complex{Tr}, Ti}}} where {Ti<:ITypes, Tr<:Union{Float64, Float32, Float16}}
+const RealHermSymComplexHermSSL{Ti, Tr} = RealHermSymComplexHerm{Tr, <:SparseMatrixCSC{<:Any, Ti}} where {Ti<:ITypes, Tr<:Union{Float64, Float32, Float16}}
 
 function \(A::RealHermSymComplexHermSSL{Ti}, B::StridedVecOrMatMaybeAdjOrTrans) where {Ti}
     T = typeof(one(eltype(A)) \ one(eltype(B)))

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -23,7 +23,7 @@ import LinearAlgebra: (\), AdjointFactorization,
                  lowrankdowndate, lowrankdowndate!, lowrankupdate, lowrankupdate!
 
 using SparseArrays
-using SparseArrays: getcolptr, AbstractSparseVecOrMat
+using SparseArrays: getcolptr, AbstractSparseVecOrMat, AbstractSparseVecOrMatMaybeAdjOrTrans
 export
     Dense,
     Factor,
@@ -112,7 +112,7 @@ const VTypes = Union{ComplexF64, Float64, ComplexF32, Float32}
 const VRealTypes = Union{Float64, Float32}
 const VComplexTypes = Union{ComplexF64, ComplexF32}
 
-const StridedVecOrMatInclAdjAndTrans{Tv} = Union{StridedVecOrMat{Tv}, Adjoint{Tv, <:StridedVecOrMat}, Transpose{Tv, <:StridedVecOrMat}}
+const StridedVecOrMatMaybeAdjOrTrans{Tv} = Union{StridedVecOrMat{Tv}, AdjOrTrans{Tv,<:StridedVecOrMat}}
 
 # exception
 struct CHOLMODException <: Exception
@@ -937,7 +937,7 @@ get_perm(FC::FactorComponent) = get_perm(Factor(FC))
 
 # Conversion/construction
 
-function Dense{T}(A::StridedVecOrMatInclAdjAndTrans) where T<:VTypes
+function Dense{T}(A::StridedVecOrMatMaybeAdjOrTrans) where T<:VTypes
     d = allocate_dense(size(A, 1), size(A, 2), size(A, 1), T)
     GC.@preserve d begin
         D = unsafe_wrap(Array, Ptr{eltype(d)}(unsafe_load(pointer(d)).x), size(A), own = false)
@@ -946,12 +946,12 @@ function Dense{T}(A::StridedVecOrMatInclAdjAndTrans) where T<:VTypes
     return d
 end
 
-function Dense(A::StridedVecOrMatInclAdjAndTrans)
+function Dense(A::StridedVecOrMatMaybeAdjOrTrans)
     T = promote_type(eltype(A), Float64)
     return Dense{T}(A)
 end
 # Don't always promote to Float64 now that we have Float32 support.
-Dense(A::StridedVecOrMatInclAdjAndTrans{T}) where
+Dense(A::StridedVecOrMatMaybeAdjOrTrans{T}) where
     {T<:Union{Float16, ComplexF16, Float32, ComplexF32}} = Dense{promote_type(T, Float32)}(A)
 
 
@@ -2025,12 +2025,12 @@ SparseVecOrMat{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 # they are, in the precision of the factor. CHOLMOD solves a real factor against a complex
 # right-hand side natively, so a complex one (#120) stays complex in that precision.
 rhs_eltype(::Type{T}, ::Type{S}) where {T<:VTypes, S} = S <: Complex ? Complex{real(T)} : T
-function strided_solve(L, B::StridedVecOrMatInclAdjAndTrans)
+function strided_solve(L, B::StridedVecOrMatMaybeAdjOrTrans)
     X = L \ Dense{rhs_eltype(eltype(L), eltype(B))}(B)
     return B isa AbstractVector ? Vector(X) : Matrix(X)
 end
 
-(\)(L::FactorComponent{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = strided_solve(L, B)
+(\)(L::FactorComponent{T}, B::StridedVecOrMatMaybeAdjOrTrans) where {T<:VTypes} = strided_solve(L, B)
 function (\)(L::FactorComponent, B::SparseVector)
     sparsevec(L\Sparse(B))
 end
@@ -2040,12 +2040,11 @@ end
 (\)(L::FactorComponent, B::Adjoint{<:Any,<:SparseMatrixCSC}) = L \ copy(B)
 (\)(L::FactorComponent, B::Transpose{<:Any,<:SparseMatrixCSC}) = L \ copy(B)
 
-const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
-                                 Adjoint{<:Any,<:SparseMatrixCSC}, Transpose{<:Any,<:SparseMatrixCSC}}
+const FactorComponentRHS = Union{StridedVecOrMatMaybeAdjOrTrans, SparseVecOrMat, AdjOrTrans{<:Any,<:SparseMatrixCSC}}
 \(adjL::Adjoint{<:Any,<:FactorComponent}, B::FactorComponentRHS) = (L = parent(adjL); adjoint(L)\B)
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
-(\)(L::Factor{T}, B::StridedVecOrMatInclAdjAndTrans) where {T<:VTypes} = strided_solve(L, B)
+(\)(L::Factor{T}, B::StridedVecOrMatMaybeAdjOrTrans) where {T<:VTypes} = strided_solve(L, B)
 # The explicit typevars avoid an ambiguity with `\(::Factorization{T}, ::VecOrMat{Complex{T}})`
 # in LinearAlgebra/factorization.jl, which is otherwise neither more nor less specific than
 # the strided method above.
@@ -2064,7 +2063,7 @@ const FactorComponentRHS = Union{StridedVecOrMatInclAdjAndTrans, SparseVecOrMat,
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
 # These mirror the `Factor` methods above, `VecOrMat` tie-breaker included.
-\(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedVecOrMatInclAdjAndTrans) = strided_solve(adjL, B)
+\(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedVecOrMatMaybeAdjOrTrans) = strided_solve(adjL, B)
 (\)(adjL::AdjointFactorization{T,<:Factor}, B::VecOrMat{Complex{T}}) where {T<:VRealTypes} = strided_solve(adjL, B)
 (\)(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::AdjOrTransAbsMat) = adjL \ copy(B)
 
@@ -2073,7 +2072,7 @@ const RealHermSymComplexHermSSL{Ti, Tr} = Union{
     Hermitian{Tr, SparseMatrixCSC{Tr, Ti}},
     Hermitian{Complex{Tr}, SparseMatrixCSC{Complex{Tr}, Ti}}} where {Ti<:ITypes, Tr<:Union{Float64, Float32, Float16}}
 
-function \(A::RealHermSymComplexHermSSL{Ti}, B::StridedVecOrMatInclAdjAndTrans) where {Ti}
+function \(A::RealHermSymComplexHermSSL{Ti}, B::StridedVecOrMatMaybeAdjOrTrans) where {Ti}
     T = typeof(one(eltype(A)) \ one(eltype(B)))
     F = cholesky(A; check = false)
     if issuccess(F)
@@ -2083,8 +2082,7 @@ function \(A::RealHermSymComplexHermSSL{Ti}, B::StridedVecOrMatInclAdjAndTrans) 
     end
 end
 
-const AbstractSparseVecOrMatInclAdjAndTrans = Union{AbstractSparseVecOrMat, AdjOrTrans{<:Any, <:AbstractSparseVecOrMat}}
-\(::RealHermSymComplexHermSSL, ::AbstractSparseVecOrMatInclAdjAndTrans) =
+\(::RealHermSymComplexHermSSL, ::AbstractSparseVecOrMatMaybeAdjOrTrans) =
     throw(ArgumentError("self-adjoint sparse system solve not implemented for sparse rhs B," *
         " consider to convert B to a dense array"))
 

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -23,7 +23,7 @@ import LinearAlgebra: (\), AdjointFactorization,
                  lowrankdowndate, lowrankdowndate!, lowrankupdate, lowrankupdate!
 
 using SparseArrays
-using SparseArrays: getcolptr, AbstractSparseVecOrMat, AbstractSparseVecOrMatMaybeAdjOrTrans
+using SparseArrays: getcolptr, AbstractSparseVecOrMat
 export
     Dense,
     Factor,
@@ -2077,7 +2077,7 @@ function \(A::RealHermSymComplexHermSSL{Ti}, B::StridedVecOrMatMaybeAdjOrTrans) 
     end
 end
 
-\(::RealHermSymComplexHermSSL, ::AbstractSparseVecOrMatMaybeAdjOrTrans) =
+\(::RealHermSymComplexHermSSL, ::Union{AbstractSparseVecOrMat, AdjOrTrans{<:Any,<:AbstractSparseVecOrMat}}) =
     throw(ArgumentError("self-adjoint sparse system solve not implemented for sparse rhs B," *
         " consider to convert B to a dense array"))
 

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -2019,7 +2019,8 @@ for (T, f) in ((:Dense, :solve), (:Sparse, :spsolve))
     end
 end
 
-SparseVecOrMat{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
+# the concrete pair that Sparse(::SparseVector)/Sparse(::SparseMatrixCSC) accept
+const SparseVectorOrMatrixCSC{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 
 # Strided right-hand sides, such as views of dense arrays (#496), are handed to CHOLMOD as
 # they are, in the precision of the factor. CHOLMOD solves a real factor against a complex
@@ -2040,7 +2041,7 @@ end
 (\)(L::FactorComponent, B::Adjoint{<:Any,<:SparseMatrixCSC}) = L \ copy(B)
 (\)(L::FactorComponent, B::Transpose{<:Any,<:SparseMatrixCSC}) = L \ copy(B)
 
-const FactorComponentRHS = Union{StridedVecOrMatMaybeAdjOrTrans, SparseVecOrMat, AdjOrTrans{<:Any,<:SparseMatrixCSC}}
+const FactorComponentRHS = Union{StridedVecOrMatMaybeAdjOrTrans, SparseVectorOrMatrixCSC, AdjOrTrans{<:Any,<:SparseMatrixCSC}}
 \(adjL::Adjoint{<:Any,<:FactorComponent}, B::FactorComponentRHS) = (L = parent(adjL); adjoint(L)\B)
 
 (\)(L::Factor{T}, B::Dense{T2}) where {T<:VTypes, T2<:VTypes} = solve(CHOLMOD_A, L, B)
@@ -2060,7 +2061,7 @@ const FactorComponentRHS = Union{StridedVecOrMatMaybeAdjOrTrans, SparseVecOrMat,
 # the eltype restriction is necessary for disambiguation with the B::StridedMatrix below
 \(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::Dense) = (L = parent(adjL); solve(CHOLMOD_A, L, B))
 \(adjL::AdjointFactorization{<:Any,<:Factor}, B::Sparse) = (L = parent(adjL); spsolve(CHOLMOD_A, L, B))
-\(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVecOrMat) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
+\(adjL::AdjointFactorization{<:Any,<:Factor}, B::SparseVectorOrMatrixCSC) = (L = parent(adjL); \(adjoint(L), Sparse(B)))
 
 # These mirror the `Factor` methods above, `VecOrMat` tie-breaker included.
 \(adjL::AdjointFactorization{<:VTypes,<:Factor}, B::StridedVecOrMatMaybeAdjOrTrans) = strided_solve(adjL, B)
@@ -2322,17 +2323,17 @@ function ishermitian(A::Sparse{<:VComplexTypes})
 end
 
 (*)(A::Symmetric{<:VRealTypes,SparseMatrixCSC{<:VRealTypes,Ti}},
-    B::SparseVecOrMat{<:VRealTypes,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
+    B::SparseVectorOrMatrixCSC{<:VRealTypes,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 (*)(A::Hermitian{<:VComplexTypes,SparseMatrixCSC{<:VComplexTypes,Ti}},
-    B::SparseVecOrMat{<:VComplexTypes,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
+    B::SparseVectorOrMatrixCSC{<:VComplexTypes,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 (*)(A::Hermitian{<:VRealTypes,SparseMatrixCSC{<:VRealTypes,Ti}},
-    B::SparseVecOrMat{<:VRealTypes,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
+    B::SparseVectorOrMatrixCSC{<:VRealTypes,Ti}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 
-(*)(A::SparseVecOrMat{<:VRealTypes,Ti},
+(*)(A::SparseVectorOrMatrixCSC{<:VRealTypes,Ti},
     B::Symmetric{<:VRealTypes,SparseMatrixCSC{<:VRealTypes,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
-(*)(A::SparseVecOrMat{<:VComplexTypes,Ti},
+(*)(A::SparseVectorOrMatrixCSC{<:VComplexTypes,Ti},
     B::Hermitian{<:VComplexTypes,SparseMatrixCSC{<:VComplexTypes,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
-(*)(A::SparseVecOrMat{<:VRealTypes,Ti},
+(*)(A::SparseVectorOrMatrixCSC{<:VRealTypes,Ti},
     B::Hermitian{<:VRealTypes,SparseMatrixCSC{<:VRealTypes,Ti}}) where {Ti} = sparse(Sparse(A)*Sparse(B))
 
 # Sort all the indices in each column for the construction of a CSC sparse matrix

--- a/src/solvers/cholmod.jl
+++ b/src/solvers/cholmod.jl
@@ -113,6 +113,8 @@ const VRealTypes = Union{Float64, Float32}
 const VComplexTypes = Union{ComplexF64, ComplexF32}
 
 const StridedVecOrMatMaybeAdjOrTrans{Tv} = Union{StridedVecOrMat{Tv}, AdjOrTrans{Tv,<:StridedVecOrMat}}
+# the concrete pair that Sparse(::SparseVector)/Sparse(::SparseMatrixCSC) accept
+const SparseVectorOrMatrixCSC{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 
 # exception
 struct CHOLMODException <: Exception
@@ -383,12 +385,10 @@ function Factor{Tv}(ptr::Ptr{cholmod_factor}) where Tv
     return Factor{Tv, Ti}(ptr)
 end
 
-const SuiteSparseStruct = Union{cholmod_dense, cholmod_sparse, cholmod_factor}
-
 # All pointer loads should be checked to make sure that SuiteSparse is not called with
 # a C_NULL pointer which could cause a segfault. Pointers are set to null
 # when serialized so this can happen when multiple processes are in use.
-function Base.unsafe_convert(::Type{Ptr{T}}, x::Union{Dense,Sparse,Factor}) where T<:SuiteSparseStruct
+function Base.unsafe_convert(::Type{Ptr{T}}, x::Union{Dense,Sparse,Factor}) where T<:Union{cholmod_dense, cholmod_sparse, cholmod_factor}
     xp = getfield(x, :ptr)
     if xp == C_NULL
         throw(ArgumentError("pointer to the $T object is null. This can " *
@@ -2018,9 +2018,6 @@ for (T, f) in ((:Dense, :solve), (:Sparse, :spsolve))
         end
     end
 end
-
-# the concrete pair that Sparse(::SparseVector)/Sparse(::SparseMatrixCSC) accept
-const SparseVectorOrMatrixCSC{Tv,Ti} = Union{SparseVector{Tv,Ti}, SparseMatrixCSC{Tv,Ti}}
 
 # Strided right-hand sides, such as views of dense arrays (#496), are handed to CHOLMOD as
 # they are, in the precision of the factor. CHOLMOD solves a real factor against a complex

--- a/src/solvers/umfpack.jl
+++ b/src/solvers/umfpack.jl
@@ -262,8 +262,8 @@ workspace_W_size(F::UmfpackLU) = workspace_W_size(F, has_refinement(F))
 workspace_W_size(S::Union{UmfpackLU{<:AbstractFloat}, AbstractSparseMatrixCSC{<:AbstractFloat}}, refinement::Bool) = refinement ? 5 * size(S, 2) : size(S, 2)
 workspace_W_size(S::Union{UmfpackLU{<:Complex}, AbstractSparseMatrixCSC{<:Complex}}, refinement::Bool) = refinement ? 10 * size(S, 2) : 4 * size(S, 2)
 
-const ATLU = Union{TransposeFactorization{<:Any, <:UmfpackLU}, AdjointFactorization{<:Any, <:UmfpackLU}}
-has_refinement(F::ATLU) = has_refinement(parent(F))
+const UMFAdjOrTransLU = Union{TransposeFactorization{<:Any, <:UmfpackLU}, AdjointFactorization{<:Any, <:UmfpackLU}}
+has_refinement(F::UMFAdjOrTransLU) = has_refinement(parent(F))
 has_refinement(F::UmfpackLU) = has_refinement(F.control)
 has_refinement(control::AbstractVector) = control[JL_UMFPACK_IRSTEP] > 0
 
@@ -277,7 +277,7 @@ end
 UmfpackWS(F::UmfpackLU{Tv, Ti}, refinement::Bool=has_refinement(F)) where {Tv, Ti} = UmfpackWS(
         Vector{Ti}(undef, size(F, 2)),
         Vector{Float64}(undef, workspace_W_size(F, refinement)))
-UmfpackWS(F::ATLU, refinement::Bool=has_refinement(F)) = UmfpackWS(parent(F), refinement)
+UmfpackWS(F::UMFAdjOrTransLU, refinement::Bool=has_refinement(F)) = UmfpackWS(parent(F), refinement)
 
 # Not using similar helps if the actual needed size has changed as it would need to be resized again
 """
@@ -299,7 +299,7 @@ Base.copy(F::UmfpackLU{Tv, Ti}, ws=UmfpackWS(F)) where {Tv, Ti} =
         copy(F.info),
         ReentrantLock()
     )
-Base.copy(F::T, ws=UmfpackWS(F)) where {T <: ATLU} =
+Base.copy(F::T, ws=UmfpackWS(F)) where {T <: UMFAdjOrTransLU} =
     T(copy(parent(F), ws))
 
 Base.transpose(F::UmfpackLU) = TransposeFactorization(F)

--- a/src/sparseconvert.jl
+++ b/src/sparseconvert.jl
@@ -1,15 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-"""
-    SparseMatrixCSCSymmHerm
-
-`Symmetric` or `Hermitian` of a `SparseMatrixCSC` or `SparseMatrixCSCView`.
-"""
-const SparseMatrixCSCSymmHerm{Tv,Ti} = Union{Symmetric{Tv,<:SparseMatrixCSCUnion{Tv,Ti}},
-                                            Hermitian{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}}
-
-const AbstractTriangularSparse{Tv,Ti} = UpperOrLowerTriangular{Tv,<:SparseMatrixCSCUnion{Tv,Ti}}
-
 # converting Symmetric/Hermitian/Triangular/SubArray of SparseMatrixCSC
 # and Transpose/Adjoint of Triangular of SparseMatrixCSC to SparseMatrixCSC
 for wr in (Symmetric, Hermitian, Transpose, Adjoint,
@@ -173,7 +163,7 @@ function _sparsem(fnzrange::Function, sA::SparseMatrixCSCSymmHerm{Tv}) where {Tv
 end
 
 # 2 cases: Unit(Upper|Lower)Triangular{Tv,AbstractSparseMatrixCSC}
-function _sparsem(A::AbstractTriangularSparse{Tv}) where Tv
+function _sparsem(A::SparseTriangular{Tv}) where Tv
     S = A.data
     rowval = rowvals(S)
     nzval = nonzeros(S)
@@ -217,7 +207,7 @@ function _sparsem(A::AbstractTriangularSparse{Tv}) where Tv
 end
 
 # 8 cases: (Transpose|Adjoint){Tv,[Unit](Upper|Lower)Triangular}
-function _sparsem(taA::AdjOrTrans{Tv,<:AbstractTriangularSparse}) where {Tv}
+function _sparsem(taA::AdjOrTrans{Tv,<:SparseTriangular}) where {Tv}
 
     sA = parent(taA)
     A = sA.data

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -203,8 +203,8 @@ julia> nnz(A)
 nnz(S::AbstractSparseMatrixCSC) = @inbounds Int(getcolptr(S)[size(S, 2) + 1]) - 1
 nnz(S::ReshapedArray{<:Any,1,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
 nnz(S::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
-nnz(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = nnz1(S)
-nnz(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = nnz1(S)
+nnz(S::UpperTriangular{<:Any,<:SparseMatrixCSCOrView}) = nnz1(S)
+nnz(S::LowerTriangular{<:Any,<:SparseMatrixCSCOrView}) = nnz1(S)
 nnz(S::SparseMatrixCSCColumnSubset) = nnz1(S)
 nnz1(S) = @inbounds sum(length.(nzrange.(Ref(S), axes(S, 2))))
 
@@ -239,8 +239,8 @@ julia> nonzeros(A)
 nonzeros(S::SparseMatrixCSC) = getfield(S, :nzval)
 nonzeros(S::FixedSparseCSC) = getfield(S, :nzval)
 nonzeros(S::SparseMatrixCSCColumnSubset)  = nonzeros(parent(S))
-nonzeros(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
-nonzeros(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
+nonzeros(S::UpperTriangular{<:Any,<:SparseMatrixCSCOrView}) = nonzeros(S.data)
+nonzeros(S::LowerTriangular{<:Any,<:SparseMatrixCSCOrView}) = nonzeros(S.data)
 
 """
     rowvals(A)
@@ -268,8 +268,8 @@ julia> rowvals(A)
 rowvals(S::SparseMatrixCSC) = getfield(S, :rowval)
 rowvals(S::FixedSparseCSC) = getfield(S, :rowval)
 rowvals(S::SparseMatrixCSCColumnSubset) = rowvals(parent(S))
-rowvals(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
-rowvals(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
+rowvals(S::UpperTriangular{<:Any,<:SparseMatrixCSCOrView}) = rowvals(S.data)
+rowvals(S::LowerTriangular{<:Any,<:SparseMatrixCSCOrView}) = rowvals(S.data)
 
 """
     nzrange(A, col::Integer)
@@ -295,8 +295,8 @@ of sparse array `A`. In conjunction with [`nonzeros`](@ref) and
 """
 Base.@propagate_inbounds nzrange(S::AbstractSparseMatrixCSC, col::Integer) = getcolptr(S)[col]:(getcolptr(S)[col+1]-1)
 Base.@propagate_inbounds nzrange(S::SparseMatrixCSCColumnSubset, col::Integer) = nzrange(parent(S), S.indices[2][col])
-nzrange(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangeup(S.data, i)
-nzrange(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangelo(S.data, i)
+nzrange(S::UpperTriangular{<:Any,<:SparseMatrixCSCOrView}, i::Integer) = nzrangeup(S.data, i)
+nzrange(S::LowerTriangular{<:Any,<:SparseMatrixCSCOrView}, i::Integer) = nzrangelo(S.data, i)
 
 indtype(S::SparseMatrixCSCColumnSubset{<:Any,Ti}) where {Ti} = Ti
 
@@ -2342,13 +2342,13 @@ function conj(A::AbstractSparseMatrixCSC{<:Complex})
     map!(conj, view(nzval, 1:nnz(A)), nzvalview(A))
     return SparseMatrixCSC(size(A, 1), size(A, 2), copy(getcolptr(A)), copy(rowvals(A)), nzval)
 end
-imag(A::SparseMatrixCSCUnion{Tv,Ti}) where {Tv<:Real,Ti} = spzeros(Tv, Ti, size(A, 1), size(A, 2))
+imag(A::SparseMatrixCSCOrView{Tv,Ti}) where {Tv<:Real,Ti} = spzeros(Tv, Ti, size(A, 1), size(A, 2))
 
 ## Binary arithmetic and boolean operators
-(+)(A::SparseMatrixCSCUnion, B::SparseMatrixCSCUnion) = map(+, A, B)
-(-)(A::SparseMatrixCSCUnion, B::SparseMatrixCSCUnion) = map(-, A, B)
+(+)(A::SparseMatrixCSCOrView, B::SparseMatrixCSCOrView) = map(+, A, B)
+(-)(A::SparseMatrixCSCOrView, B::SparseMatrixCSCOrView) = map(-, A, B)
 
-function (+)(A::SparseMatrixCSCUnion, B::Array)
+function (+)(A::SparseMatrixCSCOrView, B::Array)
     Base.promote_shape(axes(A), axes(B))
     C = Ref(zero(eltype(A))) .+ B
     rowinds, nzvals = rowvals(A), nonzeros(A)
@@ -2360,7 +2360,7 @@ function (+)(A::SparseMatrixCSCUnion, B::Array)
     end
     return C
 end
-function (+)(A::Array, B::SparseMatrixCSCUnion)
+function (+)(A::Array, B::SparseMatrixCSCOrView)
     Base.promote_shape(axes(A), axes(B))
     C = A .+ Ref(zero(eltype(B)))
     rowinds, nzvals = rowvals(B), nonzeros(B)
@@ -2372,7 +2372,7 @@ function (+)(A::Array, B::SparseMatrixCSCUnion)
     end
     return C
 end
-function (-)(A::SparseMatrixCSCUnion, B::Array)
+function (-)(A::SparseMatrixCSCOrView, B::Array)
     Base.promote_shape(axes(A), axes(B))
     C = Ref(zero(eltype(A))) .- B
     rowinds, nzvals = rowvals(A), nonzeros(A)
@@ -2384,7 +2384,7 @@ function (-)(A::SparseMatrixCSCUnion, B::Array)
     end
     return C
 end
-function (-)(A::Array, B::SparseMatrixCSCUnion)
+function (-)(A::Array, B::SparseMatrixCSCOrView)
     Base.promote_shape(axes(A), axes(B))
     C = A .- Ref(zero(eltype(B)))
     rowinds, nzvals = rowvals(B), nonzeros(B)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1916,7 +1916,7 @@ julia> SparseArrays.fkeep!((i, j, v) -> isodd(v), A)
 fkeep!(f::F, A::AbstractSparseMatrixCSC) where F<:Function = _is_fixed(A) ? _fkeep!_fixed(f, A) : _fkeep!(f, A)
 
 # deprecated syntax
-function fkeep!(x::Union{AbstractSparseMatrixCSC,AbstractCompressedVector},f::F) where F<:Function
+function fkeep!(x::SparseVecOrMat, f::F) where F<:Function
     Base.depwarn("`fkeep!(x, f::Function)` is deprecated, use `fkeep!(f::Function, x)` instead.", :fkeep!)
     return fkeep!(f, x)
 end

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -318,10 +318,10 @@ function Base.isstored(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, i::Intege
     return false
 end
 
-Base.replace_in_print_matrix(A::AbstractSparseMatrixCSCMaybeAdjOrTrans, i::Integer, j::Integer, s::AbstractString) =
+Base.replace_in_print_matrix(A::SparseMatrixCSCMaybeAdjOrTrans, i::Integer, j::Integer, s::AbstractString) =
     Base.isstored(A, i, j) ? s : Base.replace_with_centered_mark(s)
 
-function Base.array_summary(io::IO, S::AbstractSparseMatrixCSCMaybeAdjOrTrans, dims::Tuple{Vararg{Base.OneTo}})
+function Base.array_summary(io::IO, S::SparseMatrixCSCMaybeAdjOrTrans, dims::Tuple{Vararg{Base.OneTo}})
     _checkbuffers(S)
 
     xnnz = nnz(S)
@@ -331,8 +331,8 @@ function Base.array_summary(io::IO, S::AbstractSparseMatrixCSCMaybeAdjOrTrans, d
     nothing
 end
 
-# called by `show(io, MIME("text/plain"), ::AbstractSparseMatrixCSCMaybeAdjOrTrans)`
-function Base.print_array(io::IO, S::AbstractSparseMatrixCSCMaybeAdjOrTrans)
+# called by `show(io, MIME("text/plain"), ::SparseMatrixCSCMaybeAdjOrTrans)`
+function Base.print_array(io::IO, S::SparseMatrixCSCMaybeAdjOrTrans)
     if max(size(S)...) < 16
         Base.print_matrix(io, S)
     else
@@ -361,7 +361,7 @@ size(C::ColumnIndices) = (nnz(C.arr),)
 end
 
 # always show matrices as `sparse(I, J, K)`
-function Base.show(io::IO, _S::AbstractSparseMatrixCSCMaybeAdjOrTrans)
+function Base.show(io::IO, _S::SparseMatrixCSCMaybeAdjOrTrans)
     _checkbuffers(_S)
     # can't use `findnz`, because that expects all values not to be #undef
     S = _S isa Adjoint || _S isa Transpose ? parent(_S) : _S
@@ -382,7 +382,7 @@ function Base.show(io::IO, _S::AbstractSparseMatrixCSCMaybeAdjOrTrans)
 end
 
 const brailleBlocks = UInt16['⠁', '⠂', '⠄', '⡀', '⠈', '⠐', '⠠', '⢀']
-function _show_with_braille_patterns(io::IO, S::AbstractSparseMatrixCSCMaybeAdjOrTrans)
+function _show_with_braille_patterns(io::IO, S::SparseMatrixCSCMaybeAdjOrTrans)
     m, n = size(S)
     (m == 0 || n == 0) && return show(io, MIME("text/plain"), S)
 
@@ -2453,10 +2453,10 @@ end
 # Peel off `Adjoint` and `Transpose` from first argument
 # `B` may be a nested wrapper such as `Adjoint{<:Any,<:Transpose}` (from `A' == transpose(B)`),
 # hence the loose `AbstractMatrix` bound: `B` is only ever indexed
-nzeq(eq::F, A::Adjoint{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans},
+nzeq(eq::F, A::Adjoint{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans},
      B::AbstractMatrix) where {F} =
     nzeq(eq, A', B')
-nzeq(eq::F, A::Transpose{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans},
+nzeq(eq::F, A::Transpose{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans},
      B::AbstractMatrix) where {F} =
     nzeq(eq, transpose(A), transpose(B))
 
@@ -2466,24 +2466,24 @@ nzeq(eq::F, A::Transpose{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans},
 # the case where the RHS is both adjoint and transposed, i.e. where it
 # is in CSC format again.)
 function _iseq(eq::F, A::AbstractSparseMatrixCSC,
-               B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}) where {F}
+               B::AdjOrTrans{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans}) where {F}
     # Different sizes are always different
     size(A) ≠ size(B) && return false
     # Compare nonzero elements
     return nzeq(eq, A, B) && nzeq(eq, B, A)
 end
-==(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}) =
+==(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans}) =
     _iseq(==, A, B)
-Base.isequal(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}) =
+Base.isequal(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans}) =
     _iseq(isequal, A, B)
 # Peel off `Adjoint` and `Transpose` from first argument
-==(A::Adjoint{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
+==(A::Adjoint{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans}, B::SparseMatrixCSCMaybeAdjOrTrans) =
     A' == B'
-==(A::Transpose{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
+==(A::Transpose{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans}, B::SparseMatrixCSCMaybeAdjOrTrans) =
     transpose(A) == transpose(B)
-Base.isequal(A::Adjoint{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
+Base.isequal(A::Adjoint{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans}, B::SparseMatrixCSCMaybeAdjOrTrans) =
     isequal(A', B')
-Base.isequal(A::Transpose{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
+Base.isequal(A::Transpose{<:Any,<:SparseMatrixCSCMaybeAdjOrTrans}, B::SparseMatrixCSCMaybeAdjOrTrans) =
     isequal(transpose(A), transpose(B))
 
 ## Reductions

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -117,8 +117,6 @@ Experimental, unsafe. Returns a modifiable version of `x` for compatibility with
 _unsafe_unfix(x::FixedSparseCSC) = SparseMatrixCSC(size(x)..., parent(getcolptr(x)), parent(rowvals(x)), nonzeros(x))
 _unsafe_unfix(x::SparseMatrixCSC) = x
 
-const SorF = Union{<:SparseMatrixCSC, <:FixedSparseCSC}
-
 """
     SparseMatrixCSC(x::FixedSparseCSC)
 
@@ -162,7 +160,8 @@ function sparse_check_length(rowstr, rowval, minlen, Ti)
     !isbitstype(Ti) || len < typemax(Ti) || throwmax(len, typemax(Ti), rowstr)
 end
 
-size(S::SorF) = (getfield(S, :m), getfield(S, :n))
+size(S::SparseMatrixCSC) = (getfield(S, :m), getfield(S, :n))
+size(S::FixedSparseCSC) = (getfield(S, :m), getfield(S, :n))
 
 _goodbuffers(S::AbstractSparseMatrixCSC) = _goodbuffers(size(S)..., getcolptr(S), getrowval(S), nonzeros(S))
 _checkbuffers(S::AbstractSparseMatrixCSC) = (@assert _goodbuffers(S); S)
@@ -174,24 +173,8 @@ function _goodbuffers(m, n, colptr, rowval, nzval)
     # && all(issorted(@view rowval[colptr[i]:colptr[i+1]-1]) for i=1:n)
 end
 
-# Define an alias for views of a SparseMatrixCSC which include all rows and a unit range of the columns.
-# Also define a union of SparseMatrixCSC and this view since many methods can be defined efficiently for
-# this union by extracting the fields via the get function: getcolptr, getrowval, and getnzval. The key
-# insight is that getcolptr on a SparseMatrixCSCView returns an offset view of the colptr of the
-# underlying SparseMatrixCSC
-const SparseMatrixCSCView{Tv,Ti} =
-    SubArray{Tv,2,<:AbstractSparseMatrixCSC{Tv,Ti},
-        Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractUnitRange{<:Integer}}
-const SparseMatrixCSCUnion{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
-# Define an alias for views of a SparseMatrixCSC which include all rows and a selection of the columns.
-# Also define a union of SparseMatrixCSC and this view since many methods can be defined efficiently for
-# this union by extracting the fields via the get function: getrowval, and getnzval, BUT NOT getcolptr!
-const SparseMatrixCSCColumnSubset{Tv,Ti} =
-    SubArray{Tv,2,<:AbstractSparseMatrixCSC{Tv,Ti},
-        Tuple{Base.Slice{Base.OneTo{Int}},I}} where {I<:AbstractVector{<:Integer}}
-const SparseMatrixCSCUnion2{Tv,Ti} = Union{AbstractSparseMatrixCSC{Tv,Ti}, SparseMatrixCSCColumnSubset{Tv,Ti}}
-
-getcolptr(S::SorF)     = getfield(S, :colptr)
+getcolptr(S::SparseMatrixCSC) = getfield(S, :colptr)
+getcolptr(S::FixedSparseCSC) = getfield(S, :colptr)
 getcolptr(S::SparseMatrixCSCView) = view(getcolptr(parent(S)), first(S.indices[2]):(last(S.indices[2]) + 1))
 getcolptr(S::SparseMatrixCSCColumnSubset) = error("getcolptr not well-defined for $(typeof(S))")
 getrowval(S::AbstractSparseMatrixCSC) = rowvals(S)
@@ -220,8 +203,8 @@ julia> nnz(A)
 nnz(S::AbstractSparseMatrixCSC) = @inbounds Int(getcolptr(S)[size(S, 2) + 1]) - 1
 nnz(S::ReshapedArray{<:Any,1,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
 nnz(S::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}) = nnz(parent(S))
-nnz(S::UpperTriangular{<:Any,<:AbstractSparseMatrixCSC}) = nnz1(S)
-nnz(S::LowerTriangular{<:Any,<:AbstractSparseMatrixCSC}) = nnz1(S)
+nnz(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = nnz1(S)
+nnz(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = nnz1(S)
 nnz(S::SparseMatrixCSCColumnSubset) = nnz1(S)
 nnz1(S) = @inbounds sum(length.(nzrange.(Ref(S), axes(S, 2))))
 
@@ -253,7 +236,8 @@ julia> nonzeros(A)
  2
 ```
 """
-nonzeros(S::SorF) = getfield(S, :nzval)
+nonzeros(S::SparseMatrixCSC) = getfield(S, :nzval)
+nonzeros(S::FixedSparseCSC) = getfield(S, :nzval)
 nonzeros(S::SparseMatrixCSCColumnSubset)  = nonzeros(parent(S))
 nonzeros(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
 nonzeros(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = nonzeros(S.data)
@@ -281,7 +265,8 @@ julia> rowvals(A)
  3
 ```
 """
-rowvals(S::SorF) = getfield(S, :rowval)
+rowvals(S::SparseMatrixCSC) = getfield(S, :rowval)
+rowvals(S::FixedSparseCSC) = getfield(S, :rowval)
 rowvals(S::SparseMatrixCSCColumnSubset) = rowvals(parent(S))
 rowvals(S::UpperTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
 rowvals(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}) = rowvals(S.data)
@@ -315,7 +300,6 @@ nzrange(S::LowerTriangular{<:Any,<:SparseMatrixCSCUnion}, i::Integer) = nzrangel
 
 indtype(S::SparseMatrixCSCColumnSubset{<:Any,Ti}) where {Ti} = Ti
 
-const AbstractSparseMatrixCSCInclAdjointAndTranspose = Union{AbstractSparseMatrixCSC,Adjoint{<:Any,<:AbstractSparseMatrixCSC},Transpose{<:Any,<:AbstractSparseMatrixCSC}}
 function Base.isstored(A::AbstractSparseMatrixCSC, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     rows = rowvals(A)
@@ -334,10 +318,10 @@ function Base.isstored(A::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSC}, i::Intege
     return false
 end
 
-Base.replace_in_print_matrix(A::AbstractSparseMatrixCSCInclAdjointAndTranspose, i::Integer, j::Integer, s::AbstractString) =
+Base.replace_in_print_matrix(A::AbstractSparseMatrixCSCMaybeAdjOrTrans, i::Integer, j::Integer, s::AbstractString) =
     Base.isstored(A, i, j) ? s : Base.replace_with_centered_mark(s)
 
-function Base.array_summary(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTranspose, dims::Tuple{Vararg{Base.OneTo}})
+function Base.array_summary(io::IO, S::AbstractSparseMatrixCSCMaybeAdjOrTrans, dims::Tuple{Vararg{Base.OneTo}})
     _checkbuffers(S)
 
     xnnz = nnz(S)
@@ -347,8 +331,8 @@ function Base.array_summary(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTran
     nothing
 end
 
-# called by `show(io, MIME("text/plain"), ::AbstractSparseMatrixCSCInclAdjointAndTranspose)`
-function Base.print_array(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTranspose)
+# called by `show(io, MIME("text/plain"), ::AbstractSparseMatrixCSCMaybeAdjOrTrans)`
+function Base.print_array(io::IO, S::AbstractSparseMatrixCSCMaybeAdjOrTrans)
     if max(size(S)...) < 16
         Base.print_matrix(io, S)
     else
@@ -377,7 +361,7 @@ size(C::ColumnIndices) = (nnz(C.arr),)
 end
 
 # always show matrices as `sparse(I, J, K)`
-function Base.show(io::IO, _S::AbstractSparseMatrixCSCInclAdjointAndTranspose)
+function Base.show(io::IO, _S::AbstractSparseMatrixCSCMaybeAdjOrTrans)
     _checkbuffers(_S)
     # can't use `findnz`, because that expects all values not to be #undef
     S = _S isa Adjoint || _S isa Transpose ? parent(_S) : _S
@@ -398,7 +382,7 @@ function Base.show(io::IO, _S::AbstractSparseMatrixCSCInclAdjointAndTranspose)
 end
 
 const brailleBlocks = UInt16['⠁', '⠂', '⠄', '⡀', '⠈', '⠐', '⠠', '⢀']
-function _show_with_braille_patterns(io::IO, S::AbstractSparseMatrixCSCInclAdjointAndTranspose)
+function _show_with_braille_patterns(io::IO, S::AbstractSparseMatrixCSCMaybeAdjOrTrans)
     m, n = size(S)
     (m == 0 || n == 0) && return show(io, MIME("text/plain"), S)
 
@@ -2469,10 +2453,10 @@ end
 # Peel off `Adjoint` and `Transpose` from first argument
 # `B` may be a nested wrapper such as `Adjoint{<:Any,<:Transpose}` (from `A' == transpose(B)`),
 # hence the loose `AbstractMatrix` bound: `B` is only ever indexed
-nzeq(eq::F, A::Adjoint{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose},
+nzeq(eq::F, A::Adjoint{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans},
      B::AbstractMatrix) where {F} =
     nzeq(eq, A', B')
-nzeq(eq::F, A::Transpose{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose},
+nzeq(eq::F, A::Transpose{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans},
      B::AbstractMatrix) where {F} =
     nzeq(eq, transpose(A), transpose(B))
 
@@ -2482,24 +2466,24 @@ nzeq(eq::F, A::Transpose{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}
 # the case where the RHS is both adjoint and transposed, i.e. where it
 # is in CSC format again.)
 function _iseq(eq::F, A::AbstractSparseMatrixCSC,
-               B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}) where {F}
+               B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}) where {F}
     # Different sizes are always different
     size(A) ≠ size(B) && return false
     # Compare nonzero elements
     return nzeq(eq, A, B) && nzeq(eq, B, A)
 end
-==(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}) =
+==(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}) =
     _iseq(==, A, B)
-Base.isequal(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}) =
+Base.isequal(A::AbstractSparseMatrixCSC, B::AdjOrTrans{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}) =
     _iseq(isequal, A, B)
 # Peel off `Adjoint` and `Transpose` from first argument
-==(A::Adjoint{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}, B::AbstractSparseMatrixCSCInclAdjointAndTranspose) =
+==(A::Adjoint{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
     A' == B'
-==(A::Transpose{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}, B::AbstractSparseMatrixCSCInclAdjointAndTranspose) =
+==(A::Transpose{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
     transpose(A) == transpose(B)
-Base.isequal(A::Adjoint{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}, B::AbstractSparseMatrixCSCInclAdjointAndTranspose) =
+Base.isequal(A::Adjoint{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
     isequal(A', B')
-Base.isequal(A::Transpose{<:Any,<:AbstractSparseMatrixCSCInclAdjointAndTranspose}, B::AbstractSparseMatrixCSCInclAdjointAndTranspose) =
+Base.isequal(A::Transpose{<:Any,<:AbstractSparseMatrixCSCMaybeAdjOrTrans}, B::AbstractSparseMatrixCSCMaybeAdjOrTrans) =
     isequal(transpose(A), transpose(B))
 
 ## Reductions

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -84,20 +84,6 @@ inverse of fixed, should not allocate
 _unsafe_unfix(s::AbstractSparseVector) = s
 _unsafe_unfix(s::FixedSparseVector) = SparseVector(length(s), parent(nonzeroinds(s)), nonzeros(s))
 
-# Define an alias for a view of a whole column of a SparseMatrixCSC. Many methods can be written for the
-# union of such a view and a SparseVector so we define an alias for such a union as well
-const _SparseColumnView = SubArray{<:Any,1,<:AbstractSparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
-const _SparseVectorView = SubArray{<:Any,1,<:AbstractSparseVector,Tuple{Base.Slice{Base.OneTo{Int}}},false}
-const _SparseVectorUnion = Union{AbstractCompressedVector, _SparseColumnView, _SparseVectorView}
-const _AdjOrTransSparseVectorUnion = AdjOrTrans{<:Any,<:_SparseVectorUnion}
-# the following aliases are unused internally, but widespread in packages
-const SparseColumnView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseMatrixCSC{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
-const SparseVectorView{Tv,Ti}  = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},Tuple{Base.Slice{Base.OneTo{Int}}},false}
-const SparseVectorUnion{Tv,Ti} = Union{AbstractCompressedVector{Tv,Ti}, SparseColumnView{Tv,Ti}, SparseVectorView{Tv,Ti}}
-const AdjOrTransSparseVectorUnion{Tv,Ti} = LinearAlgebra.AdjOrTrans{Tv, <:SparseVectorUnion{Tv,Ti}}
-
-# allows for views of a subset of the sparse vector indices
-const SparseVectorPartialView{Tv,Ti} = SubArray{Tv,1,<:AbstractSparseVector{Tv,Ti},<:Tuple{AbstractUnitRange},false}
 
 ### Basic properties
 
@@ -1919,8 +1905,6 @@ end
 
 # * and mul!
 
-const _StridedOrTriangularMatrix{T} = Union{StridedMatrix{T}, LowerTriangular{T}, UnitLowerTriangular{T}, UpperTriangular{T}, UnitUpperTriangular{T}}
-
 _fliptri(A::UpperTriangular) = LowerTriangular(parent(parent(A)))
 _fliptri(A::UnitUpperTriangular) = UnitLowerTriangular(parent(parent(A)))
 _fliptri(A::LowerTriangular) = UpperTriangular(parent(parent(A)))
@@ -1981,7 +1965,7 @@ function _spmul!(y::AbstractVector, A::AbstractMatrix, x::AbstractSparseVector, 
 end
 
 function _At_or_Ac_mul_B!(tfun::Function,
-                            y::AbstractVector, A::_StridedOrTriangularMatrix, x::AbstractSparseVector,
+                            y::AbstractVector, A::Union{StridedMatrix,UpperOrLowerTriangular}, x::AbstractSparseVector,
                             α::Number, β::Number)
     require_one_based_indexing(y, A, x)
     n, m = size(A)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -107,12 +107,12 @@ nnz(x::SparseVectorView) = nnz(parent(x))
 nnz(x::SparseVectorPartialView) = length(nonzeroinds(x))
 
 """
-    nzrange(x::SparseVectorUnion, col)
+    nzrange(x::SparseVectorOrView, col)
 
 Give the range of indices to the structural nonzero values of a sparse vector.
 The column index `col` is ignored (assumed to be `1`).
 """
-function nzrange(x::SparseVectorUnion, j::Integer)
+function nzrange(x::SparseVectorOrView, j::Integer)
     j == 1 ? (1:nnz(x)) : throw(BoundsError(x, (":", j)))
 end
 
@@ -169,7 +169,7 @@ function nonzeroinds(x::SparseVectorPartialView)
     return @view(nzinds[first_idx:last_idx]) .- (x.indices[1][begin] - 1)
 end
 
-rowvals(x::SparseVectorUnion) = nonzeroinds(x)
+rowvals(x::SparseVectorOrView) = nonzeroinds(x)
 
 indtype(x::SparseColumnView) = indtype(parent(x))
 indtype(x::Union{SparseVectorView, SparseVectorPartialView}) = indtype(parent(x))
@@ -849,11 +849,11 @@ end
 
 Base.copy(a::SubArray{<:Any,<:Any,<:Union{SparseVector, AbstractSparseMatrixCSC}}) = parent(a)[a.indices...]
 
-function findall(x::SparseVectorUnion)
+function findall(x::SparseVectorOrView)
     return findall(identity, x)
 end
 
-function findall(p::F, x::SparseVectorUnion) where {F<:Function}
+function findall(p::F, x::SparseVectorOrView) where {F<:Function}
     if p(zero(eltype(x)))
         return invoke(findall, Tuple{Function, Any}, p, x)
     end
@@ -878,7 +878,7 @@ function findall(p::F, x::SparseVectorUnion) where {F<:Function}
 
     return I
 end
-findall(p::Base.Fix2{typeof(in)}, x::SparseVectorUnion) =
+findall(p::Base.Fix2{typeof(in)}, x::SparseVectorOrView) =
     invoke(findall, Tuple{Base.Fix2{typeof(in)}, AbstractArray}, p, x)
 
 """
@@ -900,7 +900,7 @@ julia> findnz(x)
 ([1, 4, 6, 8], [1, 2, 4, 3])
 ```
 """
-function findnz(x::SparseVectorUnion)
+function findnz(x::SparseVectorOrView)
     numnz = nnz(x)
 
     I = Vector{indtype(x)}(undef, numnz)
@@ -917,7 +917,7 @@ function findnz(x::SparseVectorUnion)
     return (I, V)
 end
 
-function findnz(x::AdjOrTransSparseVectorUnion)
+function findnz(x::AdjOrTransSparseVectorOrView)
     p = parent(x)
     numnz = nnz(p)
     I = ones(indtype(p), numnz)
@@ -1677,7 +1677,7 @@ for (fun, mode) in [(:+, 1), (:-, 1), (:*, 0), (:min, 2), (:max, 2)]
 end
 
 for fun in (:+, :-)
-    @eval @propagate_inbounds function $(fun)(x::Union{SparseVectorUnion{Tx},SparseVectorPartialView{Tx}}, y::Union{SparseVectorUnion{Ty},SparseVectorPartialView{Ty}}) where {Tx, Ty}
+    @eval @propagate_inbounds function $(fun)(x::Union{SparseVectorOrView{Tx},SparseVectorPartialView{Tx}}, y::Union{SparseVectorOrView{Ty},SparseVectorPartialView{Ty}}) where {Tx, Ty}
         @boundscheck axes(x) == axes(y) || throw(DimensionMismatch("$(axes(x)), $(axes(y))"))
         T = promote_type(Tx, Ty)
         res = spzeros(T, length(x))
@@ -1693,10 +1693,10 @@ for fun in (:+, :-)
 end
 
 ### Reduction
-Base.reducedim_initarray(A::SparseVectorUnion, region, v0, ::Type{R}) where {R} =
+Base.reducedim_initarray(A::SparseVectorOrView, region, v0, ::Type{R}) where {R} =
     fill!(Array{R}(undef, Base.to_shape(Base.reduced_indices(A, region))), v0)
 
-function Base._mapreduce(f::F, op::G, ::IndexCartesian, A::SparseVectorUnion) where {F,G}
+function Base._mapreduce(f::F, op::G, ::IndexCartesian, A::SparseVectorOrView) where {F,G}
     T = eltype(A)
     isempty(A) && return Base.mapreduce_empty(f, op, T)
     z = nnz(A)
@@ -1708,12 +1708,12 @@ function Base._mapreduce(f::F, op::G, ::IndexCartesian, A::SparseVectorUnion) wh
     _mapreducezeros(f, op, T, rest, ini)
 end
 
-Base._any(f, A::SparseVectorUnion, ::Colon) =
+Base._any(f, A::SparseVectorOrView, ::Colon) =
     iszero(length(A)) ? false : Base._mapreduce(f, |, IndexCartesian(), A)
-Base._all(f, A::SparseVectorUnion, ::Colon) =
+Base._all(f, A::SparseVectorOrView, ::Colon) =
     iszero(length(A)) ? true  : Base._mapreduce(f, &, IndexCartesian(), A)
 
-function Base.mapreducedim!(f::F, op::G, R::AbstractVector, A::SparseVectorUnion) where {F,G}
+function Base.mapreducedim!(f::F, op::G, R::AbstractVector, A::SparseVectorOrView) where {F,G}
     # dim1 reduction could be safely replaced with a mapreduce
     if length(R) == 1
         I = firstindex(R)
@@ -1751,7 +1751,7 @@ for (fun, comp, word) in ((:findmin, :(<), "minimum"), (:findmax, :(>), "maximum
     end
 end
 
-norm(x::SparseVectorUnion, p::Real=2) = norm(nonzeros(x), p)
+norm(x::SparseVectorOrView, p::Real=2) = norm(nonzeros(x), p)
 
 ### linalg.jl
 
@@ -1764,7 +1764,7 @@ adjoint(sv::AbstractCompressedVector) = Adjoint(sv)
 
 # axpy
 
-function LinearAlgebra.axpy!(a::Number, x::SparseVectorUnion, y::AbstractVector)
+function LinearAlgebra.axpy!(a::Number, x::SparseVectorOrView, y::AbstractVector)
     require_one_based_indexing(x, y)
     length(x) == length(y) || throw(DimensionMismatch(
         "Vector x has a length $(length(x)) but y has a length $(length(y))"))
@@ -1797,31 +1797,31 @@ end
 
 # scaling
 
-function rmul!(x::SparseVectorUnion, a::Real)
+function rmul!(x::SparseVectorOrView, a::Real)
     rmul!(nonzeros(x), a)
     return x
 end
-function rmul!(x::SparseVectorUnion, a::Complex)
+function rmul!(x::SparseVectorOrView, a::Complex)
     rmul!(nonzeros(x), a)
     return x
 end
-function lmul!(a::Real, x::SparseVectorUnion)
+function lmul!(a::Real, x::SparseVectorOrView)
     rmul!(nonzeros(x), a)
     return x
 end
-function lmul!(a::Complex, x::SparseVectorUnion)
+function lmul!(a::Complex, x::SparseVectorOrView)
     rmul!(nonzeros(x), a)
     return x
 end
 
-(*)(x::SparseVectorUnion, a::Number) =
+(*)(x::SparseVectorOrView, a::Number) =
     @if_move_fixed x SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) * a)
-(*)(a::Number, x::SparseVectorUnion) =
+(*)(a::Number, x::SparseVectorOrView) =
     @if_move_fixed x SparseVector(length(x), copy(nonzeroinds(x)), a * nonzeros(x))
-(/)(x::SparseVectorUnion, a::Number) =
+(/)(x::SparseVectorOrView, a::Number) =
     @if_move_fixed x SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) / a)
 # dot
-function dot(x::AbstractVector, y::SparseVectorUnion)
+function dot(x::AbstractVector, y::SparseVectorOrView)
     require_one_based_indexing(x, y)
     n = length(x)
     length(y) == n || throw(DimensionMismatch(
@@ -1835,7 +1835,7 @@ function dot(x::AbstractVector, y::SparseVectorUnion)
     return s
 end
 
-function dot(x::SparseVectorUnion, y::AbstractVector)
+function dot(x::SparseVectorOrView, y::AbstractVector)
     require_one_based_indexing(x, y)
     n = length(y)
     length(x) == n || throw(DimensionMismatch(
@@ -1870,7 +1870,7 @@ function _spdot(f::Function,
     s
 end
 
-function dot(x::SparseVectorUnion, y::SparseVectorUnion)
+function dot(x::SparseVectorOrView, y::SparseVectorOrView)
     x === y && return sum(abs2, x)
     n = length(x)
     length(y) == n || throw(DimensionMismatch(
@@ -1890,7 +1890,7 @@ end
 ### BLAS-2 / dense A * sparse x -> dense y
 
 # lowrankupdate (BLAS.ger! like)
-function LinearAlgebra.lowrankupdate!(A::StridedMatrix, x::AbstractVector, y::SparseVectorUnion, α::Number = 1)
+function LinearAlgebra.lowrankupdate!(A::StridedMatrix, x::AbstractVector, y::SparseVectorOrView, α::Number = 1)
     require_one_based_indexing(A, x, y)
     nzi = nonzeroinds(y)
     nzv = nonzeros(y)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -2421,7 +2421,7 @@ function _fillnonzero!(arr::AbstractCompressedVector{Tv,Ti}, val) where {Tv,Ti}
 end
 
 import Base.fill!
-function fill!(A::Union{AbstractCompressedVector, AbstractSparseMatrixCSC}, x)
+function fill!(A::SparseVecOrMat, x)
     T = eltype(A)
     xT = convert(T, x)
     if _iszero(xT)

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -7,6 +7,15 @@ using LinearAlgebra
 using Random
 include("forbidproperties.jl")
 
+# an AbstractSparseVector outside the types the sparse product kernel handles
+struct WrappedSparseVector <: AbstractSparseVector{Float64,Int}
+    x::SparseVector{Float64,Int}
+end
+Base.size(v::WrappedSparseVector) = size(v.x)
+Base.getindex(v::WrappedSparseVector, i::Int) = v.x[i]
+SparseArrays.nonzeros(v::WrappedSparseVector) = nonzeros(v.x)
+SparseArrays.nonzeroinds(v::WrappedSparseVector) = nonzeroinds(v.x)
+
 sA = sprandn(3, 7, 0.5)
 sC = similar(sA)
 dA = Array(sA)
@@ -266,6 +275,15 @@ begin
         vAW = tr(wr(view([zero(a)+I a], :, (n+1):2n)))
         @test vAW * B ≈ AW * B
     end
+    # the implicit unit diagonal may not fit the index type (#816)
+    A8 = sparse(Int8[1, 2, 5], Int8[2, 1, 7], [2.0, 3.0, 4.0], 127, 127)
+    @test UnitUpperTriangular(A8) * A8 isa SparseMatrixCSC{Float64,Int8}
+    @test UnitLowerTriangular(A8) * A8 ≈ Matrix(UnitLowerTriangular(A8)) * Matrix(A8)
+    @test UnitUpperTriangular(A8) * spzeros(127) == zeros(127)
+    # vectors outside the kernel's types take the generic product
+    T2 = sparse([1.0 2.0; 0.0 1.0])
+    w = WrappedSparseVector(sparsevec([0.0, 3.0]))
+    @test UnitUpperTriangular(T2) * w == UpperTriangular(T2) * w == [6.0, 3.0]
     A = A - Diagonal(diag(A)) + 2I # avoid rounding errors by division
     MA = Matrix(A)
     @testset "triangular solver for $tr($wr)" for tr in (identity, adjoint, transpose),

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -247,9 +247,12 @@ begin
         MAW = tr(wr(MA))
         @test AW * B ≈ MAW * B
         @test AW * s ≈ MAW * s ≈ MAW * sd
+        @test AW * A ≈ MAW * MA
+        tr === identity && @test AW * AW isa wr
         # and for SparseMatrixCSCView - a view of all rows and unit range of cols
         vAW = tr(wr(view([zero(A)+I A], :, (n+1):2n)))
         @test vAW * B ≈ AW * B
+        @test vAW * A ≈ AW * A
     end
     a = sprand(rng, ComplexF64, n, n, 0.01)
     ma = Matrix(a)


### PR DESCRIPTION
The `Union` aliases used for dispatch had grown to 36 across 7 files, with duplicates, near-duplicates that hid semantic differences, and no naming convention. This collects the cross-file ones into one section of `abstractsparse.jl`, drops the duplicates, reuses LinearAlgebra's aliases where they already exist, and gives the survivors one scheme. Solver scalar-type aliases stay with their solvers.

### Before and after

Counting every `const X = Union{...}` in `src`:

| | `main` | this PR |
|---|---|---|
| All `Union` aliases | 44 | 32 |
| Solver scalar / C-struct types (`ITypes`, `VTypes`, `UMFITypes`, ...) | 10 | 9 |
| Dispatch aliases | 34 | 23 |

The 23 dispatch aliases are now: 9 in the shared section of `abstractsparse.jl` (`AbstractSparseVecOrMat`, `SparseVecOrMat`, `SparseMatrixCSCOrView`, `SparseMatrixCSCOrColumnSubset`, `SparseVectorOrView`, two `<X>MaybeAdjOrTrans`, `SparseOrTri`, `LinAlgLeftQs`), 8 local to `linalg.jl` (`DenseMatrixUnion`, `DenseInputVector`, `MatrixWrappers`, `MatrixWrappersOrView`, `QuasiSparseMatrix`, `QuasiStridedMatrix`, the two kron groups), 3 in CHOLMOD (`StridedVecOrMatMaybeAdjOrTrans`, `SparseVectorOrMatrixCSC`, `FactorComponentRHS`), `UMFAdjOrTransLU` in UMFPACK, and `SparseVecOrMatStyle`, `SparseOrStructuredMatrix` and the two concat groups. Placement follows one rule: used from more than one file goes in the shared section, used across a file goes at the top of that file, used by one section sits at the head of that section. A further three aliases (`SparseTriangular`, `SparseMatrixCSCSymmHerm`, CHOLMOD's `RealHermSymComplexHermSSL`) no longer spell out a `Union` because they are built on a LinearAlgebra alias.

### Consolidation

- `SparseVecOrMat` / `_SparseArraysCSC`, `StructuredMatrix` / `_SpecialArrays`, `_SparseVectorUnion` / `SparseVectorUnion`, `DenseViewWrappers` / `WrapperMatrixTypes`, and `SparseTriangular` / `AbstractTriangularSparse` each collapse to one alias.
- "X or `Adjoint`/`Transpose` of X" is spelled `<X>MaybeAdjOrTrans` throughout (after LinearAlgebra's `StridedMaybeAdjOrTransMat`) and built from `AdjOrTrans`.
- "X or a view of X" is spelled `<X>OrView` / `<X>OrColumnSubset`. Alias names use the `Sparse` family name and accept the abstract tier of their base type; only the concrete CHOLMOD alias says otherwise in its name: `SparseMatrixCSCUnion` becomes `SparseMatrixCSCOrView`, `SparseMatrixCSCUnion2` becomes `SparseMatrixCSCOrColumnSubset`, `SparseVectorUnion` becomes `SparseVectorOrView`, and `AdjOrTransSparseVectorUnion` becomes `AdjOrTransSparseVectorOrView`. The two-tier CSC split stays: the `getcolptr`-based kernels need a unit-range column view, the `nzrange`-based ones accept any column subset (#476).
- `SorF` is gone; `SparseMatrixCSC` and `FixedSparseCSC` each define their accessors.
- The seven one-off kron intermediates are folded into `_SparseKronGroup` / `_DenseKronGroup`.
- The inline spellings of the vec-or-mat union in the broadcast style rules, `fkeep!` and `fill!` use `SparseVecOrMat`; the two adjoint/transpose `BroadcastStyle` rules become one.
- CHOLMOD's concrete `SparseVecOrMat` is renamed `SparseVectorOrMatrixCSC` so it no longer shares a name with the top-level abstract alias. It stays concrete because `Sparse(B)` only accepts those two types.
- The remaining cryptic or misleading local names are renamed: UMFPACK's `ATLU` becomes `UMFAdjOrTransLU`, `SPVM` becomes `SparseVecOrMatStyle`, and `WrapperMatrixTypes` (which is `MatrixWrappers` plus `SubArray`) becomes `MatrixWrappersOrView`. The single-use `SuiteSparseStruct` is inlined.
- `SparseOrStructuredMatrix` is built on `SparseMatrixCSCOrView` instead of listing `FixedSparseCSC`, `SparseMatrixCSC` and `SparseMatrixCSCView` explicitly, so `map` over any `AbstractSparseMatrixCSC` subtype mixed with structured matrices takes the sparse path. The pre-existing all-sparse `map`/`map!` disambiguation methods widen from `Vararg{SparseMatrixCSC}` to `Vararg{AbstractSparseMatrixCSC}` to stay more specific than both competing methods.

### Reusing LinearAlgebra's names

- `BiTriSym` was redefined identically; it is now imported from LinearAlgebra.
- `HigherOrderFns.StructuredMatrix` shadowed the larger `LinearAlgebra.StructuredMatrix` in the same file. Its set (`Diagonal`, `Bidiagonal`, `Tridiagonal`, `SymTridiagonal`) is exactly `LinearAlgebra.BandedMatrix`, which is used instead.
- CHOLMOD's `RealHermSymComplexHermSSL` is now `RealHermSymComplexHerm{Tr,<:SparseMatrixCSC{<:Any,Ti}}`; dispatch is unchanged.

### Downstream-facing names

`SparseMatrixCSCView`, `SparseColumnView` and `SparseVectorView` are unchanged and used both internally and by downstream packages (LowRankOpt, IntervalMDP, Distances, and unregistered ones). `SparseMatrixCSCUnion` (Enzyme, SparseLinearAlgebra) and `SparseVectorUnion` (FillArrays, ArrayLayouts, Distances, FrankWolfe, SparseLinearAlgebra) are no longer used internally but are kept as aliases of the new names, with a note that they may be deprecated in a future release. `AdjOrTransSparseVectorUnion` has no external user on GitHub or JuliaHub and is dropped.

### Behavior changes

- `SparseTriangular` now uses `UpperOrLowerTriangular`, so `UnitUpperTriangular`/`UnitLowerTriangular` wrappers of sparse matrices take the Gustavson product path like the non-unit ones (they are materialized via `sparse(A)` first; the temporary widens to `Int` indices when the added diagonal would not fit the parent's index type, and the result keeps the operands' index type). Tri × Tri products keep LinearAlgebra's result wrapper, including `UnitUpper * UnitUpper` staying unit.
- The sparse-vector fast path dispatches on `SparseVectorOrView` rather than `AbstractSparseVector`, so custom `AbstractSparseVector` types outside the kernel's supported set take the generic product. This also fixes `UpperTriangular(S) * v` for such vectors, a `MethodError` on `main`.
- `nnz` and `indtype` are extended to triangular wrappers of column-range views. On `main`, `UpperTriangular(view(S, :, 1:n)) * S` and 14 similar combinations throw `MethodError`; they now return correct sparse results.

A scratchpad probe of 1652 product, kron, dot, broadcast, conversion and solve combinations across sparse, view, wrapper and dense operands shows no result-type or correctness change for anything that worked on `main`, plus the 15 former `MethodError`s now passing. Full suite and Aqua/ambiguity check pass locally, and CI is green on all platforms after rebasing onto `main` past #813, #817 and #819 (the all-sparse `map!` disambiguation now carries #813's `_unaliasargs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFPoSXGFJAGgJrHT98z2AY






