### PR TITLE
Revert the SPQR adjoint changes that landed with #810

### DIFF
--- a/src/solvers/spqr.jl
+++ b/src/solvers/spqr.jl
@@ -5,7 +5,7 @@ module SPQR
 import Base: \, *
 using Base: require_one_based_indexing
 using LinearAlgebra
-using LinearAlgebra: AbstractQ, AdjointQ, AdjointAbsVec, AdjointFactorization, copy_similar
+using LinearAlgebra: AbstractQ, AdjointQ, AdjointAbsVec, copy_similar
 using ..LibSuiteSparse: SuiteSparseQR_C, SuiteSparseQR_i_C
 
 # ordering options */
@@ -439,11 +439,9 @@ LinearAlgebra.rank(S::SparseMatrixCSC; tol=_default_tol(S)) = rank(qr(S; tol))
 # This definition is similar to the definition in factorization.jl except that
 # here we have to use \ instead of ldiv! because of limitations in SPQR
 
-const AdjointQRSparse{Tv} = AdjointFactorization{Tv,<:QRSparse{Tv}}
-
 ## Two helper methods
-_ret_size(F::Union{QRSparse,AdjointQRSparse}, b::AbstractVector) = (size(F, 2),)
-_ret_size(F::Union{QRSparse,AdjointQRSparse}, B::AbstractMatrix) = (size(F, 2), size(B, 2))
+_ret_size(F::QRSparse, b::AbstractVector) = (size(F, 2),)
+_ret_size(F::QRSparse, B::AbstractMatrix) = (size(F, 2), size(B, 2))
 
 function (\)(F::QRSparse{T}, B::VecOrMat{Complex{T}}) where T<:LinearAlgebra.BlasReal
 # |z1|z3|  reinterpret  |x1|x2|x3|x4|  transpose  |x1|y1|  reshape  |x1|y1|x3|y3|
