### PR TITLE
Check the inputs' pattern against a fixed `map!` destination up front

### DIFF
--- a/src/higherorderfns.jl
+++ b/src/higherorderfns.jl
@@ -274,6 +274,7 @@ end
 # (4) _map_zeropres!/_map_notzeropres! specialized for a single sparse vector/matrix
 "Stores only the nonzero entries of `map(f, Array(A))` in `C`."
 function _map_zeropres!(f::Tf, C::SparseVecOrMat, A::SparseVecOrMat) where Tf
+    _is_fixed(C) && _checkfixedpattern(C, A)
     spaceC::Int = length(nonzeros(C))
     isfixed = _is_fixed(C, A)
     Ck = 1
@@ -339,6 +340,7 @@ end
 
 # (5) _map_zeropres!/_map_notzeropres! specialized for a pair of sparse vectors/matrices
 function _map_zeropres!(f::Tf, C::SparseVecOrMat, A::SparseVecOrMat, B::SparseVecOrMat) where Tf
+    _is_fixed(C) && _checkfixedpattern(C, A, B)
     isfixed = _is_fixed(C, A, B)
     spaceC::Int = length(nonzeros(C))
     rowsentinelA = convert(indtype(A), numrows(C) + 1)
@@ -417,8 +419,9 @@ end
 
 # (6) _map_zeropres!/_map_notzeropres! for more than two sparse matrices / vectors
 function _map_zeropres!(f::Tf, C::SparseVecOrMat, As::Vararg{SparseVecOrMat,N}) where {Tf,N}
+    _is_fixed(C) && _checkfixedpattern(C, As...)
     spaceC::Int = length(nonzeros(C))
-    isfixed = _is_fixed(As...)
+    isfixed = _is_fixed(C, As...)
     rowsentinel = numrows(C) + 1
     Ck = 1
     stopks = _colstartind_all(1, As)
@@ -467,6 +470,43 @@ function _map_notzeropres!(f::Tf, fillvalue, C::SparseVecOrMat, As::Vararg{Spars
     end
     return _checkbuffers(C)
 end
+
+# A fixed destination keeps every entry of the inputs' union pattern, so that union must be
+# its own pattern. Inputs sharing C's pattern are the common case and cheap to verify;
+# otherwise a dry run of the merge above checks this before anything is written.
+function _checkfixedpattern(C::SparseVecOrMat, As::Vararg{SparseVecOrMat,N}) where N
+    all(A -> _samepattern(C, A), As) && return nothing
+    rowsentinel = numrows(C) + 1
+    Ck = 1
+    stopks = _colstartind_all(1, As)
+    @inbounds for j in columns(C)
+        Ck == colstartind(C, j) || _throwfixedpattern(C)
+        stopCk = colboundind(C, j)
+        ks = stopks
+        stopks = _colboundind_all(j, As)
+        rows = _rowforind_all(rowsentinel, ks, stopks, As)
+        activerow = min(rows...)
+        while activerow < rowsentinel
+            (Ck < stopCk && storedinds(C)[Ck] == activerow) || _throwfixedpattern(C)
+            Ck += 1
+            _, ks, rows = _fusedupdate_all(rowsentinel, activerow, rows, ks, stopks, As)
+            activerow = min(rows...)
+        end
+        Ck == stopCk || _throwfixedpattern(C)
+    end
+    return nothing
+end
+function _samepattern(C::SparseVecOrMat, A::SparseVecOrMat)
+    @inbounds for j in columns(C)
+        (colstartind(C, j) == colstartind(A, j) && colboundind(C, j) == colboundind(A, j)) || return false
+    end
+    @inbounds for k in 1:(colboundind(C, numcols(C)) - 1)
+        storedinds(C)[k] == storedinds(A)[k] || return false
+    end
+    return true
+end
+@noinline _throwfixedpattern(C) =
+    throw(ArgumentError("the inputs' combined sparsity pattern differs from that of the $(nameof(typeof(C))) destination, whose pattern is read-only"))
 
 # helper methods for map/map! methods just above
 @inline _colstartind(j, A) = colstartind(A, j)

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -71,6 +71,12 @@ struct_eq(A::AbstractSparseVector, B::AbstractSparseVector) =
     @test struct_eq(F, H, A)
     @test_throws ArgumentError map!(x -> x + 1, H, F)
     @test_throws ArgumentError H .= F .+ 1
+    G = sprandn(10, 10, 0.3)
+    @test_throws ArgumentError map!(identity, H, G)
+    @test_throws ArgumentError map!(+, H, A, G)
+    @test_throws ArgumentError H .= A .+ A .+ G
+    @test struct_eq(F, H, A)
+    @test map!((x, y, z) -> x - y + z - z, H, A, A, A) == 0 .* A   # zeros stay stored
     @test struct_eq(F, H, A)
     F .= false
     @test struct_eq(F, H, A)
@@ -116,6 +122,7 @@ end
     x = FixedSparseVector(copy(y))
     @test struct_eq(x, y)
     @test_throws ArgumentError map!(v -> v + 1, x, y)
+    @test_throws ArgumentError map!(identity, x, sprandn(10, 0.3))
     @test struct_eq(x, y)
     nonzeros(x) .= 0
     @test struct_eq(x, y)


### PR DESCRIPTION
Follow-up to #819, which covered the `f(0) != 0` case. This covers the other way `map!` or same-shape broadcast can fail on a fixed destination: inputs whose combined sparsity pattern is not the destination's.

A `FixedSparseCSC` or `FixedSparseVector` destination keeps every entry of the inputs' union pattern, so that union must equal its own pattern. When it did not, the kernel failed partway through with

```
ERROR: Can't change SparseArrays.ReadOnly{Int64, 1, Vector{Int64}}.
```

The zero-preserving `map!` kernels now verify the pattern before writing anything and throw

```
ERROR: ArgumentError: the inputs' combined sparsity pattern differs from that of the FixedSparseCSC destination, whose pattern is read-only
```

The check first compares each input's pattern directly against the destination's, which is the common case and cheap. Only if that fails does it do a dry run of the same N-way merge the kernel uses, so the error is raised with the destination untouched.

While there, the three-or-more-input kernel decided whether to keep zero results from the inputs alone, unlike the one- and two-input kernels which include the destination. A fixed destination with three plain inputs therefore dropped entries and errored on `main`:

```julia
julia> A = sparse([1.0 0; 0 2.0]); F = SparseArrays.fixed(A);
julia> map!((a, b, c) -> a - b + c - c, F, A, A, A)
ERROR: Can't change SparseArrays.ReadOnly{Int64, 1, Vector{Int64}}.
```

It now keeps them like the other kernels.

Cost of the up-front check on a 2000×2000, 2% dense fixed destination with same-pattern inputs, best of 20 runs on nightly:

| | main | this PR |
|---|---|---|
| `F .= A .+ A` | 0.18 ms | 0.24 ms |
| `map!(+, F, A, B)` | 0.19 ms | 0.24 ms |
| `map!(x -> 2x, F, A)` | 0.08 ms | 0.11 ms |

The existing zero-allocation tests for fixed broadcast still hold. Tests are folded into the existing `FixedSparseCSC` and `FixedSparseVector` testsets: one-, two- and three-input mismatches, the three-input zero case, and that the destination's structure is untouched after a throw. `test/fixed.jl` and `test/higherorderfns.jl` pass locally on nightly.

Broadcast between differently shaped arguments into a fixed destination goes through separate kernels and still reports the `ReadOnly` error; that's left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbVK4MsughyxiN1U6gd1mm
