### PR TITLE
Throw a clear error when `map!` or broadcast would densify a fixed sparse array

### DIFF
--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -316,12 +316,17 @@ end
 # helper functions for these methods and some of those below
 @inline _densecoloffsets(A::AbstractCompressedVector) = 0
 @inline _densecoloffsets(A::AbstractSparseMatrixCSC) = 0:size(A, 1):(size(A, 1)*(size(A, 2) - 1))
+# a fixed pattern cannot be densified unless it already is; fail here rather than deep in ReadOnly
+_checkdensifiable(A) = _is_fixed(A) && nnz(A) != widelength(A) &&
+    throw(ArgumentError("cannot store a nonzero f(0) into a $(nameof(typeof(A))), its sparsity pattern is read-only"))
 function _densestructure!(A::AbstractCompressedVector)
+    _checkdensifiable(A)
     expandstorage!(A, length(A))
     copyto!(nonzeroinds(A), 1:length(A))
     return A
 end
 function _densestructure!(A::AbstractSparseMatrixCSC)
+    _checkdensifiable(A)
     nnzA = size(A, 1) * size(A, 2)
     expandstorage!(A, nnzA)
     copyto!(getcolptr(A), 1:size(A, 1):(nnzA + 1))

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -69,6 +69,9 @@ struct_eq(A::AbstractSparseVector, B::AbstractSparseVector) =
     @test struct_eq(F, H, A)
     H = map!(zero, copy(F), F)
     @test struct_eq(F, H, A)
+    @test_throws ArgumentError map!(x -> x + 1, H, F)
+    @test_throws ArgumentError H .= F .+ 1
+    @test struct_eq(F, H, A)
     F .= false
     @test struct_eq(F, H, A)
     F .= A .+ A
@@ -111,6 +114,8 @@ end
 @testset "FixedSparseVector" begin
     y = sprandn(10, 0.3)
     x = FixedSparseVector(copy(y))
+    @test struct_eq(x, y)
+    @test_throws ArgumentError map!(v -> v + 1, x, y)
     @test struct_eq(x, y)
     nonzeros(x) .= 0
     @test struct_eq(x, y)


### PR DESCRIPTION
Follow-up to the discussion on #813.

`map!` and in-place broadcast already work on `FixedSparseCSC` and `FixedSparseVector` when `f(0) == 0`: the kernels keep every stored entry and never touch the pattern. When `f(0) != 0` the result is dense, so the destination's structure has to be rewritten, which a fixed pattern forbids. That case failed, correctly but unhelpfully, with

```
ERROR: can't resize SparseArrays.ReadOnly{Int64, 1, Vector{Int64}}
```

from inside the storage helpers. Every non-zero-preserving `map!` and broadcast kernel goes through `_densestructure!`, so this adds one check there and throws

```
ERROR: ArgumentError: cannot store a nonzero f(0) into a FixedSparseCSC, its sparsity pattern is read-only
```

A fixed array whose pattern is already fully dense is left alone and keeps working, since densifying it is a no-op.

Tests are folded into the existing `FixedSparseCSC` and `FixedSparseVector` testsets and check that the destination's structure is untouched after the throw. `test/fixed.jl` and `test/higherorderfns.jl` pass locally on nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbVK4MsughyxiN1U6gd1mm