@@ -572,130 +570,6 @@ function LinearAlgebra.ldiv!(X::StridedVecOrMat{T}, F::QRSparse{T}, B::StridedVe
             for j in axes(W, 2)
                 for i in 1:rnk
                     @inbounds X[F.cpiv[i], j] = W[i, j]
-                end
-            end
-        end
-    end
-
-    return X
-end
-
-function (\)(Fadj::AdjointQRSparse{T}, B::VecOrMat{Complex{T}}) where T<:LinearAlgebra.BlasReal
-    # See the QRSparse method above for the layout of the reinterpretation
-    require_one_based_indexing(Fadj, B)
-    c2r = reshape(copy(transpose(reinterpret(T, reshape(B, (1, length(B)))))), size(B, 1), 2*size(B, 2))
-    x = Fadj\c2r
-    return collect(reshape(reinterpret(Complex{T}, copy(transpose(reshape(x, (length(x) >> 1), 2)))), _ret_size(Fadj, B)))
-end
-
-function (\)(Fadj::AdjointQRSparse{T}, B::StridedVecOrMat{T}) where {T}
-    X = similar(B, ntuple(i -> i == 1 ? size(Fadj, 2) : size(B, 2), Val(ndims(B))))
-    # Note that we copy the parent factorization here for thread-safety
-    return ldiv!(X, adjoint(copy(parent(Fadj))), B)
-end
-
-"""
-    (\\)(F::AdjointFactorization{<:Any,<:QRSparse}, B::StridedVecOrMat)
-
-Solve the underdetermined system ``A^*x=b`` when `F` is the sparse QR factorization of the
-tall matrix ``A``, i.e. `F = qr(A)` with `size(A, 1) >= size(A, 2)`. The minimum-norm
-solution is returned; when ``A`` is rank deficient, the equations corresponding to the
-dependent columns of ``A`` are dropped, mirroring the basic solution returned by
-`F \\ B`. Overdetermined systems are not supported here as they would require a
-factorization of ``A^*`` rather than of ``A``.
-
-# Examples
-```jldoctest
-julia> A = sparse([1,2,3,4,1,2,3,4], [1,1,1,1,2,2,2,2], [1.0,1.0,1.0,1.0,1.0,-1.0,1.0,-1.0])
-4×2 SparseMatrixCSC{Float64, Int64} with 8 stored entries:
- 1.0   1.0
- 1.0  -1.0
- 1.0   1.0
- 1.0  -1.0
-
-julia> x = qr(A)'\\[4.0, 0.0]
-4-element Vector{Float64}:
- 1.0
- 1.0
- 1.0
- 1.0
-
-julia> A'x
-2-element Vector{Float64}:
- 4.0
- 0.0
-```
-"""
-(\)(Fadj::AdjointQRSparse, B::StridedVecOrMat) = Fadj\convert(AbstractArray{eltype(Fadj)}, B)
-
-function LinearAlgebra.ldiv!(X::StridedVecOrMat{T}, Fadj::AdjointQRSparse{T}, B::StridedVecOrMat{T}) where {T}
-    F = parent(Fadj)
-    m, n = size(F)
-    # Solving A'x = b for a wide A would be an overdetermined problem requiring a
-    # least-squares solve with R', which the triangular solve below cannot provide
-    if m < n
-        throw(DimensionMismatch("overdetermined systems are not supported"))
-    end
-    if n != size(B, 1)
-        throw(DimensionMismatch("size(Fadj) = $(size(Fadj)) but size(B) = $(size(B))"))
-    end
-    if m != size(X, 1)
-        throw(DimensionMismatch("size(Fadj) = $(size(Fadj)) but size(X) = $(size(X))"))
-    end
-    if ndims(B) > 1 && size(X, 2) != size(B, 2)
-        throw(DimensionMismatch("size(X) = $(size(X)) but size(B) = $(size(B))"))
-    end
-
-    rnk = rank(F)
-
-    # With A[prow, pcol] == Q*R we have A' == Pcol*R'*Q'*Prow, so x = Prow'*Q*(R' \ Pcol'*b)
-    @lock F._lock begin
-        # Workspace has max(m, n) == m rows, which is what Q acts on
-        W = _get_ldiv_workspace(F, B)
-
-        # Gather the column permutation of B into the leading n rows of W
-        # NB: cpiv == [] if SPQR was called with ORDERING_FIXED
-        if length(F.cpiv) == 0
-            for j in axes(W, 2)
-                for i in 1:n
-                    @inbounds W[i, j] = B[i, j]
-                end
-            end
-        else
-            for j in axes(W, 2)
-                for i in 1:n
-                    @inbounds W[i, j] = B[F.cpiv[i], j]
-                end
-            end
-        end
-
-        # Zero the free variables so that Q*W is the minimum-norm solution. When A is
-        # rank deficient this also drops the equations that the leading block of R
-        # cannot represent, which is the counterpart of the basic solution above.
-        for j in axes(W, 2)
-            for i in (rnk + 1):m
-                @inbounds W[i, j] = zero(T)
-            end
-        end
-
-        # Solve R'*W = Pcol'*B by forward substitution. See the ldiv! above for why
-        # generic_trimatdiv! is called directly rather than through LowerTriangular.
-        W_rnk = @view(W[Base.OneTo(rnk), :])
-        LinearAlgebra.generic_trimatdiv!(W_rnk, 'U', 'N', adjoint,
-                                         @view(F.R[:, Base.OneTo(rnk)]), W_rnk)
-
-        # Multiply by Q and undo the row permutation, i.e. X[prow] = Q*W
-        lmul!(F.Q, @view(W[Base.OneTo(m), :]))
-        if length(F.rpivinv) == 0
-            for j in axes(W, 2)
-                for i in 1:m
-                    @inbounds X[i, j] = W[i, j]
-                end
-            end
-        else
-            for j in axes(W, 2)
-                for i in 1:m
-                    @inbounds X[i, j] = W[F.rpivinv[i], j]
                 end
             end
         end

--- a/test/spqr.jl
+++ b/test/spqr.jl
@@ -79,14 +79,6 @@ itypes = sizeof(Int) == 4 ? (Int32,) : (Int32, Int64)
         @test_throws DimensionMismatch A\B[1:m-1,:]
         C, x = A[1:9, :], fill(eltyB(1), 9)
         @test C*(C\x) ≈ x # Underdetermined system
-
-        # Minimum-norm solution of the underdetermined A'x = b (#656)
-        D = B[1:n, :]
-        @test F'\D ≈ Array(A)'\D
-        @test F'\D[:,1] ≈ Array(A)'\D[:,1]
-        @test transpose(F)\D ≈ transpose(Array(A))\D
-        @test A'\D ≈ Array(A)'\D
-        @test_throws DimensionMismatch F'\B
     end
 
     # Make sure that conversion to Sparse doesn't use SuiteSparse's symmetric flag
@@ -135,13 +127,10 @@ end
      A = sparse([1:n; rand(1:m, nn - n)], [1:n; rand(1:n, nn - n)], randn(nn), m, n)
      b = randn(m)
      xref = Array(A) \ b
-     c = randn(n)
-     cref = Array(A)' \ c
      for ordering ∈ SPQR.ORDERINGS
          QR = qr(A, ordering=ordering)
          x = QR \ b
          @test x ≈ xref
-         @test QR' \ c ≈ cref
      end
      @test_throws ErrorException qr(A, ordering=Int32(10))
 end
@@ -217,11 +206,6 @@ end
         @test_throws DimensionMismatch ldiv!(zeros(n), F, zeros(m - 1))
         @test_throws DimensionMismatch ldiv!(zeros(n - 1), F, zeros(m))
         @test_throws DimensionMismatch ldiv!(zeros(n, 2), F, zeros(m, 3))
-        @test_throws DimensionMismatch ldiv!(zeros(m), F', zeros(n - 1))
-        @test_throws DimensionMismatch ldiv!(zeros(m - 1), F', zeros(n))
-        @test_throws DimensionMismatch ldiv!(zeros(m, 2), F', zeros(n, 3))
-        # A' is overdetermined when A is wide, which needs a factorization of A'
-        @test_throws DimensionMismatch qr(sprandn(n, m, 0.5))' \ zeros(m)
     end
 
     @testset "copying QRSparse" begin


### PR DESCRIPTION
#810 was meant to only bump the version and julia compat to 1.14, but it was accidentally based on the branch of #804 and squash-merged with the "Solve with the adjoint of a sparse QR factorization" change included (see https://github.com/JuliaSparse/SparseArrays.jl/pull/810#issuecomment-5633278266). This reverts the `src/solvers/spqr.jl` and `test/spqr.jl` portion of a248d20 so that #804 can be reviewed and merged on its own. The `Project.toml` bump is kept.

Both files are restored byte-for-byte to their state before a248d20, and `test/spqr.jl` passes locally on the 1.14-DEV build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFzXKGsJuSogARQpDGipPr
