### PR TITLE
Fix pattern corruption, generic fallbacks and error messages for fixed sparse arrays

### DIFF
--- a/src/SparseArrays.jl
+++ b/src/SparseArrays.jl
@@ -21,7 +21,7 @@ import LinearAlgebra: mul!, ldiv!, rdiv!, cholesky, adjoint!, diag, eigen, dot,
     cond, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu,
     matop_dest, copytrito!, nonzeroinds
 
-import Base: adjoint, argmin, argmax, Array, broadcast, circshift!, complex, Complex,
+import Base: adjoint, argmin, argmax, Array, broadcast, circshift, circshift!, complex, Complex,
     conj, conj!, convert, copy, copy!, copyto!, count, diff, findall, findmax, findmin, findnext, findprev,
     float, getindex, imag, inv, kron, kron!, length, map, maximum, minimum, permute!, promote_rule, real,
     rot180, rotl90, rotr90, setindex!, show, similar, size, sum, transpose,

--- a/src/abstractsparse.jl
+++ b/src/abstractsparse.jl
@@ -204,6 +204,8 @@ end
 
 @inline _is_fixed(::AbstractArray) = false
 @inline _is_fixed(A::AbstractArray, Bs::Vararg{Any,N}) where N = _is_fixed(A) || (N > 0 && _is_fixed(Bs...))
+@noinline _throwfixedinsert(A, I...) =
+    throw(ArgumentError("cannot store a new entry at ($(join(I, ", "))) in a $(nameof(typeof(A))), its sparsity pattern is read-only"))
 macro if_move_fixed(a...)
     length(a) <= 1 && error("@if_move_fixed needs at least two arguments")
     h, v = esc.(a[1:end - 1]), esc(a[end])

--- a/src/readonly.jl
+++ b/src/readonly.jl
@@ -25,15 +25,14 @@ Base.eachindex(i::IndexCartesian, x::ReadOnly) = eachindex(i, parent(x))
 
 Base.unsafe_convert(x::Type{Ptr{T}}, A::ReadOnly) where T = Base.unsafe_convert(x, parent(A))
 Base.elsize(::Type{ReadOnly{T,N,V}}) where {T,N,V} = Base.elsize(V)
-Base.@propagate_inbounds @inline Base.setindex!(x::ReadOnly, v, ind::Vararg{Integer}) = if v == getindex(parent(x), ind...)
-        v
-    else
-        error("Can't change $(typeof(x)).")
-    end
+@noinline _readonly_error(x) =
+    throw(ArgumentError("cannot modify a $(nameof(typeof(x))) array, the sparsity pattern of a fixed sparse array is read-only"))
+Base.@propagate_inbounds @inline Base.setindex!(x::ReadOnly, v, ind::Vararg{Integer}) =
+    v == getindex(parent(x), ind...) ? v : _readonly_error(x)
 for i in [:IteratorSize, :IndexStyle]
     @eval(@inline Base.$i(::Type{ReadOnly{T,N,V}}) where {T,N,V} = Base.$i(V))
 end
-@inline Base.resize!(x::ReadOnly, l) = l == length(parent(x)) ? x : error("can't resize $(typeof(x))")
+@inline Base.resize!(x::ReadOnly, l) = l == length(parent(x)) ? x : _readonly_error(x)
 Base.copy(x::ReadOnly) = ReadOnly(copy(parent(x)))
 (==)(x::ReadOnly, y::AbstractVector) = parent(x) == y
 (==)(x::AbstractVector, y::ReadOnly) = x == parent(y)

