### PR TITLE
Throw when the destination of sparse `transpose!`/`adjoint!` aliases the source

### DIFF
--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -1442,6 +1442,10 @@ function ftranspose!(X::AbstractSparseMatrixCSC{Tv,Ti}, A::AbstractSparseMatrixC
     elseif size(X, 1) != size(A, 2)
         throw(DimensionMismatch(string("destination argument `X`'s row count, ",
             "`size(X, 1) (= $(size(X, 1)))`, must match source argument `A`'s column count, `size(A, 2) (= $(size(A, 2)))`")))
+    # halfperm! overwrites X's buffers while reading A's. With nnz(A) == 0 only the colptr is
+    # written, and the empty rowval/nzval buffers would falsely alias (they share one `Memory`)
+    elseif nnz(A) > 0 ? Base.mightalias(X, A) : Base.mightalias(getcolptr(X), getcolptr(A))
+        throw(ArgumentError("destination argument `X` must not share memory with source argument `A`"))
     end
     halfperm!(X, A, axes(A,2), f)
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -800,6 +800,8 @@ end
     @testset "common error checking of [c]transpose! methods (ftranspose!)" begin
         @test_throws DimensionMismatch transpose!(A[:, 1:(smalldim - 1)], A)
         @test_throws DimensionMismatch transpose!(A[1:(smalldim - 1), 1], A)
+        @test_throws ArgumentError transpose!(A, A) # #812
+        @test_throws ArgumentError adjoint!(A, A)
     end
     @testset "common error checking of permute[!] methods / source-perm compat" begin
         @test_throws DimensionMismatch permute(A, p[1:(end - 1)], q)


### PR DESCRIPTION
Fixes #812

**Bug.** `transpose!(A, A)` and `adjoint!(A, A)` on a `SparseMatrixCSC` silently emptied `A`. `ftranspose!` passes both arguments straight to `halfperm!`, which `fill!`s the destination's `colptr` with zeros and then counts entries out of the source, so when the two share buffers the source is destroyed before it is read.

**Fix.** `ftranspose!` now throws an `ArgumentError` when `X` and `A` might share memory, alongside the existing `DimensionMismatch` checks. Detection uses `Base.mightalias`, so it also catches partial aliasing (e.g. a destination built on the source's `nzval`) and `FixedSparseCSC`. One wrinkle: on Julia 1.11+ all empty `Vector{T}`s share a single `Memory`, so two unrelated structurally-empty matrices report as aliased through their empty `rowval`/`nzval`. That tripped the `sort!(A; dims=2)` path on `spzeros`. With `nnz(A) == 0` only the `colptr` is written, so in that case just the `colptr`s are compared.

**Tests.** Two `@test_throws ArgumentError` lines added to the existing `[c]transpose!` error-checking testset in `test/linalg.jl`.

**Verified locally** on the 1.14-DEV build: full `Pkg.test()` passes. Also checked (not committed) that the source is untouched after the throw, that partial `nzval` aliasing and `FixedSparseCSC` self-transposition throw, and that empty and non-aliased transposes still work.

**Not addressed.** The dense `transpose!(B, B)` behaviour in the issue lives in LinearAlgebra, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB4WFqTjfGaTmJLc2kRizB