--- a/src/sparsematrix.jl
+++ b/src/sparsematrix.jl
@@ -91,14 +91,18 @@ FixedSparseCSC(m::Integer, n::Integer, colptr::Vector{Ti}, rowval::Vector{Ti}, n
 FixedSparseCSC(x::AbstractSparseMatrixCSC{Tv,Ti}) where {Tv,Ti} =
     FixedSparseCSC{Tv,Ti}(size(x, 1), size(x, 2),
         getcolptr(x), rowvals(x), nonzeros(x))
-FixedSparseCSC{Tv,Ti}(x::AbstractSparseMatrixCSC) where {Tv,Ti} =
-    FixedSparseCSC{Tv,Ti}(size(x, 1), size(x, 2),
-        getcolptr(x), rowvals(x), nonzeros(x))
+# shares x's buffers when the types already match, converts them otherwise
+function FixedSparseCSC{Tv,Ti}(x::AbstractSparseMatrixCSC) where {Tv,Ti}
+    y = _unsafe_unfix(x)
+    FixedSparseCSC{Tv,Ti}(size(y, 1), size(y, 2),
+        convert(Vector{Ti}, getcolptr(y)), convert(Vector{Ti}, rowvals(y)), convert(Vector{Tv}, nonzeros(y)))
+end
 
 """
     fixed(x...)
 
-Experimental. Like `sparse` but returns a sparse array whose `_is_fixed` is `true`.
+Experimental. Like `sparse` but returns a sparse array whose sparsity pattern is read-only:
+stored entries can change value, but none can be added or removed.
 """
 fixed(x...) = move_fixed(sparse(x...))
 fixed(x::AbstractSparseMatrixCSC) = FixedSparseCSC(x)
@@ -115,7 +119,7 @@ move_fixed(x::AbstractSparseMatrixCSC) = FixedSparseCSC(size(x)..., getcolptr(x)
 Experimental, unsafe. Returns a modifiable version of `x` for compatibility with this codebase.
 """
 _unsafe_unfix(x::FixedSparseCSC) = SparseMatrixCSC(size(x)..., parent(getcolptr(x)), parent(rowvals(x)), nonzeros(x))
-_unsafe_unfix(x::SparseMatrixCSC) = x
+_unsafe_unfix(x::AbstractSparseMatrixCSC) = x
 
 const SorF = Union{<:SparseMatrixCSC, <:FixedSparseCSC}
 
@@ -565,7 +569,28 @@ copy(S::AbstractSparseMatrixCSC) =
     SparseMatrixCSC(size(S, 1), size(S, 2), copy(getcolptr(S)), copy(rowvals(S)), copy(nonzeros(S)))
 copy(S::FixedSparseCSC) =
     FixedSparseCSC(size(S, 1), size(S, 2), getcolptr(S), rowvals(S), copy(nonzeros(S)))
+# A fixed destination keeps its pattern: B's stored entries must lie in it and A's other
+# entries become zero. The pattern is checked in full before anything is written.
+function _copyto_fixed!(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)
+    size(A) == size(B) || throw(DimensionMismatch(lazy"cannot copy a matrix of size $(size(B)) into a fixed one of size $(size(A))"))
+    Arv, Brv, Anz, Bnz = rowvals(A), rowvals(B), nonzeros(A), nonzeros(B)
+    for write in (false, true)
+        write && fill!(Anz, zero(eltype(A)))
+        @inbounds for j in axes(A, 2)
+            k, kend = Int(getcolptr(A)[j]), Int(getcolptr(A)[j+1]) - 1
+            for p in nzrange(B, j)
+                i = Brv[p]
+                while k <= kend && Arv[k] < i; k += 1; end
+                (k <= kend && Arv[k] == i) || _throwfixedinsert(A, i, j)
+                write && (Anz[k] = Bnz[p])
+            end
+        end
+    end
+    return A
+end
+
 function copyto!(A::AbstractSparseMatrixCSC, B::AbstractSparseMatrixCSC)
+    _is_fixed(A) && return _copyto_fixed!(A, B)
     # If the two matrices have the same length then all the
     # elements in A will be overwritten.
     if widelength(A) == widelength(B)
@@ -717,13 +742,16 @@ the original sparse matrix, except in the case where dimensions of the
 output matrix are different from the output.
 
 The output matrix has zeros in the same locations as the input, but
-uninitialized values for the nonzero locations.
+uninitialized values for the nonzero locations. A `FixedSparseCSC` input keeps
+its fixed pattern only in the structure-preserving form; the forms taking a
+shape return a `SparseMatrixCSC`.
 """
 similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}) where {Ti,TvNew} =
     @if_move_fixed S _sparsesimilar(S, TvNew, Ti)
 
+# a new shape carries no pattern over, so the result is never fixed
 similar(S::AbstractSparseMatrixCSC{<:Any,Ti}, ::Type{TvNew}, dims::Union{Dims{1},Dims{2}}) where {Ti,TvNew} =
-    @if_move_fixed S _sparsesimilar(S, TvNew, Ti, dims)
+    _sparsesimilar(S, TvNew, Ti, dims)
 
 # The following methods cover similar(A, Tv, Ti[, shape...]) calls, which specify the
 # result's index type in addition to its entry type, and aren't covered by the hooks above.
@@ -3332,6 +3360,7 @@ function _setindex_scalar!(A::AbstractSparseMatrixCSC{Tv,Ti}, _v, _i::Integer, _
         !isbitstype(Ti) || nz < typemax(Ti) ||
             throw(ArgumentError("nnz(A) going to exceed typemax(Ti) = $(typemax(Ti))"))
 
+        _is_fixed(A) && _throwfixedinsert(A, i, j)
         # if nnz(A) < length(rowval/nzval): no need to grow rowval and preserve values
         _insert!(rowvals(A), searchk, i, nz)
         _insert!(nonzeros(A), searchk, v, nz)
@@ -3357,6 +3386,12 @@ function Base.fill!(V::SubArray{Tv, <:Any, <:AbstractSparseMatrixCSC{Tv}, <:Tupl
     A = parent(V)
     I, J = V.indices
     if isempty(I) || isempty(J); return A; end
+    if _is_fixed(A)   # the scalar path keeps the pattern and throws outside it
+        for j in J, i in I
+            A[i, j] = x
+        end
+        return V
+    end
     # lt=≤ to check for strict sorting
     if !issorted(I, lt=≤); I = sort!(unique(I)); end
     if !issorted(J, lt=≤); J = sort!(unique(J)); end
@@ -3535,6 +3570,13 @@ function setindex!(A::AbstractSparseMatrixCSC{Tv,Ti}, V::AbstractVecOrMat, Ix::U
     checkbounds(A, I, J)
     nJ = length(J)
     Base.setindex_shape_check(V, length(I), nJ)
+    if _is_fixed(A)   # the scalar path keeps the pattern and throws outside it
+        k = 0
+        for j in J, i in I
+            A[i, j] = V[k += 1]
+        end
+        return A
+    end
     B = _to_same_csc(A, V, I, J)
 
     m, n = size(A)
@@ -3660,6 +3702,13 @@ setindex!(A::Matrix, x::AbstractSparseMatrixCSC, I::AbstractVector{Bool}, J::Abs
 function setindex!(A::AbstractSparseMatrixCSC, x::AbstractArray, I::AbstractMatrix{Bool})
     require_one_based_indexing(A, x, I)
     checkbounds(A, I)
+    if _is_fixed(A)   # the scalar path keeps the pattern and throws outside it
+        k = 0
+        for ci in CartesianIndices(I)
+            I[ci] && (A[ci] = x[k += 1])
+        end
+        return A
+    end
     n = sum(I)
     (n == 0) && (return A)
 
@@ -3761,6 +3810,12 @@ end
 function setindex!(A::AbstractSparseMatrixCSC, x::AbstractArray, Ix::AbstractVector{<:Integer})
     require_one_based_indexing(A, x, Ix)
     (I,) = Base.ensure_indexable(to_indices(A, (Ix,)))
+    if _is_fixed(A)   # the scalar path keeps the pattern and throws outside it
+        for (k, i) in enumerate(I)
+            A[i] = x[k]
+        end
+        return A
+    end
     # We check bounds after sorting I
     n = length(I)
     (n == 0) && (return A)
@@ -4583,6 +4638,9 @@ end
 
 circshift!(O::AbstractSparseMatrixCSC, X::AbstractSparseMatrixCSC, (r,)::Base.DimsInteger{1}) = circshift!(O, X, (r,0))
 circshift!(O::AbstractSparseMatrixCSC, X::AbstractSparseMatrixCSC, r::Real) = circshift!(O, X, (Integer(r),0))
+# a fixed X keeps its pattern under `similar`, so shift into a plain copy instead
+circshift(X::AbstractSparseMatrixCSC, s::Base.DimsInteger) = circshift!(similar(_unsafe_unfix(X)), X, s)
+circshift(X::AbstractSparseMatrixCSC, s::Real) = circshift!(similar(_unsafe_unfix(X)), X, (Integer(s),))
 
 ## swaprows! / swapcols!
 macro swap(a, b)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -77,6 +77,8 @@ FixedSparseVector(n::Integer, nzind::Vector{<:Integer}, nzval::Vector) =
     FixedSparseVector(n, ReadOnly(nzind), nzval)
 
 FixedSparseVector(s::AbstractSparseVector) = FixedSparseVector(length(s), copy(nonzeroinds(s)), copy(nonzeros(s)))
+FixedSparseVector{Tv,Ti}(s::AbstractSparseVector) where {Tv,Ti} =
+    FixedSparseVector{Tv,Ti}(length(s), ReadOnly(Vector{Ti}(nonzeroinds(s))), Vector{Tv}(nonzeros(s)))
 
 """
 inverse of fixed, should not allocate
@@ -209,7 +211,11 @@ function _sparsesimilar(S::SparseVector, ::Type{TvNew}, ::Type{TiNew}, dims::Dim
     return sizehint!(S1, min(widelength(S1), length(nonzeroinds(S))))
 end
 
-_sparsesimilar(S::FixedSparseVector, x...) = move_fixed(_sparsesimilar(_unsafe_unfix(S), x...))
+_sparsesimilar(S::FixedSparseVector, ::Type{TvNew}, ::Type{TiNew}) where {TvNew,TiNew} =
+    move_fixed(_sparsesimilar(_unsafe_unfix(S), TvNew, TiNew))
+# a new shape carries no pattern over, so the result is never fixed
+_sparsesimilar(S::FixedSparseVector, ::Type{TvNew}, ::Type{TiNew}, dims::Dims) where {TvNew,TiNew} =
+    _sparsesimilar(_unsafe_unfix(S), TvNew, TiNew, dims)
 
 # The following methods hook into the AbstractArray similar hierarchy. The first method
 # covers similar(A[, Tv]) calls, which preserve stored-entry structure, and the latter
@@ -438,6 +444,7 @@ end
         nzval[k] = v
     else  # i not found
         if v isa AbstractArray || v !== zero(eltype(x)) # stricter than iszero to support v[i] = -0.0
+            _is_fixed(x) && _throwfixedinsert(x, i)
             insert!(nzind, k, i)
             insert!(nzval, k, v)
         end
@@ -612,7 +619,25 @@ function prep_sparsevec_copy_dest!(A::AbstractCompressedVector, lB, nnzB)
     end
 end
 
+# see `_copyto_fixed!` for matrices
+function _copyto_fixed!(A::AbstractCompressedVector, B::AbstractCompressedVector)
+    length(A) == length(B) || throw(DimensionMismatch(lazy"cannot copy a vector of length $(length(B)) into a fixed one of length $(length(A))"))
+    Ai, Bi, Anz, Bnz = nonzeroinds(A), nonzeroinds(B), nonzeros(A), nonzeros(B)
+    for write in (false, true)
+        write && fill!(Anz, zero(eltype(A)))
+        k = 1
+        @inbounds for p in eachindex(Bi)
+            i = Bi[p]
+            while k <= length(Ai) && Ai[k] < i; k += 1; end
+            (k <= length(Ai) && Ai[k] == i) || _throwfixedinsert(A, i)
+            write && (Anz[k] = Bnz[p])
+        end
+    end
+    return A
+end
+
 function copyto!(A::AbstractCompressedVector, B::AbstractCompressedVector)
+    _is_fixed(A) && return _copyto_fixed!(A, B)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))
     copyto!(nonzeroinds(A), nonzeroinds(B))
     copyto!(nonzeros(A), nonzeros(B))
@@ -622,6 +647,7 @@ end
 copyto!(A::AbstractCompressedVector, B::AbstractVector) = copyto!(A, sparsevec(B))
 
 function copyto!(A::AbstractCompressedVector, B::AbstractSparseMatrixCSC)
+    _is_fixed(A) && return _copyto_fixed!(A, copyto!(spzeros(eltype(A), indtype(A), length(B)), B))
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))
 
     ptr = 1

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -13,10 +13,10 @@ using SparseArrays: AbstractSparseVector, AbstractSparseMatrixCSC, FixedSparseCS
     @test copy(r)::ReadOnly == r
     @test ReadOnly(r) === r
     @test (resize!(r, length(r)); true)
-    @test_throws ErrorException resize!(r, length(r) - 1)
-    @test_throws ErrorException resize!(r, length(r) + 1)
-    @test_throws ErrorException r[1] = r[1] + 1
-    @test_throws ErrorException r[1] = r[1] - 1
+    @test_throws ArgumentError resize!(r, length(r) - 1)
+    @test_throws ArgumentError resize!(r, length(r) + 1)
+    @test_throws ArgumentError r[1] = r[1] + 1
+    @test_throws ArgumentError r[1] = r[1] - 1
     @test (r[1] = r[1]; true)
 end
 
@@ -106,6 +106,21 @@ struct_eq(A::AbstractSparseVector, B::AbstractSparseVector) =
     B = similar(F)
     @test typeof(B) == typeof(F)
     @test struct_eq(B, F)
+    @test similar(F, 3, 3) isa SparseMatrixCSC
+    @test typeof(FixedSparseCSC{Float32,Int32}(F)) == FixedSparseCSC{Float32,Int32}
+    G = fixed(sparse([1, 2], [1, 2], [1.0, 2.0], 2, 2))
+    @test_throws ArgumentError G[2, 1] = 1.0
+    @test_throws ArgumentError G[:, 1] .= 1.0
+    @test_throws ArgumentError G[1:2, 1:2] = ones(2, 2)
+    @test_throws ArgumentError copyto!(G, sparse(ones(2, 2)))
+    @test struct_eq(G, sparse(Diagonal([1.0, 2.0]))) && G == Diagonal([1.0, 2.0])
+    G[1:2, 1:2] = [3 0; 0 4]
+    G[:, 2] .= 0
+    @test G == [3 0; 0 0] && nnz(G) == 2
+    G .= sparse([2], [2], [6.0], 2, 2)   # a subset pattern zero-fills the rest
+    @test G == [0 0; 0 6] && nnz(G) == 2
+    @test circshift(G, (1, 0)) == circshift(Matrix(G), (1, 0))
+    @test Diagonal([2.0, 3.0]) * G == [0 0; 0 18] && Symmetric(G) * G == [0 0; 0 36]
 end
 @testset "SparseMatrixCSC conversions" begin
     A = sprandn(10, 10, 0.3)
@@ -139,6 +154,14 @@ end
     t = similar(x)
     @test typeof(t) == typeof(x)
     @test struct_eq(t, x)
+    @test similar(x, 5) isa SparseVector
+    @test typeof(FixedSparseVector{Float32,Int32}(x)) == FixedSparseVector{Float32,Int32}
+    w = fixed(sparsevec([1, 3], [1.0, 2.0], 4))
+    @test_throws ArgumentError w[2] = 1.0
+    @test_throws ArgumentError copyto!(w, sparsevec([2], [1.0], 4))
+    @test struct_eq(w, sparsevec([1, 3], [1.0, 2.0], 4))
+    w .= sparsevec([3], [5.0], 4)
+    @test w == [0, 0, 5, 0] && nnz(w) == 2
 end
 
 @testset "Issue #190" begin


### PR DESCRIPTION
Stacked on #820. Follow-up to the review of `FixedSparseCSC`: it stays unexported and experimental, but the paths that silently corrupted it or failed with internal errors are fixed.

**Corruption.** `copyto!(F, B)`, which `F .= B` lowers to, resized `nzval` before failing on the read-only `rowval`:

```julia
julia> F = SparseArrays.fixed(sparse([1,2,3,1],[1,2,3,3],[1.0,2.0,3.0,4.0],3,3));
julia> F .= sparse([1],[1],[9.0],3,3)
ERROR: can't resize SparseArrays.ReadOnly{Int64, 1, Vector{Int64}}
julia> length(nonzeros(F)), SparseArrays.getcolptr(F)[end]-1
(1, 4)
```

Both the matrix and vector `copyto!` now check that `B`'s pattern lies within the destination's before writing anything, then zero-fill the stored entries `B` does not have. A subset pattern therefore works; a superset throws with the destination untouched.

**Generic fallbacks.** `similar(F, dims)` returned an empty *fixed* array that could never hold a value, so `Symmetric(F) * F`, `F * Symmetric(F)`, `Diagonal(d) * F`, `F * Bidiagonal(...)` and `circshift(F, s)` all failed. The shape-taking `similar` forms now return a plain `SparseMatrixCSC`/`SparseVector` (the structure-preserving `similar(F)` still returns a fixed array, as before and as tested), and `circshift` shifts into a plain copy.

**Errors.** Out-of-pattern `setindex!` surfaced as `MethodError: no method matching _insert!(::ReadOnly...)`, or as `can't resize ReadOnly` for ranged/masked/linear writes and `fill!` of a view. Those now throw

```
ArgumentError: cannot store a new entry at (2, 1) in a FixedSparseCSC, its sparsity pattern is read-only
```

and in-pattern ranged writes (`F[1:2, 1:2] = ...`, `F[:, 2] .= 0`) go through the scalar path and work. The `ReadOnly` wrapper's own errors are `ArgumentError`s that mention the fixed pattern.

**Conversion.** `FixedSparseCSC{Float32,Int32}(F)` was a `MethodError` because the typed constructor forwarded the existing buffers; it now converts them (and still shares when the types match). `FixedSparseVector{Tv,Ti}(x)` is added alongside.

Tests are folded into the existing `ReadOnly`, `FixedSparseCSC` and `FixedSparseVector` testsets. `test/fixed.jl`, `sparsevector.jl`, `higherorderfns.jl`, `sparsematrix_constructors_indexing.jl`, `sparsematrix_ops.jl`, `linalg.jl`, `issues.jl` and the Aqua ambiguity check pass locally on nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsx7eoka1GS4F96uzxT2wG
